### PR TITLE
[89] Employers agent details added to scheme

### DIFF
--- a/app/controllers/staff/schemes_controller.rb
+++ b/app/controllers/staff/schemes_controller.rb
@@ -50,6 +50,12 @@ class Staff::SchemesController < Staff::BaseController
   end
 
   def scheme_params
-    params.require(:scheme).permit(:name, :contractor_name, :contractor_email_address)
+    params.require(:scheme).permit(
+      :name,
+      :contractor_name,
+      :contractor_email_address,
+      :employer_agent_name,
+      :employer_agent_email_address
+    )
   end
 end

--- a/app/models/scheme.rb
+++ b/app/models/scheme.rb
@@ -8,7 +8,11 @@ class Scheme < ApplicationRecord
             :contractor_email_address,
             presence: true
 
-  validates :contractor_email_address, format: { with: URI::MailTo::EMAIL_REGEXP }
+  validates :contractor_email_address,
+            format: { with: URI::MailTo::EMAIL_REGEXP }
+  validates :employer_agent_email_address,
+            format: { with: URI::MailTo::EMAIL_REGEXP },
+            allow_blank: true
 
   include PublicActivity::Model
   tracked owner: ->(controller, _) { controller.current_user if controller }

--- a/app/views/shared/properties/_information.html.haml
+++ b/app/views/shared/properties/_information.html.haml
@@ -12,6 +12,12 @@
     %dt.govuk-summary-list__key Contractor email address
     %dd.govuk-summary-list__value= property.scheme.contractor_email_address
   %div.govuk-summary-list__row
+    %dt.govuk-summary-list__key Employer agent name
+    %dd.govuk-summary-list__value= property.scheme.employer_agent_name
+  %div.govuk-summary-list__row
+    %dt.govuk-summary-list__key Employer email address
+    %dd.govuk-summary-list__value= property.scheme.employer_agent_email_address
+  %div.govuk-summary-list__row
     %dt.govuk-summary-list__key Property address
     %dd.govuk-summary-list__value= property.address
   %div.govuk-summary-list__row

--- a/app/views/shared/schemes/_information.html.haml
+++ b/app/views/shared/schemes/_information.html.haml
@@ -8,3 +8,9 @@
   %div.govuk-summary-list__row
     %dt.govuk-summary-list__key Contractor email address
     %dd.govuk-summary-list__value= scheme.contractor_email_address
+  %div.govuk-summary-list__row
+    %dt.govuk-summary-list__key Employer agent name
+    %dd.govuk-summary-list__value= scheme.employer_agent_name
+  %div.govuk-summary-list__row
+    %dt.govuk-summary-list__key Employer agent email address
+    %dd.govuk-summary-list__value= scheme.employer_agent_email_address

--- a/app/views/staff/schemes/edit.html.haml
+++ b/app/views/staff/schemes/edit.html.haml
@@ -11,4 +11,6 @@
         = f.input :name
         = f.input :contractor_name
         = f.input :contractor_email_address
+        = f.input :employer_agent_name
+        = f.input :employer_agent_email_address
       = f.button :submit, I18n.t('generic.button.update', resource: 'Scheme')

--- a/app/views/staff/schemes/new.html.haml
+++ b/app/views/staff/schemes/new.html.haml
@@ -15,4 +15,6 @@
         = f.input :name
         = f.input :contractor_name
         = f.input :contractor_email_address
+        = f.input :employer_agent_name
+        = f.input :employer_agent_email_address
       = f.button :submit, I18n.t('generic.button.create', resource: 'Scheme')

--- a/db/migrate/20190603095239_add_employer_agent_to_scheme.rb
+++ b/db/migrate/20190603095239_add_employer_agent_to_scheme.rb
@@ -1,0 +1,6 @@
+class AddEmployerAgentToScheme < ActiveRecord::Migration[5.2]
+  def change
+    add_column :schemes, :employer_agent_name, :string
+    add_column :schemes, :employer_agent_email_address, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_30_150640) do
+ActiveRecord::Schema.define(version: 2019_06_03_095239) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -84,6 +84,8 @@ ActiveRecord::Schema.define(version: 2019_05_30_150640) do
     t.datetime "updated_at", null: false
     t.string "contractor_name"
     t.string "contractor_email_address"
