### PR TITLE
[29] Contractor contact details belong to scheme

### DIFF
--- a/app/controllers/staff/schemes_controller.rb
+++ b/app/controllers/staff/schemes_controller.rb
@@ -22,6 +22,23 @@ class Staff::SchemesController < Staff::BaseController
     @scheme = Scheme.find(scheme_id)
   end
 
+  def edit
+    @scheme = Scheme.find(scheme_id)
+  end
+
+  def update
+    @scheme = Scheme.find(scheme_id)
+    @scheme.assign_attributes(scheme_params)
+
+    if @scheme.valid?
+      @scheme.save
+      flash[:success] = I18n.t('generic.notice.update.success', resource: 'scheme')
+      redirect_to estate_scheme_path(@scheme.estate, @scheme)
+    else
+      render :edit
+    end
+  end
+
   private
 
   def estate_id

--- a/app/controllers/staff/schemes_controller.rb
+++ b/app/controllers/staff/schemes_controller.rb
@@ -33,6 +33,6 @@ class Staff::SchemesController < Staff::BaseController
   end
 
   def scheme_params
-    params.require(:scheme).permit(:name)
+    params.require(:scheme).permit(:name, :contractor_name, :contractor_email_address)
   end
 end

--- a/app/models/scheme.rb
+++ b/app/models/scheme.rb
@@ -3,7 +3,10 @@ class Scheme < ApplicationRecord
   has_many :properties, dependent: :destroy
   belongs_to :estate, dependent: :destroy
 
-  validates :name, presence: true
+  validates :name,
+            :contractor_name,
+            :contractor_email_address,
+            presence: true
 
   include PublicActivity::Model
   tracked owner: ->(controller, _) { controller.current_user if controller }

--- a/app/models/scheme.rb
+++ b/app/models/scheme.rb
@@ -8,6 +8,8 @@ class Scheme < ApplicationRecord
             :contractor_email_address,
             presence: true
 
+  validates :contractor_email_address, format: { with: URI::MailTo::EMAIL_REGEXP }
+
   include PublicActivity::Model
   tracked owner: ->(controller, _) { controller.current_user if controller }
 end

--- a/app/views/shared/priorities/_table.html.haml
+++ b/app/views/shared/priorities/_table.html.haml
@@ -1,0 +1,14 @@
+%table.govuk-table.priorities
+  %thead.govuk-table__head
+    %tr.govuk-table__row
+      %th.govuk-table__header
+        %h2.govuk-heading-m
+          Name
+      %th.govuk-table__header
+        %h2.govuk-heading-m
+          Days
+  %tbody.govuk-table__body
+    - priorities.each do |priority|
+      %tr.govuk-table__row
+        %td.govuk-table__cell= priority.name
+        %td.govuk-table__cell= priority.days

--- a/app/views/shared/properties/_information.html.haml
+++ b/app/views/shared/properties/_information.html.haml
@@ -6,6 +6,12 @@
     %dt.govuk-summary-list__key Scheme
     %dd.govuk-summary-list__value= property.scheme.name
   %div.govuk-summary-list__row
+    %dt.govuk-summary-list__key Contractor name
+    %dd.govuk-summary-list__value= property.scheme.contractor_name
+  %div.govuk-summary-list__row
+    %dt.govuk-summary-list__key Contractor email address
+    %dd.govuk-summary-list__value= property.scheme.contractor_email_address
+  %div.govuk-summary-list__row
     %dt.govuk-summary-list__key Property address
     %dd.govuk-summary-list__value= property.address
   %div.govuk-summary-list__row

--- a/app/views/shared/schemes/_information.html.haml
+++ b/app/views/shared/schemes/_information.html.haml
@@ -1,5 +1,8 @@
 %dl.govuk-summary-list.scheme_information
   %div.govuk-summary-list__row
