### PR TITLE
Fix/87 make breadcrumbs dynamic

### DIFF
--- a/app/helpers/breadcrumb_helper.rb
+++ b/app/helpers/breadcrumb_helper.rb
@@ -1,14 +1,19 @@
 module BreadcrumbHelper
   def breadcrumb_link_to(title, url, *args)
-    content_tag(:li, title.titleize, class: 'govuk-breadcrumbs__list-item') do
+    # rubocop:disable Rails/OutputSafety
+    content_tag(:li,
+                title.titleize,
+                class: 'govuk-breadcrumbs__list-item') do
       link_to(title.titleize, url, *args, class: 'govuk-breadcrumbs__link')
     end.html_safe
+    # rubocop:enable Rails/OutputSafety
   end
 
   def breadcrumb_current(title = nil, &blk)
-    content_tag(:li, title.titleize, class: 'govuk-breadcrumbs__list-item', 'aria-current' => 'page') do
-      (title.nil? && block_given?) ? content_tag(:span, &blk) : content_tag(:span, title)
+    content_tag(:li,
+                title.titleize,
+                class: 'govuk-breadcrumbs__list-item', 'aria-current' => 'page') do
+      title.nil? && block_given? ? content_tag(:span, &blk) : content_tag(:span, title)
     end
   end
-
 end

--- a/app/helpers/breadcrumb_helper.rb
+++ b/app/helpers/breadcrumb_helper.rb
@@ -1,0 +1,14 @@
+module BreadcrumbHelper
+  def breadcrumb_link_to(title, url, *args)
+    content_tag(:li, title.titleize, class: 'govuk-breadcrumbs__list-item') do
+      link_to(title.titleize, url, *args, class: 'govuk-breadcrumbs__link')
+    end.html_safe
+  end
+
+  def breadcrumb_current(title = nil, &blk)
+    content_tag(:li, title.titleize, class: 'govuk-breadcrumbs__list-item', 'aria-current' => 'page') do
+      (title.nil? && block_given?) ? content_tag(:span, &blk) : content_tag(:span, title)
+    end
+  end
+
+end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -23,7 +23,7 @@
     %header.govuk-header{"data-module": "header", role: "banner"}
       .govuk-header__container.govuk-width-container
         .govuk-header__logo
-          %a.govuk-header__link.govuk-header__link--homepage{href: 'https://www.gov.uk'}
+          %a.govuk-header__link.govuk-header__link--homepage{href: root_path}
             %span.govuk-header__logotype
               %svg.govuk-header__logotype-crown{focusable: "false", height: "32", role: "presentation", viewbox: "0 0 141.78 25.28", width: "200", xmlns: "http://www.w3.org/2000/svg"}
                 %path{d: "M118.94 9.23a2.63 2.63 0 0 0-2.85 2.45h5.28a2.39 2.39 0 0 0-2.43-2.45zM53 16.32a1.59 1.59 0 0 0 1.73 1.34A2.19 2.19 0 0 0 57 15.4v-1.34a9.75 9.75 0 0 1-2.18.7c-1.2.24-1.82.58-1.82 1.56z", fill: "none"}
@@ -43,10 +43,6 @@
             beta
           %span.govuk-phase-banner__text
             This is a new service
-      .govuk-breadcrumbs
-        %ol.govuk-breadcrumbs__list
-          %li.govuk-breadcrumbs__list-item{'aria-current' => 'page'}
-            = link_to "Home", root_path, class: 'govuk-breadcrumbs__link'
 
       %main#main-content.govuk-main-wrapper.app-main-class{role: "main"}
         - flash.each do |name, msg|

--- a/app/views/staff/estates/new.html.haml
+++ b/app/views/staff/estates/new.html.haml
@@ -1,5 +1,7 @@
 - content_for :page_title_prefix, I18n.t('page_title.staff.estates.create')
 
+= link_to "Back to Home", root_path, class: 'govuk-back-link'
+
 .govuk-grid-row
   .govuk-grid-column-two-thirds
     %h1.govuk-heading-xl

--- a/app/views/staff/estates/show.html.haml
+++ b/app/views/staff/estates/show.html.haml
@@ -1,5 +1,10 @@
 - content_for :page_title_prefix, I18n.t('page_title.staff.estates.show', name: @estate.name)
 
+.govuk-breadcrumbs
+  %ol.govuk-breadcrumbs__list
+    = breadcrumb_link_to("Home", root_path)
+    = breadcrumb_current("Estate details for: #{@estate.name}")
+
 .govuk-grid-row
   .govuk-grid-column-two-thirds
     %h1.govuk-heading-xl= I18n.t('page_title.staff.estates.show', name: @estate.name).titleize