+    t.string "employer_agent_name"
+    t.string "employer_agent_email_address"
     t.index ["estate_id"], name: "index_schemes_on_estate_id"
   end
 

--- a/spec/factories/schemes.rb
+++ b/spec/factories/schemes.rb
@@ -3,6 +3,8 @@ FactoryBot.define do
     name { Faker::GreekPhilosophers.name }
     contractor_name { Faker::GreekPhilosophers.name }
     contractor_email_address { Faker::Internet.email }
+    employer_agent_name { Faker::GreekPhilosophers.name }
+    employer_agent_email_address { Faker::Internet.email }
     association :estate, factory: :estate
   end
 end

--- a/spec/features/anyone_can_create_a_scheme_spec.rb
+++ b/spec/features/anyone_can_create_a_scheme_spec.rb
@@ -15,15 +15,24 @@ RSpec.feature 'Anyone can create a scheme' do
       fill_in 'scheme[name]', with: 'Kings Cresent'
       fill_in 'scheme[contractor_name]', with: 'Builders R Us'
       fill_in 'scheme[contractor_email_address]', with: 'email@example.com'
+      fill_in 'scheme[employer_agent_name]', with: 'Alex'
+      fill_in 'scheme[employer_agent_email_address]', with: 'alex@example.com'
       click_on(I18n.t('generic.button.create', resource: 'Scheme'))
     end
 
     expect(page).to have_content(I18n.t('generic.notice.create.success', resource: 'scheme'))
+
+    scheme = Scheme.first
+
     within('table.schemes') do
-      scheme = Scheme.first
       expect(page).to have_content(scheme.name)
       expect(page).to have_content(scheme.contractor_name)
+      click_on(I18n.t('generic.link.show'))
     end
+
+    expect(page).to have_content(scheme.contractor_email_address)
+    expect(page).to have_content(scheme.employer_agent_name)
+    expect(page).to have_content(scheme.employer_agent_email_address)
   end
 
   scenario 'an invalid scheme cannot be submitted' do

--- a/spec/features/anyone_can_create_a_scheme_spec.rb
+++ b/spec/features/anyone_can_create_a_scheme_spec.rb
@@ -42,5 +42,13 @@ RSpec.feature 'Anyone can create a scheme' do
     within('.scheme_name') do
       expect(page).to have_content("can't be blank")
     end
+
+    within('.scheme_contractor_name') do
+      expect(page).to have_content("can't be blank")
+    end
+
+    within('.scheme_contractor_email_address') do
+      expect(page).to have_content("can't be blank")
+    end
   end
 end

--- a/spec/features/anyone_can_update_a_scheme_spec.rb
+++ b/spec/features/anyone_can_update_a_scheme_spec.rb
@@ -19,6 +19,8 @@ RSpec.feature 'Anyone can update a scheme' do
       fill_in 'scheme[name]', with: '1'
       fill_in 'scheme[contractor_name]', with: 'A new contractor name'
       fill_in 'scheme[contractor_email_address]', with: 'new@email.com'
+      fill_in 'scheme[employer_agent_name]', with: 'Alex'
+      fill_in 'scheme[employer_agent_email_address]', with: 'alex@example.com'
       click_on(I18n.t('generic.button.update', resource: 'Scheme'))
     end
   end

--- a/spec/features/anyone_can_view_a_property_spec.rb
+++ b/spec/features/anyone_can_view_a_property_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
-RSpec.feature 'Anyone can create a defect' do
-  scenario 'a property can be found and defect can be created' do
+RSpec.feature 'Anyone can view a property' do
+  scenario 'a property can be found and viewed' do
     property = create(:property, address: '1 Hackney Street')
 
     visit root_path

--- a/spec/features/anyone_can_view_a_property_spec.rb
+++ b/spec/features/anyone_can_view_a_property_spec.rb
@@ -22,6 +22,8 @@ RSpec.feature 'Anyone can view a property' do
       expect(page).to have_content(property.scheme.name)
       expect(page).to have_content(property.scheme.contractor_name)
       expect(page).to have_content(property.scheme.contractor_email_address)