+    %dt.govuk-summary-list__key Name
+    %dd.govuk-summary-list__value= scheme.name
+  %div.govuk-summary-list__row
     %dt.govuk-summary-list__key Contractor name
     %dd.govuk-summary-list__value= scheme.contractor_name
   %div.govuk-summary-list__row

--- a/app/views/shared/schemes/_information.html.haml
+++ b/app/views/shared/schemes/_information.html.haml
@@ -1,0 +1,7 @@
+%dl.govuk-summary-list.scheme_information
+  %div.govuk-summary-list__row
+    %dt.govuk-summary-list__key Contractor name
+    %dd.govuk-summary-list__value= scheme.contractor_name
+  %div.govuk-summary-list__row
+    %dt.govuk-summary-list__key Contractor email address
+    %dd.govuk-summary-list__value= scheme.contractor_email_address

--- a/app/views/shared/schemes/_table.html.haml
+++ b/app/views/shared/schemes/_table.html.haml
@@ -6,9 +6,13 @@
           Name
       %th.govuk-table__header
         %h2.govuk-heading-m
+          Contractor
+      %th.govuk-table__header
+        %h2.govuk-heading-m
           Actions
   %tbody.govuk-table__body
     - estate.schemes.each do |scheme|
       %tr.govuk-table__row
         %td.govuk-table__cell= scheme.name
+        %td.govuk-table__cell= scheme.contractor_name
         %td.govuk-table__cell= link_to I18n.t('generic.link.show'), estate_scheme_path(scheme.estate, scheme), class: 'govuk-link'

--- a/app/views/shared/schemes/_table.html.haml
+++ b/app/views/shared/schemes/_table.html.haml
@@ -1,0 +1,12 @@
+%table.govuk-table.schemes
+  %thead.govuk-table__head
+    %tr.govuk-table__row
+      %th.govuk-table__header
+        %h2.govuk-heading-m
+          Name
+      %th.govuk-table__header
+  %tbody.govuk-table__body
+    - estate.schemes.each do |scheme|
+      %tr.govuk-table__row
+        %td.govuk-table__cell= scheme.name
+        %td.govuk-table__cell= link_to I18n.t('generic.link.show'), estate_scheme_path(scheme.estate, scheme), class: 'govuk-link'

--- a/app/views/shared/schemes/_table.html.haml
+++ b/app/views/shared/schemes/_table.html.haml
@@ -5,6 +5,8 @@
         %h2.govuk-heading-m
           Name
       %th.govuk-table__header
+        %h2.govuk-heading-m
+          Actions
   %tbody.govuk-table__body
     - estate.schemes.each do |scheme|
       %tr.govuk-table__row

--- a/app/views/staff/estates/show.html.haml
+++ b/app/views/staff/estates/show.html.haml
@@ -5,15 +5,4 @@
     %h1.govuk-heading-xl= I18n.t('page_title.staff.estates.show', name: @estate.name).titleize
     = link_to(I18n.t('generic.button.create', resource: 'Scheme'), new_estate_scheme_path(@estate), class: 'govuk-button mb0')
 
-    %table.govuk-table.schemes
-      %thead.govuk-table__head
-        %tr.govuk-table__row
-          %th.govuk-table__header
-            %h2.govuk-heading-m
-              Name
-          %th.govuk-table__header
-      %tbody.govuk-table__body
-        - @estate.schemes.each do |scheme|
-          %tr.govuk-table__row
-            %td.govuk-table__cell= scheme.name
-            %td.govuk-table__cell= link_to I18n.t('generic.link.show'), estate_scheme_path(@estate, scheme), class: 'govuk-link'
+    = render partial: '/shared/schemes/table', locals: { estate: @estate }