--- a/app/views/staff/estates/show.html.haml
+++ b/app/views/staff/estates/show.html.haml
@@ -2,8 +2,8 @@
 
 .govuk-breadcrumbs
   %ol.govuk-breadcrumbs__list
-    = breadcrumb_link_to("Home", root_path)
-    = breadcrumb_current("Estate details for: #{@estate.name}")
+    = breadcrumb_link_to('Home', root_path)
+    = breadcrumb_current(I18n.t('page_title.staff.estates.show', name: @estate.name))
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds

--- a/app/views/staff/priorities/new.html.haml
+++ b/app/views/staff/priorities/new.html.haml
@@ -1,5 +1,7 @@
 - content_for :page_title_prefix, I18n.t('page_title.staff.schemes.show', name: @scheme.name)
 
+= link_to "Back to #{@scheme.name} scheme view", estate_scheme_path(@scheme.estate, @scheme), class: 'govuk-back-link'
+
 .govuk-grid-row
   .govuk-grid-column-two-thirds
     %h1.govuk-heading-xl

--- a/app/views/staff/priorities/new.html.haml
+++ b/app/views/staff/priorities/new.html.haml
@@ -1,6 +1,6 @@
 - content_for :page_title_prefix, I18n.t('page_title.staff.schemes.show', name: @scheme.name)
 
-= link_to "Back to #{@scheme.name} scheme view", estate_scheme_path(@scheme.estate, @scheme), class: 'govuk-back-link'
+= link_to "Back to scheme #{@scheme.name}", estate_scheme_path(@scheme.estate, @scheme), class: 'govuk-back-link'
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds

--- a/app/views/staff/priorities/new.html.haml
+++ b/app/views/staff/priorities/new.html.haml
@@ -1,6 +1,6 @@
 - content_for :page_title_prefix, I18n.t('page_title.staff.schemes.show', name: @scheme.name)
 
-= link_to "Back to scheme #{@scheme.name}", estate_scheme_path(@scheme.estate, @scheme), class: 'govuk-back-link'
+= link_to "Back to #{I18n.t('page_title.staff.schemes.show', name: @scheme.name)}", estate_scheme_path(@scheme.estate, @scheme), class: 'govuk-back-link'
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds

--- a/app/views/staff/properties/edit.html.haml
+++ b/app/views/staff/properties/edit.html.haml
@@ -1,6 +1,6 @@
 - content_for :page_title_prefix, I18n.t('page_title.staff.properties.edit', name: @scheme.name)
 
-= link_to "Back to scheme #{@scheme.name}", estate_scheme_path(@scheme.estate, @scheme), class: 'govuk-back-link'
+= link_to "Back to #{I18n.t('page_title.staff.schemes.show', name: @scheme.name)}", estate_scheme_path(@scheme.estate, @scheme), class: 'govuk-back-link'
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds

--- a/app/views/staff/properties/edit.html.haml
+++ b/app/views/staff/properties/edit.html.haml
@@ -1,5 +1,7 @@
 - content_for :page_title_prefix, I18n.t('page_title.staff.properties.edit', name: @scheme.name)
 
+= link_to "Back to #{@scheme.name} scheme view", estate_scheme_path(@scheme.estate, @scheme), class: 'govuk-back-link'
+
 .govuk-grid-row
   .govuk-grid-column-two-thirds
     %h1.govuk-heading-xl

--- a/app/views/staff/properties/edit.html.haml
+++ b/app/views/staff/properties/edit.html.haml
@@ -1,6 +1,6 @@
 - content_for :page_title_prefix, I18n.t('page_title.staff.properties.edit', name: @scheme.name)
 
-= link_to "Back to #{@scheme.name} scheme view", estate_scheme_path(@scheme.estate, @scheme), class: 'govuk-back-link'
+= link_to "Back to scheme #{@scheme.name}", estate_scheme_path(@scheme.estate, @scheme), class: 'govuk-back-link'
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds

--- a/app/views/staff/properties/new.html.haml
+++ b/app/views/staff/properties/new.html.haml
@@ -1,5 +1,7 @@
 - content_for :page_title_prefix, I18n.t('page_title.staff.properties.create', name: @scheme.name)
 
+= link_to "Back to #{@scheme.name} scheme view", estate_scheme_path(@scheme.estate, @scheme), class: 'govuk-back-link'
+
 .govuk-grid-row
   .govuk-grid-column-two-thirds
     %h1.govuk-heading-xl

--- a/app/views/staff/properties/new.html.haml
+++ b/app/views/staff/properties/new.html.haml
@@ -1,6 +1,6 @@
 - content_for :page_title_prefix, I18n.t('page_title.staff.properties.create', name: @scheme.name)
 
-= link_to "Back to scheme #{@scheme.name}", estate_scheme_path(@scheme.estate, @scheme), class: 'govuk-back-link'
+= link_to "Back to #{I18n.t('page_title.staff.schemes.show', name: @scheme.name)}", estate_scheme_path(@scheme.estate, @scheme), class: 'govuk-back-link'
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds

