### PR TITLE
[90] Add Universal Property Reference Number (UPRN) to properties

### DIFF
--- a/app/controllers/staff/properties_controller.rb
+++ b/app/controllers/staff/properties_controller.rb
@@ -60,6 +60,11 @@ class Staff::PropertiesController < Staff::BaseController
   end
 
   def property_params
-    params.require(:property).permit(:core_name, :address, :postcode)
+    params.require(:property).permit(
+      :core_name,
+      :address,
+      :postcode,
+      :uprn
+    )
   end
 end

--- a/app/models/property.rb
+++ b/app/models/property.rb
@@ -2,7 +2,11 @@ class Property < ApplicationRecord
   belongs_to :scheme, dependent: :destroy
   has_many :defects, dependent: :restrict_with_error
 
-  validates :core_name, :address, :postcode, presence: true
+  validates :core_name,
+            :address,
+            :postcode,
+            :uprn,
+            presence: true
 
   include PgSearch
   pg_search_scope :search_by_address, against: %i[address core_name]

--- a/app/models/property.rb
+++ b/app/models/property.rb
@@ -8,6 +8,8 @@ class Property < ApplicationRecord
             :uprn,
             presence: true
 
+  validates :uprn, uniqueness: true
+
   include PgSearch
   pg_search_scope :search_by_address, against: %i[address core_name]
 

--- a/app/views/shared/properties/_information.html.haml
+++ b/app/views/shared/properties/_information.html.haml
@@ -18,6 +18,9 @@
     %dt.govuk-summary-list__key Employer email address
     %dd.govuk-summary-list__value= property.scheme.employer_agent_email_address
   %div.govuk-summary-list__row
+    %dt.govuk-summary-list__key UPRN
+    %dd.govuk-summary-list__value= property.uprn
+  %div.govuk-summary-list__row
     %dt.govuk-summary-list__key Property address
     %dd.govuk-summary-list__value= property.address
   %div.govuk-summary-list__row

--- a/app/views/shared/properties/_table.html.haml
+++ b/app/views/shared/properties/_table.html.haml
@@ -3,6 +3,9 @@
     %tr.govuk-table__row
       %th.govuk-table__header
         %h2.govuk-heading-m
+          UPRN
+      %th.govuk-table__header
+        %h2.govuk-heading-m
           Core name
       %th.govuk-table__header
         %h2.govuk-heading-m
@@ -18,6 +21,7 @@
   %tbody.govuk-table__body
     - properties.each do |property|
       %tr.govuk-table__row
+        %td.govuk-table__cell= property.uprn
         %td.govuk-table__cell= property.core_name
         %td.govuk-table__cell= property.address
         %td.govuk-table__cell= property.postcode

--- a/app/views/staff/properties/edit.html.haml
+++ b/app/views/staff/properties/edit.html.haml
@@ -13,4 +13,5 @@
         = f.input :core_name
         = f.input :address
         = f.input :postcode
+        = f.input :uprn, label: 'Universal Property Reference Number (UPRN)'
       = f.button :submit, I18n.t('generic.button.update', resource: 'Property')

--- a/app/views/staff/properties/new.html.haml
+++ b/app/views/staff/properties/new.html.haml
@@ -13,4 +13,5 @@
         = f.input :core_name
         = f.input :address
         = f.input :postcode
+        = f.input :uprn, label: 'Universal Property Reference Number (UPRN)'
       = f.button :submit, I18n.t('generic.button.create', resource: 'Property')

--- a/app/views/staff/schemes/show.html.haml
+++ b/app/views/staff/schemes/show.html.haml
@@ -7,7 +7,7 @@
     = breadcrumb_current(I18n.t('page_title.staff.schemes.show', name: @scheme.name))
 
 .govuk-grid-row
-  .govuk-grid-column-two-thirds
+  .govuk-grid-column-full
     %h1.govuk-heading-xl= I18n.t('page_title.staff.schemes.show', name: @scheme.name)
     = link_to(I18n.t('generic.button.edit', resource: 'Scheme'), edit_estate_scheme_path(@scheme.estate, @scheme), class: 'govuk-button mb0')
     = render partial: '/shared/schemes/information', locals: { scheme: @scheme }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,3 +38,13 @@ en:
       update:
         success:
           'The %{resource} has successfully been updated.'
+  activerecord:
+    attributes:
+      property:
+        uprn: 'UPRN'
+    errors:
+      models:
+        property:
+          attributes:
+            uprn:
+              blank: "can't be blank"

--- a/db/migrate/20190603115200_add_uprn_to_properties.rb
+++ b/db/migrate/20190603115200_add_uprn_to_properties.rb
@@ -1,0 +1,6 @@
+class AddUprnToProperties < ActiveRecord::Migration[5.2]
+  def change
+    add_column :properties, :uprn, :string
+    add_index :properties, :uprn, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_03_095239) do
+ActiveRecord::Schema.define(version: 2019_06_03_115200) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -74,7 +74,9 @@ ActiveRecord::Schema.define(version: 2019_06_03_095239) do
     t.uuid "scheme_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "uprn"
     t.index ["scheme_id"], name: "index_properties_on_scheme_id"
+    t.index ["uprn"], name: "index_properties_on_uprn", unique: true
   end
 
   create_table "schemes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/factories/properties.rb
+++ b/spec/factories/properties.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
     core_name { Faker::Address.community }
     address { Faker::Address.street_address }
     postcode { Faker::Address.zip_code }
+    uprn { Faker::Number.number(12) }
     association :scheme, factory: :scheme
   end
 end