--- a/app/views/staff/schemes/edit.html.haml
+++ b/app/views/staff/schemes/edit.html.haml
@@ -1,0 +1,14 @@
+- content_for :page_title_prefix, I18n.t('page_title.staff.schemes.edit', name: @scheme.name)
+
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    %h1.govuk-heading-xl
+      = I18n.t('page_title.staff.schemes.edit', name: @scheme.name).titleize
+      %span.govuk-caption-l= 'Step 1 of 1'
+
+    = simple_form_for [@scheme.estate, @scheme] do |f|
+      .govuk-form-group
+        = f.input :name
+        = f.input :contractor_name
+        = f.input :contractor_email_address
+      = f.button :submit, I18n.t('generic.button.update', resource: 'Scheme')

--- a/app/views/staff/schemes/new.html.haml
+++ b/app/views/staff/schemes/new.html.haml
@@ -9,4 +9,6 @@
     = simple_form_for [@estate, @scheme] do |f|
       .form-group
         = f.input :name
+        = f.input :contractor_name
+        = f.input :contractor_email_address
       = f.button :submit, I18n.t('generic.button.create', resource: 'Scheme')

--- a/app/views/staff/schemes/show.html.haml
+++ b/app/views/staff/schemes/show.html.haml
@@ -3,6 +3,8 @@
 .govuk-grid-row
   .govuk-grid-column-two-thirds
     %h1.govuk-heading-xl= I18n.t('page_title.staff.schemes.show', name: @scheme.name).titleize
+    = render partial: '/shared/schemes/information', locals: { scheme: @scheme }
+
     = link_to(I18n.t('generic.button.create', resource: 'Priority'), new_estate_scheme_priority_path(@scheme.estate, @scheme), class: 'govuk-button mb0')
     = render partial: '/shared/priorities/table', locals: { priorities: @scheme.priorities }
 

--- a/app/views/staff/schemes/show.html.haml
+++ b/app/views/staff/schemes/show.html.haml
@@ -3,6 +3,7 @@
 .govuk-grid-row
   .govuk-grid-column-two-thirds
     %h1.govuk-heading-xl= I18n.t('page_title.staff.schemes.show', name: @scheme.name).titleize
+    = link_to(I18n.t('generic.button.edit', resource: 'Scheme'), edit_estate_scheme_path(@scheme.estate, @scheme), class: 'govuk-button mb0')
     = render partial: '/shared/schemes/information', locals: { scheme: @scheme }
 
     = link_to(I18n.t('generic.button.create', resource: 'Priority'), new_estate_scheme_priority_path(@scheme.estate, @scheme), class: 'govuk-button mb0')

--- a/app/views/staff/schemes/show.html.haml
+++ b/app/views/staff/schemes/show.html.haml
@@ -4,22 +4,7 @@
   .govuk-grid-column-two-thirds
     %h1.govuk-heading-xl= I18n.t('page_title.staff.schemes.show', name: @scheme.name).titleize
     = link_to(I18n.t('generic.button.create', resource: 'Priority'), new_estate_scheme_priority_path(@scheme.estate, @scheme), class: 'govuk-button mb0')
-
-    %table.govuk-table.priorities
-      %thead.govuk-table__head
-        %tr.govuk-table__row
-          %th.govuk-table__header
-            %h2.govuk-heading-m
-              Name
-          %th.govuk-table__header
-            %h2.govuk-heading-m
-              Days
-      %tbody.govuk-table__body
-        - @scheme.priorities.each do |priority|
-          %tr.govuk-table__row
-            %td.govuk-table__cell= priority.name
-            %td.govuk-table__cell= priority.days
+    = render partial: '/shared/priorities/table', locals: { priorities: @scheme.priorities }
 
     = link_to(I18n.t('generic.button.create', resource: 'Property'), new_estate_scheme_property_path(@scheme.estate, @scheme), class: 'govuk-button mb0')
-
     = render partial: '/shared/properties/table', locals: { properties: @scheme.properties }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,6 +12,7 @@ en:
       schemes:
         show: '%{name} scheme'
         create: 'Create scheme'
+        edit: 'Update scheme'
       priorities:
         create: 'Create priority'
       properties:
@@ -28,6 +29,7 @@ en:
     button:
       create: 'Create %{resource}'
       update: 'Update %{resource}'
