### PR TITLE
Seeds only create 1 estate instead of 100s

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,9 +1,11 @@
 raise if Rails.env.production?
 
-Estate.destroy_all
-Scheme.destroy_all
-Property.destroy_all
-Defect.destroy_all
+Defect.delete_all
+Property.delete_all
+Priority.delete_all
+Scheme.delete_all
+Estate.delete_all
+PublicActivity::Activity.delete_all
 
 # Estates
 estate = FactoryBot.create(:estate, name: 'Kings Cresent')
@@ -13,25 +15,30 @@ scheme1 = FactoryBot.create(:scheme, estate: estate, name: '1')
 FactoryBot.create(:scheme, estate: estate, name: '2')
 
 # Priorties
-FactoryBot.create(:priority, scheme: scheme1, name: 'P1', days: 1)
-FactoryBot.create(:priority, scheme: scheme1, name: 'P2', days: 3)
-FactoryBot.create(:priority, scheme: scheme1, name: 'P3', days: 5)
-FactoryBot.create(:priority, scheme: scheme1, name: 'P4', days: 30)
+priority1 = FactoryBot.create(:priority, scheme: scheme1, name: 'P1', days: 1)
+priority2 = FactoryBot.create(:priority, scheme: scheme1, name: 'P2', days: 3)
+priority3 = FactoryBot.create(:priority, scheme: scheme1, name: 'P3', days: 5)
+priority4 = FactoryBot.create(:priority, scheme: scheme1, name: 'P4', days: 30)
 
 # Priorties
-FactoryBot.create(
+property1 = FactoryBot.create(
   :property, scheme: scheme1, core_name: 'DZ1', address: '1 Hackney Street', postcode: 'N16NU'
 )
-FactoryBot.create(
+property2 = FactoryBot.create(
   :property, scheme: scheme1, core_name: 'DZ1', address: '2 Hackney Street', postcode: 'N16NU'
 )
-FactoryBot.create(
+property3 = FactoryBot.create(
   :property, scheme: scheme1, core_name: 'DZ2', address: '3 Hackney Street', postcode: 'N16NP'
 )
-FactoryBot.create(
+property4 = FactoryBot.create(
   :property, scheme: scheme1, core_name: 'DZ2', address: '4 Hackney Street', postcode: 'N16NP'
 )
 
-Property.all.each do |property|
-  FactoryBot.create_list(:defect, 10, property: property)
+[property1, property2, property3, property4].each do |property|
+  FactoryBot.create_list(
+    :defect,
+    10,
+    property: property,
+    priority: [priority1, priority2, priority3, priority4].sample
+  )
 end


### PR DESCRIPTION
* When creating defects without attaching a priority, it was forcing new priority to be created with a new scheme and therefore a new estate.
* Delete_all should be used instead of destroy_all as we have guards to ensure properties and priorities are not deleted whilst they have defects attached to them.