--- a/spec/features/anyone_can_create_a_property_spec.rb
+++ b/spec/features/anyone_can_create_a_property_spec.rb
@@ -15,6 +15,7 @@ RSpec.feature 'Anyone can create a property' do
       fill_in 'property[core_name]', with: 'A name for a collection of blocks'
       fill_in 'property[address]', with: 'Flat 1, Hackney Street'
       fill_in 'property[postcode]', with: 'N16NU'
+      fill_in 'property[uprn]', with: '100081272892'
       click_on(I18n.t('generic.button.create', resource: 'Property'))
     end
 
@@ -23,6 +24,7 @@ RSpec.feature 'Anyone can create a property' do
       expect(page).to have_content('A name for a collection of blocks')
       expect(page).to have_content('Flat 1, Hackney Street')
       expect(page).to have_content('N16NU')
+      expect(page).to have_content('100081272892')
     end
   end
 
@@ -48,6 +50,10 @@ RSpec.feature 'Anyone can create a property' do
     end
 
     within('.property_postcode') do
+      expect(page).to have_content("can't be blank")
+    end
+
+    within('.property_uprn') do
       expect(page).to have_content("can't be blank")
     end
   end

--- a/spec/features/anyone_can_create_a_property_spec.rb
+++ b/spec/features/anyone_can_create_a_property_spec.rb
@@ -20,10 +20,9 @@ RSpec.feature 'Anyone can create a property' do
 
     expect(page).to have_content(I18n.t('generic.notice.create.success', resource: 'property'))
     within('table.properties') do
-      property = Property.first
-      expect(page).to have_content(property.core_name)
-      expect(page).to have_content(property.address)
-      expect(page).to have_content(property.postcode)
+      expect(page).to have_content('A name for a collection of blocks')
+      expect(page).to have_content('Flat 1, Hackney Street')
+      expect(page).to have_content('N16NU')
     end
   end
 

--- a/spec/features/anyone_can_create_a_property_spec.rb
+++ b/spec/features/anyone_can_create_a_property_spec.rb
@@ -43,5 +43,13 @@ RSpec.feature 'Anyone can create a property' do
     within('.property_core_name') do
       expect(page).to have_content("can't be blank")
     end
+
+    within('.property_address') do
+      expect(page).to have_content("can't be blank")
+    end
+
+    within('.property_postcode') do
+      expect(page).to have_content("can't be blank")
+    end
   end
 end

--- a/spec/features/anyone_can_view_a_property_spec.rb
+++ b/spec/features/anyone_can_view_a_property_spec.rb
@@ -24,6 +24,7 @@ RSpec.feature 'Anyone can view a property' do
       expect(page).to have_content(property.scheme.contractor_email_address)
       expect(page).to have_content(property.scheme.employer_agent_name)
       expect(page).to have_content(property.scheme.employer_agent_email_address)
+      expect(page).to have_content(property.uprn)
       expect(page).to have_content(property.address)
       expect(page).to have_content(property.core_name)
     end

--- a/spec/models/property_spec.rb
+++ b/spec/models/property_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe Property, type: :model do
 
     errors = priority.errors.full_messages
 
-    expect(errors).to include("Name can't be blank")
-    expect(errors).to include("Days can't be blank")
-    expect(errors).to include('Scheme must exist')
+    expect(errors).to include("Core name can't be blank")
+    expect(errors).to include("Address can't be blank")
+    expect(errors).to include("Postcode can't be blank")
   end
 end

--- a/spec/models/property_spec.rb
+++ b/spec/models/property_spec.rb
@@ -15,5 +15,6 @@ RSpec.describe Property, type: :model do
     expect(errors).to include("Core name can't be blank")
     expect(errors).to include("Address can't be blank")
     expect(errors).to include("Postcode can't be blank")
+    expect(errors).to include("UPRN can't be blank")
   end
 end

--- a/spec/models/property_spec.rb
+++ b/spec/models/property_spec.rb
@@ -7,14 +7,27 @@ RSpec.describe Property, type: :model do
   it_behaves_like 'a trackable resource', resource: described_class
 
   it 'validates presence of required fields' do
-    priority = described_class.new
-    expect(priority.valid?).to be_falsey
+    property = described_class.new
+    expect(property.valid?).to be_falsey
 
-    errors = priority.errors.full_messages
+    errors = property.errors.full_messages
 
     expect(errors).to include("Core name can't be blank")
     expect(errors).to include("Address can't be blank")
     expect(errors).to include("Postcode can't be blank")
     expect(errors).to include("UPRN can't be blank")
+  end
+
+  context 'when a duplicate UPRN is used' do
+    it 'is invalid' do
+      _existing_property = create(:property, uprn: '123')
+      new_property = described_class.new(uprn: '123')
+
+      expect(new_property.valid?).to be_falsey
+
+      errors = new_property.errors.full_messages
+
+      expect(errors).to include('UPRN has already been taken')
+    end
   end
 end


### PR DESCRIPTION
## Changes in this PR:
- UPRN must be added to each property
- You can read more about what the UPRN is here https://www.geoplace.co.uk/documents/10181/128676/UPRN+-+your+golden+thread/22717600-66e3-40b5-b4b1-b5ed839669c0
- UPRN must be unique to an individual property

## Screenshots of UI changes:
![Screenshot 2019-06-03 at 13 24 08](https://user-images.githubusercontent.com/912473/58801617-f598d000-8602-11e9-8a5f-93986fc7e797.png)
![Screenshot 2019-06-03 at 13 24 21](https://user-images.githubusercontent.com/912473/58801618-f598d000-8602-11e9-8724-43c66746a71d.png)
![Screenshot 2019-06-03 at 13 24 02](https://user-images.githubusercontent.com/912473/58801619-f598d000-8602-11e9-9a0f-3640d1672c74.png)