+      edit: 'Edit %{resource}'
       find: 'Find Property'
     notice:
       create:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   root to: 'staff/dashboard#index'
   get 'check' => 'application#check'
   resources :estates, controller: 'staff/estates', only: %i[new create show] do
-    resources :schemes, controller: 'staff/schemes', only: %i[new create show] do
+    resources :schemes, controller: 'staff/schemes', only: %i[new create show edit update] do
       resources :priorities, controller: 'staff/priorities', only: %i[new create]
       resources :properties, controller: 'staff/properties',
                              only: %i[new create edit update] do

--- a/db/migrate/20190530150640_add_contractor_to_scheme.rb
+++ b/db/migrate/20190530150640_add_contractor_to_scheme.rb
@@ -1,0 +1,6 @@
+class AddContractorToScheme < ActiveRecord::Migration[5.2]
+  def change
+    add_column :schemes, :contractor_name, :string
+    add_column :schemes, :contractor_email_address, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_29_174458) do
+ActiveRecord::Schema.define(version: 2019_05_30_150640) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -82,6 +82,8 @@ ActiveRecord::Schema.define(version: 2019_05_29_174458) do
     t.uuid "estate_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "contractor_name"
+    t.string "contractor_email_address"
     t.index ["estate_id"], name: "index_schemes_on_estate_id"
   end
 

--- a/spec/factories/schemes.rb
+++ b/spec/factories/schemes.rb
@@ -1,6 +1,8 @@
 FactoryBot.define do
   factory :scheme do
     name { Faker::GreekPhilosophers.name }
+    contractor_name { Faker::GreekPhilosophers.name }
+    contractor_email_address { Faker::Internet.email }
     association :estate, factory: :estate
   end
 end

--- a/spec/features/anyone_can_create_a_scheme_spec.rb
+++ b/spec/features/anyone_can_create_a_scheme_spec.rb
@@ -13,6 +13,8 @@ RSpec.feature 'Anyone can create a scheme' do
     expect(page).to have_content(I18n.t('page_title.staff.schemes.create').titleize)
     within('form.new_scheme') do
       fill_in 'scheme[name]', with: 'Kings Cresent'
+      fill_in 'scheme[contractor_name]', with: 'Builders R Us'
+      fill_in 'scheme[contractor_email_address]', with: 'email@example.com'
       click_on(I18n.t('generic.button.create', resource: 'Scheme'))
     end
 

--- a/spec/features/anyone_can_create_a_scheme_spec.rb
+++ b/spec/features/anyone_can_create_a_scheme_spec.rb
@@ -20,7 +20,9 @@ RSpec.feature 'Anyone can create a scheme' do
 
     expect(page).to have_content(I18n.t('generic.notice.create.success', resource: 'scheme'))
     within('table.schemes') do
-      expect(page).to have_content(Scheme.first.name)
+      scheme = Scheme.first
+      expect(page).to have_content(scheme.name)
+      expect(page).to have_content(scheme.contractor_name)
     end
   end
 

