### PR TITLE
(feature) Add breadcrumb navigation template

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -45,11 +45,8 @@
             This is a new service
       .govuk-breadcrumbs
         %ol.govuk-breadcrumbs__list
-          %li.govuk-breadcrumbs__list-item
-            %a.govuk-breadcrumbs__link{:href => "#"} Home
-          %li.govuk-breadcrumbs__list-item
-            %a.govuk-breadcrumbs__link{:href => "#"} Something view
-          %li.govuk-breadcrumbs__list-item{"aria-current" => "page"} Current page
+          %li.govuk-breadcrumbs__list-item{'aria-current' => 'page'}
+            = link_to "Home", root_path, class: 'govuk-breadcrumbs__link'
 
       %main#main-content.govuk-main-wrapper.app-main-class{role: "main"}
         - flash.each do |name, msg|

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -43,6 +43,14 @@
             beta
           %span.govuk-phase-banner__text
             This is a new service
+      .govuk-breadcrumbs
+        %ol.govuk-breadcrumbs__list
+          %li.govuk-breadcrumbs__list-item
+            %a.govuk-breadcrumbs__link{:href => "#"} Home
+          %li.govuk-breadcrumbs__list-item
+            %a.govuk-breadcrumbs__link{:href => "#"} Something view
+          %li.govuk-breadcrumbs__list-item{"aria-current" => "page"} Current page
+
       %main#main-content.govuk-main-wrapper.app-main-class{role: "main"}
         - flash.each do |name, msg|
           %div{class: "flash #{name}"}


### PR DESCRIPTION
Added a breadcrumb navigation template for future use on nested pages.

## Changes in this PR:

Add breadcrumb template

## Screenshots of UI changes:

### Before
<img width="1060" alt="Screenshot 2019-05-23 at 16 23 50" src="https://user-images.githubusercontent.com/2632224/58265228-2b25f980-7d77-11e9-928d-15256eb0d927.png">


### After

<img width="808" alt="Screenshot 2019-05-23 at 15 07 11" src="https://user-images.githubusercontent.com/2632224/58265181-18132980-7d77-11e9-8703-285ed00565ee.png">

<img width="1087" alt="Screenshot 2019-05-23 at 17 20 34" src="https://user-images.githubusercontent.com/2632224/58269309-2bc28e00-7d7f-11e9-91ab-4e63d4f28c0a.png">