+      expect(page).to have_content(property.scheme.employer_agent_name)
+      expect(page).to have_content(property.scheme.employer_agent_email_address)
       expect(page).to have_content(property.address)
       expect(page).to have_content(property.core_name)
     end

--- a/spec/features/anyone_can_view_a_scheme_spec.rb
+++ b/spec/features/anyone_can_view_a_scheme_spec.rb
@@ -20,6 +20,8 @@ RSpec.feature 'Anyone can view a scheme' do
       expect(page).to have_content(scheme.name)
       expect(page).to have_content(scheme.contractor_name)
       expect(page).to have_content(scheme.contractor_email_address)
+      expect(page).to have_content(scheme.employer_agent_name)
+      expect(page).to have_content(scheme.employer_agent_email_address)
     end
 
     within('.priorities') do

--- a/spec/features/anyone_can_view_a_scheme_spec.rb
+++ b/spec/features/anyone_can_view_a_scheme_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.feature 'Anyone can view a scheme' do
+  scenario 'a scheme can be found and viewed' do
+    scheme = create(:scheme)
+    property = create(:property, scheme: scheme)
+    priority = create(:priority, scheme: scheme)
+
+    visit root_path
+
+    expect(page).to have_content(I18n.t('page_title.staff.dashboard'))
+    click_on(I18n.t('generic.link.show'))
+
+    expect(page).to have_content(I18n.t('page_title.staff.estates.show', name: scheme.estate.name))
+    click_on(I18n.t('generic.link.show').titleize)
+
+    expect(page).to have_content(I18n.t('page_title.staff.schemes.show', name: scheme.name).titleize)
+
+    within('.scheme_information') do
+      expect(page).to have_content(scheme.name)
+      expect(page).to have_content(scheme.contractor_name)
+      expect(page).to have_content(scheme.contractor_email_address)
+    end
+
+    within('.priorities') do
+      expect(page).to have_content(priority.name)
+      expect(page).to have_content(priority.days)
+    end
+
+    within('.properties') do
+      expect(page).to have_content(property.core_name)
+      expect(page).to have_content(property.address)
+      expect(page).to have_content(property.postcode)
+    end
+  end
+end

--- a/spec/models/scheme_spec.rb
+++ b/spec/models/scheme_spec.rb
@@ -29,4 +29,16 @@ RSpec.describe Scheme, type: :model do
       expect(scheme.valid?).to be_falsey
     end
   end
+
+  describe 'validates that employer_agent email address looks like one' do
+    it 'returns true with a valid email address' do
+      scheme = build(:scheme, employer_agent_email_address: 'email@example.com')
+      expect(scheme.valid?).to be_truthy
+    end
+
+    it 'returns false with an invalid email address' do
+      scheme = build(:scheme, employer_agent_email_address: 'not a real email')
+      expect(scheme.valid?).to be_falsey
+    end
+  end
 end


### PR DESCRIPTION
## Changes in this PR:
- employer agent name and email address can be attached to a scheme as an optional value (for now until we are confident when the employer agent information for each scheme becomes available)
- retrofit a view feature test for schemes

## Screenshots of UI changes:

### Before
![Screenshot 2019-06-03 at 12 09 46](https://user-images.githubusercontent.com/912473/58797676-80c09880-85f8-11e9-98c0-83aaac1abc12.png)

### After

![Screenshot 2019-06-03 at 12 01 40](https://user-images.githubusercontent.com/912473/58797680-83bb8900-85f8-11e9-9c6e-908ff9e63a9f.png)
![Screenshot 2019-06-03 at 12 07 58](https://user-images.githubusercontent.com/912473/58797681-83bb8900-85f8-11e9-9eee-63a4e4d7a769.png)
![Screenshot 2019-06-03 at 12 08 38](https://user-images.githubusercontent.com/912473/58797682-83bb8900-85f8-11e9-8cce-1eb8ce139539.png)