--- a/spec/features/anyone_can_update_a_scheme_spec.rb
+++ b/spec/features/anyone_can_update_a_scheme_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.feature 'Anyone can update a scheme' do
+  let!(:scheme) { create(:scheme) }
+
+  scenario 'a scheme can be udpated' do
+    scheme = create(:scheme)
+
+    visit estate_scheme_path(scheme.estate, scheme)
+
+    within('.scheme_information') do
+      expect(page).to have_content(scheme.contractor_name)
+      expect(page).to have_content(scheme.contractor_email_address)
+    end
+
+    click_on(I18n.t('generic.button.edit', resource: 'Scheme'))
+
+    within('form.edit_scheme') do
+      fill_in 'scheme[name]', with: '1'
+      fill_in 'scheme[contractor_name]', with: 'A new contractor name'
+      fill_in 'scheme[contractor_email_address]', with: 'new@email.com'
+      click_on(I18n.t('generic.button.update', resource: 'Scheme'))
+    end
+  end
+
+  scenario 'an invalid scheme cannot be updated' do
+    scheme = create(:scheme)
+
+    visit estate_scheme_path(scheme.estate, scheme)
+
+    click_on(I18n.t('generic.button.edit', resource: 'Scheme'))
+
+    within('form.edit_scheme') do
+      fill_in 'scheme[name]', with: ''
+      fill_in 'scheme[contractor_name]', with: ''
+      fill_in 'scheme[contractor_email_address]', with: ''
+
+      click_on(I18n.t('generic.button.update', resource: 'Scheme'))
+    end
+
+    within('.scheme_name') do
+      expect(page).to have_content("can't be blank")
+    end
+
+    within('.scheme_contractor_name') do
+      expect(page).to have_content("can't be blank")
+    end
+
+    within('.scheme_contractor_email_address') do
+      expect(page).to have_content("can't be blank")
+    end
+  end
+end

--- a/spec/features/anyone_can_view_a_property_spec.rb
+++ b/spec/features/anyone_can_view_a_property_spec.rb
@@ -20,6 +20,8 @@ RSpec.feature 'Anyone can create a defect' do
     within('.property_information') do
       expect(page).to have_content(property.scheme.estate.name)
       expect(page).to have_content(property.scheme.name)
+      expect(page).to have_content(property.scheme.contractor_name)
+      expect(page).to have_content(property.scheme.contractor_email_address)
       expect(page).to have_content(property.address)
       expect(page).to have_content(property.core_name)
     end

--- a/spec/models/scheme_spec.rb
+++ b/spec/models/scheme_spec.rb
@@ -17,4 +17,16 @@ RSpec.describe Scheme, type: :model do
     expect(errors).to include("Contractor name can't be blank")
     expect(errors).to include("Contractor email address can't be blank")
   end
+
+  describe 'validates that contractor email address looks like one' do
+    it 'returns true with a valid email address' do
+      scheme = build(:scheme, contractor_email_address: 'email@example.com')
+      expect(scheme.valid?).to be_truthy
+    end
+
+    it 'returns false with an invalid email address' do
+      scheme = build(:scheme, contractor_email_address: 'not a real email')
+      expect(scheme.valid?).to be_falsey
+    end
+  end
 end

--- a/spec/models/scheme_spec.rb
+++ b/spec/models/scheme_spec.rb
@@ -14,5 +14,7 @@ RSpec.describe Scheme, type: :model do
     errors = scheme.errors.full_messages
 
     expect(errors).to include("Name can't be blank")
+    expect(errors).to include("Contractor name can't be blank")
+    expect(errors).to include("Contractor email address can't be blank")
   end
 end


### PR DESCRIPTION
## Changes in this PR:
- Contractor details can be added to a scheme
- Contractor details can be edited for a scheme
- Contractor details appear in the scheme and property view
- Contractor email address validation

## Screenshots of UI changes:

![Screenshot 2019-05-30 at 16 44 48](https://user-images.githubusercontent.com/912473/58645066-81a4b200-82fa-11e9-97d4-a1c3939d5565.png)
![Screenshot 2019-05-30 at 16 44 57](https://user-images.githubusercontent.com/912473/58645067-81a4b200-82fa-11e9-855d-8ffb285f7b6c.png)
![Screenshot 2019-05-30 at 16 45 08](https://user-images.githubusercontent.com/912473/58645068-81a4b200-82fa-11e9-9fe3-b929625d832e.png)
![Screenshot 2019-05-30 at 16 45 23](https://user-images.githubusercontent.com/912473/58645071-81a4b200-82fa-11e9-90da-abf48714232a.png)
![Screenshot 2019-05-30 at 16 45 31](https://user-images.githubusercontent.com/912473/58645072-823d4880-82fa-11e9-87de-1fb4ca104eca.png)
