### PR TITLE
An agent can create properties

### DIFF
--- a/app/controllers/staff/properties_controller.rb
+++ b/app/controllers/staff/properties_controller.rb
@@ -1,0 +1,30 @@
+class Staff::PropertiesController < Staff::BaseController
+  def new
+    @scheme = Scheme.find(scheme_id)
+    @property = Property.new
+  end
+
+  def create
+    @scheme = Scheme.find(scheme_id)
+    @property = Property.new(property_params)
+    @property.scheme = @scheme
+
+    if @property.valid?
+      @property.save
+      flash[:success] = I18n.t('generic.notice.success', resource: 'property')
+      redirect_to estate_scheme_path(@scheme.estate, @scheme)
+    else
+      render :new
+    end
+  end
+
+  private
+
+  def scheme_id
+    params[:scheme_id]
+  end
+
+  def property_params
+    params.require(:property).permit(:core_name, :address, :postcode)
+  end
+end

--- a/app/models/property.rb
+++ b/app/models/property.rb
@@ -1,0 +1,4 @@
+class Property < ApplicationRecord
+  validates :core_name, :address, :postcode, presence: true
+  belongs_to :scheme, dependent: :destroy
+end

--- a/app/models/scheme.rb
+++ b/app/models/scheme.rb
@@ -1,5 +1,6 @@
 class Scheme < ApplicationRecord
   validates :name, presence: true
   has_many :priorities, dependent: :destroy
+  has_many :properties, dependent: :destroy
   belongs_to :estate, dependent: :destroy
 end

--- a/app/views/staff/properties/new.html.haml
+++ b/app/views/staff/properties/new.html.haml
@@ -1,0 +1,14 @@
+- content_for :page_title_prefix, I18n.t('page_title.staff.properties.create', name: @scheme.name)
+
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    %h1.govuk-heading-xl
+      = I18n.t('page_title.staff.properties.create', name: @scheme.name).titleize
+      %span.govuk-caption-l= 'Step 1 of 1'
+
+    = simple_form_for [@scheme.estate, @scheme, @property] do |f|
+      .govuk-form-group
+        = f.input :core_name
+        = f.input :address
+        = f.input :postcode
+      = f.button :submit, I18n.t('generic.button.create', resource: 'Property')

--- a/app/views/staff/schemes/show.html.haml
+++ b/app/views/staff/schemes/show.html.haml
@@ -19,3 +19,24 @@
           %tr.govuk-table__row
             %td.govuk-table__cell= priority.name
             %td.govuk-table__cell= priority.days
+
+    = link_to(I18n.t('generic.button.create', resource: 'Property'), new_estate_scheme_property_path(@scheme.estate, @scheme), class: 'govuk-button mb0')
+
+    %table.govuk-table.properties
+      %thead.govuk-table__head
+        %tr.govuk-table__row
+          %th.govuk-table__header
+            %h2.govuk-heading-m
+              Core name
+          %th.govuk-table__header
+            %h2.govuk-heading-m
+              Address
+          %th.govuk-table__header
+            %h2.govuk-heading-m
+              Postcode
+      %tbody.govuk-table__body
+        - @scheme.properties.each do |property|
+          %tr.govuk-table__row
+            %td.govuk-table__cell= property.core_name
+            %td.govuk-table__cell= property.address
+            %td.govuk-table__cell= property.postcode

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   resources :estates, controller: 'staff/estates', only: %i[new create show] do
     resources :schemes, controller: 'staff/schemes', only: %i[new create show] do
       resources :priorities, controller: 'staff/priorities', only: %i[new create]
+      resources :properties, controller: 'staff/properties', only: %i[new create]
     end
   end
 end

--- a/db/migrate/20190523095524_create_property.rb
+++ b/db/migrate/20190523095524_create_property.rb
@@ -1,0 +1,11 @@
+class CreateProperty < ActiveRecord::Migration[5.1]
+  def change
+    create_table :properties, id: :uuid do |t|
+      t.string :core_name
+      t.string :address
+      t.string :postcode
+      t.references :scheme, foreign_key: true, index: true, type: :uuid
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190522164700) do
+ActiveRecord::Schema.define(version: 20190523095524) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -31,6 +31,16 @@ ActiveRecord::Schema.define(version: 20190522164700) do
     t.index ["scheme_id"], name: "index_priorities_on_scheme_id"
   end
 
+  create_table "properties", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "core_name"
+    t.string "address"
+    t.string "postcode"
+    t.uuid "scheme_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["scheme_id"], name: "index_properties_on_scheme_id"
+  end
+
   create_table "schemes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name", null: false
     t.uuid "estate_id"
@@ -40,5 +50,6 @@ ActiveRecord::Schema.define(version: 20190522164700) do
   end
 
   add_foreign_key "priorities", "schemes"
+  add_foreign_key "properties", "schemes"
   add_foreign_key "schemes", "estates"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,4 +1,8 @@
 raise if Rails.env.production?
