### PR TITLE
Drop old repairs table

### DIFF
--- a/db/migrate/20190522164250_drop_repairs.rb
+++ b/db/migrate/20190522164250_drop_repairs.rb
@@ -1,0 +1,5 @@
+class DropRepairs < ActiveRecord::Migration[5.1]
+  def change
+    drop_table(:repairs, force: true) if ActiveRecord::Base.connection.tables.include?('repairs')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190522160614) do
+ActiveRecord::Schema.define(version: 20190522164250) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -29,10 +29,6 @@ ActiveRecord::Schema.define(version: 20190522160614) do
     t.datetime "updated_at", null: false
     t.integer "days"
     t.index ["scheme_id"], name: "index_priorities_on_scheme_id"
-  end
-
-  create_table "repairs", force: :cascade do |t|
-    t.string "description", null: false
   end
 
   create_table "schemes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|


### PR DESCRIPTION
## Changes in this PR:
* This is no longer used after it was added through the app we copied from, we tried to remove it once but in the confusion it didn't actually change the schema so this is the second crack.