--- a/app/views/staff/properties/new.html.haml
+++ b/app/views/staff/properties/new.html.haml
@@ -1,6 +1,6 @@
 - content_for :page_title_prefix, I18n.t('page_title.staff.properties.create', name: @scheme.name)
 
-= link_to "Back to #{@scheme.name} scheme view", estate_scheme_path(@scheme.estate, @scheme), class: 'govuk-back-link'
+= link_to "Back to scheme #{@scheme.name}", estate_scheme_path(@scheme.estate, @scheme), class: 'govuk-back-link'
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds

--- a/app/views/staff/schemes/new.html.haml
+++ b/app/views/staff/schemes/new.html.haml
@@ -1,5 +1,6 @@
 - content_for :page_title_prefix, I18n.t('page_title.staff.schemes.create')
 
+= link_to "Back to #{@estate.name} ", estate_path(@estate), class: 'govuk-back-link'
 .govuk-grid-row
   .govuk-grid-column-two-thirds
     %h1.govuk-heading-xl

--- a/app/views/staff/schemes/new.html.haml
+++ b/app/views/staff/schemes/new.html.haml
@@ -1,6 +1,6 @@
 - content_for :page_title_prefix, I18n.t('page_title.staff.schemes.create')
 
-= link_to "Back to #{@estate.name} ", estate_path(@estate), class: 'govuk-back-link'
+= link_to "Back to #{@estate.name} estate", estate_path(@estate), class: 'govuk-back-link'
 .govuk-grid-row
   .govuk-grid-column-two-thirds
     %h1.govuk-heading-xl

--- a/app/views/staff/schemes/new.html.haml
+++ b/app/views/staff/schemes/new.html.haml
@@ -1,6 +1,9 @@
 - content_for :page_title_prefix, I18n.t('page_title.staff.schemes.create')
 
-= link_to "Back to #{@estate.name} estate", estate_path(@estate), class: 'govuk-back-link'
+= link_to "Back to #{I18n.t('page_title.staff.estates.show', name: @estate.name)}", estate_path(@estate), class: 'govuk-back-link'
+
+
+
 .govuk-grid-row
   .govuk-grid-column-two-thirds
     %h1.govuk-heading-xl

--- a/app/views/staff/schemes/show.html.haml
+++ b/app/views/staff/schemes/show.html.haml
@@ -2,8 +2,8 @@
 
 .govuk-breadcrumbs
   %ol.govuk-breadcrumbs__list
-    = breadcrumb_link_to("Home", root_path)
-    = breadcrumb_link_to(@scheme.estate.name, estate_path(@scheme.estate))
+    = breadcrumb_link_to('Home', root_path)
+    = breadcrumb_link_to("#{@scheme.estate.name} estate", estate_path(@scheme.estate))
     = breadcrumb_current("Scheme #{@scheme.name}")
 
 .govuk-grid-row

--- a/app/views/staff/schemes/show.html.haml
+++ b/app/views/staff/schemes/show.html.haml
@@ -1,5 +1,11 @@
 - content_for :page_title_prefix, I18n.t('page_title.staff.schemes.show', name: @scheme.name)
 
+.govuk-breadcrumbs
+  %ol.govuk-breadcrumbs__list
+    = breadcrumb_link_to("Home", root_path)
+    = breadcrumb_link_to(@scheme.estate.name, estate_path(@scheme.estate))
+    = breadcrumb_current("Scheme #{@scheme.name}")
+
 .govuk-grid-row
   .govuk-grid-column-two-thirds
     %h1.govuk-heading-xl= I18n.t('page_title.staff.schemes.show', name: @scheme.name).titleize


### PR DESCRIPTION
## Changes in this PR:

- Introduces dynamic breadcrumbs navigation into nested page views for estates and schemes

- and adds back links to create and edit pages

## Screenshots of UI changes:

### After
<img width="937" alt="Screenshot 2019-05-29 at 17 52 35" src="https://user-images.githubusercontent.com/2632224/58575912-04fece80-823b-11e9-9f62-251ada1bce57.png">
<img width="1042" alt="Screenshot 2019-05-29 at 17 52 41" src="https://user-images.githubusercontent.com/2632224/58575913-04fece80-823b-11e9-8523-06a653601279.png">
<img width="995" alt="Screenshot 2019-05-29 at 17 52 51" src="https://user-images.githubusercontent.com/2632224/58575914-04fece80-823b-11e9-970b-94ac8d3f3f01.png">
<img width="928" alt="Screenshot 2019-05-29 at 17 53 25" src="https://user-images.githubusercontent.com/2632224/58575915-05976500-823b-11e9-903d-e824542afff2.png">