+
+Estate.destroy_all
+Scheme.destroy_all
+
 # Estates
 estate = FactoryBot.create(:estate, name: 'Kings Cresent')
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -15,3 +15,17 @@ FactoryBot.create(:priority, scheme: scheme1, name: 'P1', days: 1)
 FactoryBot.create(:priority, scheme: scheme1, name: 'P2', days: 3)
 FactoryBot.create(:priority, scheme: scheme1, name: 'P3', days: 5)
 FactoryBot.create(:priority, scheme: scheme1, name: 'P4', days: 30)
+
+# Priorties
+FactoryBot.create(
+  :property, scheme: scheme1, core_name: 'DZ1', address: '1 Hackney Street', postcode: 'N16NU'
+)
+FactoryBot.create(
+  :property, scheme: scheme1, core_name: 'DZ1', address: '2 Hackney Street', postcode: 'N16NU'
+)
+FactoryBot.create(
+  :property, scheme: scheme1, core_name: 'DZ2', address: '3 Hackney Street', postcode: 'N16NP'
+)
+FactoryBot.create(
+  :property, scheme: scheme1, core_name: 'DZ2', address: '4 Hackney Street', postcode: 'N16NP'
+)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,3 +1,4 @@
+raise if Rails.env.production?
 # Estates
 estate = FactoryBot.create(:estate, name: 'Kings Cresent')
 

--- a/spec/factories/properties.rb
+++ b/spec/factories/properties.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :property do
+    core_name { Faker::Address.community }
+    address { Faker::Address.street_address }
+    postcode { Faker::Address.zip_code }
+  end
+end

--- a/spec/features/anyone_can_create_a_property_spec.rb
+++ b/spec/features/anyone_can_create_a_property_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.feature 'Anyone can create a property' do
+  let!(:scheme) { create(:scheme) }
+
+  scenario 'a property can be created' do
+    visit estate_scheme_path(scheme.estate, scheme)
+
+    expect(page).to have_content(I18n.t('page_title.staff.schemes.show', name: scheme.name).titleize)
+
+    click_on(I18n.t('generic.button.create', resource: 'Property'))
+
+    expect(page).to have_content(I18n.t('page_title.staff.properties.create').titleize)
+    within('form.new_property') do
+      fill_in 'property[core_name]', with: 'A name for a collection of blocks'
+      fill_in 'property[address]', with: 'Flat 1, Hackney Street'
+      fill_in 'property[postcode]', with: 'N16NU'
+      click_on(I18n.t('generic.button.create', resource: 'Property'))
+    end
+
+    expect(page).to have_content(I18n.t('generic.notice.success', resource: 'property'))
+    within('table.properties') do
+      property = Property.first
+      expect(page).to have_content(property.core_name)
+      expect(page).to have_content(property.address)
+      expect(page).to have_content(property.postcode)
+    end
+  end
+
+  scenario 'an invalid property cannot be submitted' do
+    visit estate_scheme_path(scheme.estate, scheme)
+
+    expect(page).to have_content(I18n.t('page_title.staff.schemes.show', name: scheme.name).titleize)
+
+    click_on(I18n.t('generic.button.create', resource: 'Property'))
+
+    expect(page).to have_content(I18n.t('page_title.staff.properties.create').titleize)
+    within('form.new_property') do
+      # Deliberately forget to fill out the required name field
+      click_on(I18n.t('generic.button.create', resource: 'Property'))
+    end
+
+    within('.property_core_name') do
+      expect(page).to have_content("can't be blank")
+    end
+  end
+end

--- a/spec/models/property.rb
+++ b/spec/models/property.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe Property, type: :model do
+  it { should belong_to(:scheme) }
+  it 'validates presence of required fields' do
+    priority = described_class.new
+    expect(priority.valid?).to be_falsey
+
+    errors = priority.errors.full_messages
+
+    expect(errors).to include("Name can't be blank")
+    expect(errors).to include("Days can't be blank")
+    expect(errors).to include('Scheme must exist')
+  end
+end

--- a/spec/models/scheme_spec.rb
+++ b/spec/models/scheme_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe Scheme, type: :model do
   it { should belong_to(:estate) }
   it { should have_many(:priorities) }
+  it { should have_many(:properties) }
   it 'validates presence of required fields' do
     scheme = described_class.new
     expect(scheme.valid?).to be_falsey


### PR DESCRIPTION
## Changes in this PR:
- Properties can be added against individual schemes
- There is likely more work to be done for reporting purposes around connecting properties to individual cores and blocks in a reliable way through associations, I'm deferring this until later as it shouldn't be too hard to do to remove the core name as a string and replace it with an association. In the mean time, agents will have to be able to correct property information

## Screenshots of UI changes:

### After

![Screenshot 2019-05-23 at 11 24 10](https://user-images.githubusercontent.com/912473/58245842-9c50b700-7d4d-11e9-8efb-ed8b487a0820.png)

