### PR TITLE
(fix) Staging and production autodeploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,37 +31,9 @@ jobs:
       - image: buildpack-deps:trusty
     steps:
       - run: true
-  deploy-staging:
-    <<: *deploy
-    steps:
-      - run:
-          name: Deploy Staging to Heroku
-          command: |
-            git push https://heroku:$HEROKU_API_KEY@git.heroku.com/$HEROKU_APP_NAME_STAGING.git develop
-  deploy-production:
-    <<: *deploy
-    steps:
-      - run:
-          name: Deploy Master to Heroku
-          command: |
-            git push https://heroku:$HEROKU_API_KEY@git.heroku.com/$HEROKU_APP_NAME_PRODUCTION.git master
 
 workflows:
   version: 2
   continuous_delivery:
     jobs:
       - build_and_test
-      - deploy-staging:
-          requires:
-            - build_and_test
-          filters:
-            branches:
-              only:
-                - develop
-      - deploy-production:
-          requires:
-            - build_and_test
-          filters:
-            branches:
-              only:
-                - master


### PR DESCRIPTION
* CircleCI could arguably be configured to take on this responsibility however Heroku was already perfectly able to complete this task. CircleCI will be used as the CI checks and Heroku will be listening to see them pass on merges to develop and master.
