### PR TITLE
[46] Protect environments with basic auth

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,8 @@
 inherit_gem:
   dxw-utils:
     - dxw-rubocop.yml
+
+Metrics/AbcSize:
+    Max: 25
+    Exclude:
+      - 'spec/**/*'

--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 gem 'uglifier', '>= 1.3.0'
 gem 'sentry-raven'
 gem 'newrelic_rpm'
+gem 'figaro'
 
 group :development, :test do
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,8 @@ GEM
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
     ffi (1.10.0)
+    figaro (1.1.1)
+      thor (~> 0.14)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     haml (5.0.4)
@@ -302,6 +304,7 @@ DEPENDENCIES
   dxw-utils!
   factory_bot_rails
   faker
+  figaro
   haml-rails
   high_voltage
   html2haml

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,23 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
+  before_action :check_staging_auth, except: :check
+
   def check
     render json: { status: 'OK' }, status: :ok
   end
+
+  def check_staging_auth
+    return unless authenticate?
+
+    authenticate_or_request_with_http_basic('Global') do |name, password|
+      name == Figaro.env.http_user && password == Figaro.env.http_pass
+    end
+  end
+
+  # rubocop:disable Rails/UnknownEnv
+  def authenticate?
+    Rails.env.staging? || (Figaro.env.http_user && Figaro.env.http_pass)
+  end
+  # rubocop:enable Rails/UnknownEnv
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -1,0 +1,92 @@
+Rails.application.configure do
+  # Settings specified here will take precedence over those in config/application.rb.
+
+  # Code is not reloaded between requests.
+  config.cache_classes = true
+
+  # Eager load code on boot. This eager loads most of Rails and
+  # your application in memory, allowing both threaded web servers
+  # and those relying on copy on write to perform better.
+  # Rake tasks automatically ignore this option for performance.
+  config.eager_load = true
+
+  # Full error reports are disabled and caching is turned on.
+  config.consider_all_requests_local       = false
+  config.action_controller.perform_caching = true
+
+  # Attempt to read encrypted secrets from `config/secrets.yml.enc`.
+  # Requires an encryption key in `ENV["RAILS_MASTER_KEY"]` or
+  # `config/secrets.yml.key`.
+  config.read_encrypted_secrets = true
+
+  # Disable serving static files from the `/public` folder by default since
+  # Apache or NGINX already handles this.
+  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+
+  # Compress JavaScripts and CSS.
+  config.assets.js_compressor = :uglifier
+  # config.assets.css_compressor = :sass
+
+  # Do not fallback to assets pipeline if a precompiled asset is missed.
+  config.assets.compile = false
+
+  # `config.assets.precompile` and `config.assets.version` have moved to
+  # config/initializers/assets.rb
+
+  # Enable serving of images, stylesheets, and JavaScripts from an asset server.
+  # config.action_controller.asset_host = 'http://assets.example.com'
+
+  # Specifies the header that your server uses for sending files.
+  # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache
+  # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
+
+  # Mount Action Cable outside main process or domain
+  # config.action_cable.mount_path = nil
+  # config.action_cable.url = 'wss://example.com/cable'
+  # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
+
+  # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
+  # config.force_ssl = true
+
+  # Use the lowest log level to ensure availability of diagnostic information
+  # when problems arise.
+  config.log_level = :debug
+
+  # Prepend all log lines with the following tags.
+  config.log_tags = [:request_id]
+
+  # Use a different cache store in production.
+  # config.cache_store = :mem_cache_store
+
+  # Use a real queuing backend for Active Job (and separate queues per environment)
+  # config.active_job.queue_adapter     = :resque
+  # config.active_job.queue_name_prefix = "report-a-defect_#{Rails.env}"
+  config.action_mailer.perform_caching = false
+
+  # Ignore bad email addresses and do not raise email delivery errors.
+  # Set this to true and configure the email server for immediate delivery to raise delivery errors.
+  # config.action_mailer.raise_delivery_errors = false
+
+  # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
+  # the I18n.default_locale when a translation cannot be found).
+  config.i18n.fallbacks = true
+
+  # Send deprecation notices to registered listeners.
+  config.active_support.deprecation = :notify
+
+  # Use default logging formatter so that PID and timestamp are not suppressed.
+  config.log_formatter = ::Logger::Formatter.new
+
+  # Use a different logger for distributed setups.
+  # require 'syslog/logger'
+  # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
+
+  if ENV['RAILS_LOG_TO_STDOUT'].present?
+    logger           = ActiveSupport::Logger.new(STDOUT)
+    logger.formatter = config.log_formatter
+    config.logger    = ActiveSupport::TaggedLogging.new(logger)
+  end
+
+  # Do not dump schema after migrations.
+  config.active_record.dump_schema_after_migration = false
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -59,6 +59,8 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
 
