### PR TITLE
Defect forms show the expected completion dates before crea…

### DIFF
--- a/app/models/priority.rb
+++ b/app/models/priority.rb
@@ -9,6 +9,6 @@ class Priority < ApplicationRecord
   tracked owner: ->(controller, _) { controller.current_user if controller }
 
   def form_label
-    "#{name} - target completion: #{days.days.from_now.strftime('%d/%m/%Y')}"
+    "#{name} - target completion: #{days.days.from_now.to_s(:date)}"
   end
 end

--- a/app/models/priority.rb
+++ b/app/models/priority.rb
@@ -7,4 +7,8 @@ class Priority < ApplicationRecord
 
   include PublicActivity::Model
   tracked owner: ->(controller, _) { controller.current_user if controller }
+
+  def form_label
+    "#{name} - target completion: #{days.days.from_now.strftime('%d/%m/%Y')}"
+  end
 end

--- a/app/views/staff/defects/new.html.haml
+++ b/app/views/staff/defects/new.html.haml
@@ -28,5 +28,7 @@
                   wrapper: 'select',
                   input_html: { class: 'priorities' },
                   collection: @property.scheme.priorities,
-                  required: true
+                  required: true,
+                  label_method: :form_label
+
       = f.button :submit, I18n.t('generic.button.create', resource: 'Defect')

--- a/config/initializers/time_formats.rb
+++ b/config/initializers/time_formats.rb
@@ -1,0 +1,1 @@
+Time::DATE_FORMATS[:date] = '%d/%m/%Y'

--- a/spec/models/priority_spec.rb
+++ b/spec/models/priority_spec.rb
@@ -24,4 +24,15 @@ RSpec.describe Priority, type: :model do
     errors = priority.errors.full_messages
     expect(errors).to include('Days is not a number')
   end
+
+  describe '#form_label' do
+    it 'returns a string that combines name and what the expected completion date would be' do
+      travel_to Time.zone.parse('2019-05-23')
+
+      priority = create(:priority, name: 'P1', days: 3)
+      expect(priority.form_label).to eq('P1 - target completion: 26/05/2019')
+
+      travel_back
+    end
+  end
 end


### PR DESCRIPTION
…tion

## Changes in this PR:
- to save on the complexity of a review page we think by showing this dynamic date in the future will give the agent confidence that it's got the right priority set on it. To be validated in usability testing.

## Screenshots of UI changes:

### Before
![Screenshot 2019-05-30 at 17 24 25](https://user-images.githubusercontent.com/912473/58647587-cda62580-82ff-11e9-94f6-dcf097dfc420.png)

### After
![Screenshot 2019-05-30 at 17 24 57](https://user-images.githubusercontent.com/912473/58647633-e0b8f580-82ff-11e9-992d-06c62ce7cb40.png)

![Screenshot 2019-05-30 at 17 25 04](https://user-images.githubusercontent.com/912473/58647644-e6164000-82ff-11e9-984a-67ab1a32321d.png)