+  config.include AuthHelpers
+
   if Bullet.enable?
     config.before(:each) do
       Bullet.start_request

--- a/spec/requests/staging_auth_spec.rb
+++ b/spec/requests/staging_auth_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe 'staging authentication', type: :request do
+  context 'when in development' do
+    it_behaves_like 'no basic auth'
+  end
+
+  context 'when in test' do
+    it_behaves_like 'no basic auth'
+  end
+
+  context 'when in staging' do
+    before(:each) { stub_global_auth(return_value: true) }
+    it_behaves_like 'basic auth'
+  end
+
+  context 'when in production' do
+    before(:each) { stub_global_auth(return_value: false) }
+    it_behaves_like 'no basic auth'
+  end
+end

--- a/spec/support/auth_helpers.rb
+++ b/spec/support/auth_helpers.rb
@@ -1,0 +1,73 @@
+module AuthHelpers
+  def stub_global_auth(return_value: true)
+    allow_any_instance_of(ApplicationController)
+      .to receive(:authenticate?)
+      .and_return(return_value)
+  end
+
+  def stub_env_for_staging_auth(env_field_for_username: :http_user,
+                                env_field_for_password: :http_pass,
+                                env_value_for_username: 'foo',
+                                env_value_for_password: 'bar')
+    fake_env = double.as_null_object
+    allow(Figaro).to receive(:env).and_return(fake_env)
+    allow(fake_env).to receive(env_field_for_username.to_sym).and_return(env_value_for_username)
+    allow(fake_env).to receive(env_field_for_password.to_sym).and_return(env_value_for_password)
+  end
+end
+
+RSpec.shared_examples 'basic auth' do
+  context 'when the path is root' do
+    let(:path) { '/' }
+
+    it 'returns 401 and asks for the basic auth credentials' do
+      get path
+      expect(response).to have_http_status(401)
+    end
+
+    context 'when the correct basic auth credentials are given' do
+      it 'returns a 200' do
+        username = 'username'
+        password = 'foobar'
+
+        stub_env_for_staging_auth(env_field_for_username: :http_user,
+                                  env_field_for_password: :http_pass,
+                                  env_value_for_username: username,
+                                  env_value_for_password: password)
+
+        encoded_credentials = ActionController::HttpAuthentication::Basic.encode_credentials(username, password)
+
+        get path, env: { 'HTTP_AUTHORIZATION': encoded_credentials }
+
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    context 'when the incorrect basic auth credentials are given' do
+      it 'returns a 401' do
+        stub_env_for_staging_auth(env_field_for_username: :http_user,
+                                  env_field_for_password: :http_pass,
+                                  env_value_for_username: nil,
+                                  env_value_for_password: nil)
+
+        encoded_credentials = ActionController::HttpAuthentication::Basic.encode_credentials('wrong-user', 'password')
+        get path, env: { 'HTTP_AUTHORIZATION': encoded_credentials }
+        expect(response).to have_http_status(401)
+      end
+    end
+  end
+end
+
+RSpec.shared_examples 'no basic auth' do
+  context 'when the path is root' do
+    it 'returns a 200' do
+      stub_env_for_staging_auth(env_field_for_username: :http_user,
+                                env_field_for_password: :http_pass,
+                                env_value_for_username: nil,
+                                env_value_for_password: nil)
+      get '/'
+
+      expect(response).to have_http_status(200)
+    end
+  end
+end


### PR DESCRIPTION
## Changes in this PR:
- staging will always have basic auth as a requirement 
- production and other environments can enable/disable it by adding the required ENV variables to Heroku 
