### PR TITLE
[76] Agents can edit a defect

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -13,3 +13,7 @@ p {
 .govuk-header__container {
   border-bottom: 10px solid $lbh-primary;
 }
+
+.collection_radio_buttons {
+  @extend .govuk-radios__label;
+}

--- a/app/controllers/staff/defects_controller.rb
+++ b/app/controllers/staff/defects_controller.rb
@@ -23,6 +23,24 @@ class Staff::DefectsController < Staff::BaseController
     @defect = Defect.find(id)
   end
 
+  def edit
+    @defect = Defect.find(id)
+  end
+
+  def update
+    @defect = Defect.find(id)
+    @defect.assign_attributes(defect_params)
+    @defect.priority = Priority.find(priority_id) if priority_id.present?
+
+    if @defect.valid?
+      @defect.save
+      flash[:success] = I18n.t('generic.notice.update.success', resource: 'defect')
+      redirect_to property_defect_path(@defect.property, @defect)
+    else
+      render :edit
+    end
+  end
+
   private
 
   def id

--- a/app/controllers/staff/defects_controller.rb
+++ b/app/controllers/staff/defects_controller.rb
@@ -62,6 +62,7 @@ class Staff::DefectsController < Staff::BaseController
       :contact_email_address,
       :contact_phone_number,
       :trade,
+      :status
     )
   end
 end

--- a/app/controllers/staff/defects_controller.rb
+++ b/app/controllers/staff/defects_controller.rb
@@ -19,6 +19,10 @@ class Staff::DefectsController < Staff::BaseController
     end
   end
 
+  def show
+    @defect = Defect.find(id)
+  end
+
   private
 
   def id

--- a/app/helpers/date_helper.rb
+++ b/app/helpers/date_helper.rb
@@ -1,0 +1,9 @@
+module DateHelper
+  class FormatDateError < RuntimeError; end
+
+  def format_date(date, format = :default)
+    return 'No date given' if date.nil?
+
+    date.to_s(format).lstrip
+  end
+end

--- a/app/helpers/defect_helper.rb
+++ b/app/helpers/defect_helper.rb
@@ -2,4 +2,8 @@ module DefectHelper
   def priority_form_label(priority:)
     "#{priority.name} - #{pluralize(priority.days, 'day')} from now"
   end
+
+  def status_form_label(option_array:)
+    option_array.first.capitalize.tr('_', ' ')
+  end
 end

--- a/app/helpers/defect_helper.rb
+++ b/app/helpers/defect_helper.rb
@@ -1,0 +1,5 @@
+module DefectHelper
+  def priority_form_label(priority:)
+    "#{priority.name} - #{pluralize(priority.days, 'day')} from now"
+  end
+end

--- a/app/models/defect.rb
+++ b/app/models/defect.rb
@@ -71,7 +71,7 @@ class Defect < ApplicationRecord
   def set_completion_date
     return unless priority
 
-    self.target_completion_date = Time.zone.now + priority.days
+    self.target_completion_date = Time.zone.now + priority.days.days
   end
 
   def status

--- a/app/models/priority.rb
+++ b/app/models/priority.rb
@@ -7,8 +7,4 @@ class Priority < ApplicationRecord
 
   include PublicActivity::Model
   tracked owner: ->(controller, _) { controller.current_user if controller }
-
-  def form_label
-    "#{name} - target completion: #{days.days.from_now.to_s(:date)}"
-  end
 end

--- a/app/views/shared/defects/_information.html.haml
+++ b/app/views/shared/defects/_information.html.haml
@@ -3,6 +3,9 @@
     %dt.govuk-summary-list__key Reference number
     %dd.govuk-summary-list__value= defect.reference_number
   %div.govuk-summary-list__row
+    %dt.govuk-summary-list__key Status
+    %dd.govuk-summary-list__value= defect.status
+  %div.govuk-summary-list__row
     %dt.govuk-summary-list__key Description
     %dd.govuk-summary-list__value= defect.description
   %div.govuk-summary-list__row
@@ -20,9 +23,6 @@
   %div.govuk-summary-list__row
     %dt.govuk-summary-list__key Target completion date
     %dd.govuk-summary-list__value= format_date(defect.target_completion_date)
-  %div.govuk-summary-list__row
-    %dt.govuk-summary-list__key Status
-    %dd.govuk-summary-list__value= defect.status
   %div.govuk-summary-list__row
     %dt.govuk-summary-list__key Priority
     %dd.govuk-summary-list__value= defect.priority.name

--- a/app/views/shared/defects/_information.html.haml
+++ b/app/views/shared/defects/_information.html.haml
@@ -19,7 +19,7 @@
     %dd.govuk-summary-list__value= defect.trade
   %div.govuk-summary-list__row
     %dt.govuk-summary-list__key Target completion date
-    %dd.govuk-summary-list__value= defect.target_completion_date
+    %dd.govuk-summary-list__value= format_date(defect.target_completion_date)
   %div.govuk-summary-list__row
     %dt.govuk-summary-list__key Status
     %dd.govuk-summary-list__value= defect.status

--- a/app/views/shared/defects/_information.html.haml
+++ b/app/views/shared/defects/_information.html.haml
@@ -1,0 +1,31 @@
+%dl.govuk-summary-list.defect_information
+  %div.govuk-summary-list__row
+    %dt.govuk-summary-list__key Reference number
+    %dd.govuk-summary-list__value= defect.reference_number
+  %div.govuk-summary-list__row
+    %dt.govuk-summary-list__key Description
+    %dd.govuk-summary-list__value= defect.description
+  %div.govuk-summary-list__row
+    %dt.govuk-summary-list__key Contact name
+    %dd.govuk-summary-list__value= defect.contact_name
+  %div.govuk-summary-list__row
+    %dt.govuk-summary-list__key Contact email address
+    %dd.govuk-summary-list__value= defect.contact_email_address
+  %div.govuk-summary-list__row
+    %dt.govuk-summary-list__key Contact phone number
+    %dd.govuk-summary-list__value= defect.contact_phone_number
+  %div.govuk-summary-list__row
+    %dt.govuk-summary-list__key Trade
+    %dd.govuk-summary-list__value= defect.trade
+  %div.govuk-summary-list__row
+    %dt.govuk-summary-list__key Target completion date
+    %dd.govuk-summary-list__value= defect.target_completion_date
+  %div.govuk-summary-list__row
+    %dt.govuk-summary-list__key Status
+    %dd.govuk-summary-list__value= defect.status
+  %div.govuk-summary-list__row
+    %dt.govuk-summary-list__key Priority
+    %dd.govuk-summary-list__value= defect.priority.name
+  %div.govuk-summary-list__row
+    %dt.govuk-summary-list__key Property
+    %dd.govuk-summary-list__value= defect.property.address

--- a/app/views/shared/defects/_table.html.haml
+++ b/app/views/shared/defects/_table.html.haml
@@ -25,6 +25,6 @@
         %td.govuk-table__cell= defect.reference_number
         %td.govuk-table__cell= defect.status
         %td.govuk-table__cell= defect.priority.name
-        %td.govuk-table__cell= defect.target_completion_date
+        %td.govuk-table__cell= format_date(defect.target_completion_date)
         %td.govuk-table__cell= defect.trade
         %td.govuk-table__cell= link_to(I18n.t('generic.link.show'), property_defect_path(defect.property, defect), class: 'govuk-link')

--- a/app/views/shared/defects/_table.html.haml
+++ b/app/views/shared/defects/_table.html.haml
@@ -16,6 +16,9 @@
       %th.govuk-table__header
         %h2.govuk-heading-m
           Trade
+      %th.govuk-table__header
+        %h2.govuk-heading-m
+          Actions
   %tbody.govuk-table__body
     - defects.each do |defect|
       %tr.govuk-table__row
@@ -24,3 +27,4 @@
         %td.govuk-table__cell= defect.priority.name
         %td.govuk-table__cell= defect.target_completion_date
         %td.govuk-table__cell= defect.trade
+        %td.govuk-table__cell= link_to(I18n.t('generic.link.show'), property_defect_path(defect.property, defect), class: 'govuk-link')

--- a/app/views/shared/defects/_table.html.haml
+++ b/app/views/shared/defects/_table.html.haml
@@ -1,0 +1,26 @@
+%table.govuk-table.defects
+  %thead.govuk-table__head
+    %tr.govuk-table__row
+      %th.govuk-table__header
+        %h2.govuk-heading-m
+          Reference number
+      %th.govuk-table__header
+        %h2.govuk-heading-m
+          Status
+      %th.govuk-table__header
+        %h2.govuk-heading-m
+          Priority
+      %th.govuk-table__header
+        %h2.govuk-heading-m
+          Target completion date
+      %th.govuk-table__header
+        %h2.govuk-heading-m
+          Trade
+  %tbody.govuk-table__body
+    - defects.each do |defect|
+      %tr.govuk-table__row
+        %td.govuk-table__cell= defect.reference_number
+        %td.govuk-table__cell= defect.status
+        %td.govuk-table__cell= defect.priority.name
+        %td.govuk-table__cell= defect.target_completion_date
+        %td.govuk-table__cell= defect.trade

--- a/app/views/shared/properties/_information.html.haml
+++ b/app/views/shared/properties/_information.html.haml
@@ -1,23 +1,5 @@
 %dl.govuk-summary-list.property_information
   %div.govuk-summary-list__row
-    %dt.govuk-summary-list__key Estate
-    %dd.govuk-summary-list__value= property.scheme.estate.name
-  %div.govuk-summary-list__row
-    %dt.govuk-summary-list__key Scheme
-    %dd.govuk-summary-list__value= property.scheme.name
-  %div.govuk-summary-list__row
-    %dt.govuk-summary-list__key Contractor name
-    %dd.govuk-summary-list__value= property.scheme.contractor_name
-  %div.govuk-summary-list__row
-    %dt.govuk-summary-list__key Contractor email address
-    %dd.govuk-summary-list__value= property.scheme.contractor_email_address
-  %div.govuk-summary-list__row
-    %dt.govuk-summary-list__key Employer agent name
-    %dd.govuk-summary-list__value= property.scheme.employer_agent_name
-  %div.govuk-summary-list__row
-    %dt.govuk-summary-list__key Employer email address
-    %dd.govuk-summary-list__value= property.scheme.employer_agent_email_address
-  %div.govuk-summary-list__row
     %dt.govuk-summary-list__key UPRN
     %dd.govuk-summary-list__value= property.uprn
   %div.govuk-summary-list__row
@@ -26,3 +8,6 @@
   %div.govuk-summary-list__row
     %dt.govuk-summary-list__key Property core
     %dd.govuk-summary-list__value= property.core_name
+  %div.govuk-summary-list__row
+    %dt.govuk-summary-list__key Postcode
+    %dd.govuk-summary-list__value= property.postcode

--- a/app/views/shared/schemes/_information.html.haml
+++ b/app/views/shared/schemes/_information.html.haml
@@ -1,6 +1,9 @@
 %dl.govuk-summary-list.scheme_information
   %div.govuk-summary-list__row
-    %dt.govuk-summary-list__key Name
+    %dt.govuk-summary-list__key Estate
+    %dd.govuk-summary-list__value= scheme.estate.name
+  %div.govuk-summary-list__row
+    %dt.govuk-summary-list__key Scheme
     %dd.govuk-summary-list__value= scheme.name
   %div.govuk-summary-list__row
     %dt.govuk-summary-list__key Contractor name

--- a/app/views/staff/defects/edit.html.haml
+++ b/app/views/staff/defects/edit.html.haml
@@ -1,0 +1,46 @@
+- content_for :page_title_prefix, I18n.t('page_title.staff.defects.edit', reference_number: @defect.reference_number)
+
+= link_to "Back to #{I18n.t('page_title.staff.defects.show', reference_number: @defect.reference_number)}", property_defect_path(@defect.property, @defect), class: 'govuk-back-link'
+
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    %h1.govuk-heading-xl
+      = I18n.t('page_title.staff.defects.edit', reference_number: @defect.reference_number)
+      %span.govuk-caption-l= 'Step 1 of 1'
+
+    = simple_form_for [@defect.property, @defect] do |f|
+      .govuk-form-group
+        = f.input :description,
+                  wrapper: 'textarea',
+                  as: :text,
+                  input_html: { rows: 10 },
+                  required: true
+        = f.input :contact_name
+        = f.input :contact_email_address
+        = f.input :contact_phone_number
+        = f.input :trade,
+                  wrapper: 'select',
+                  input_html: { class: 'trades' },
+                  collection: Defect::TRADES,
+                  required: true
+      .existing-priority-information
+        %label.govuk-label
+          %span Priority status
+          %p.govuk-inset-text= @defect.priority.name
+        %label.govuk-label
+          %span Target date for completion
+          %p.govuk-inset-text
+            = @defect.target_completion_date if @defect.target_completion_date?
+
+      = f.input :priority,
+                as: :radio_buttons,
+                wrapper: :radio_buttons,
+                item_wrapper_class: 'govuk-radios__item',
+                item_label_class: 'govuk-label',
+                input_html: { class: 'priorities' },
+                collection: @defect.property.scheme.priorities,
+                required: false,
+                selected: @defect.priority,
+                label_method: ->(obj){ priority_form_label(priority: obj) }
+
+      = f.button :submit, I18n.t('generic.button.update', resource: 'Defect')

--- a/app/views/staff/defects/edit.html.haml
+++ b/app/views/staff/defects/edit.html.haml
@@ -30,7 +30,7 @@
         %label.govuk-label
           %span Target date for completion
           %p.govuk-inset-text
-            = @defect.target_completion_date if @defect.target_completion_date?
+            = format_date(@defect.target_completion_date) if @defect.target_completion_date?
 
       = f.input :priority,
                 as: :radio_buttons,

--- a/app/views/staff/defects/edit.html.haml
+++ b/app/views/staff/defects/edit.html.haml
@@ -23,6 +23,14 @@
                   input_html: { class: 'trades' },
                   collection: Defect::TRADES,
                   required: true
+        = f.input :status,
+                  wrapper: 'select',
+                  input_html: { class: 'status' },
+                  collection: Defect.statuses,
+                  selected: @defect.status,
+                  required: true,
+                  label_method: ->(obj){ status_form_label(option_array: obj) },
+                  value_method: :first
       .existing-priority-information
         %label.govuk-label
           %span Priority status

--- a/app/views/staff/defects/new.html.haml
+++ b/app/views/staff/defects/new.html.haml
@@ -10,11 +10,11 @@
     = render partial: '/shared/properties/information', locals: { property: @property }
 
     = simple_form_for @defect, html: { class: 'new_defect' }, action: :post, url: property_defects_path(@property) do |f|
-      .form-group
+      .govuk-form-group
         = f.input :description,
                   wrapper: 'textarea',
                   as: :text,
-                  input_html: { rows: 5 },
+                  input_html: { rows: 10 },
                   required: true
         = f.input :contact_name
         = f.input :contact_email_address
@@ -25,10 +25,13 @@
                   collection: Defect::TRADES,
                   required: true
         = f.input :priority,
-                  wrapper: 'select',
+                  as: :radio_buttons,
+                  wrapper: :radio_buttons,
+                  item_wrapper_class: 'govuk-radios__item',
+                  item_label_class: 'govuk-label',
                   input_html: { class: 'priorities' },
                   collection: @property.scheme.priorities,
                   required: true,
-                  label_method: :form_label
-
+                  selected: @defect.priority,
+                  label_method: ->(obj){ priority_form_label(priority: obj) }
       = f.button :submit, I18n.t('generic.button.create', resource: 'Defect')

--- a/app/views/staff/defects/show.html.haml
+++ b/app/views/staff/defects/show.html.haml
@@ -1,4 +1,4 @@
-- content_for :page_title_prefix, I18n.t('page_title.staff.defects.create')
+- content_for :page_title_prefix, I18n.t('page_title.staff.defects.show', reference_number: @defect.reference_number)
 
 .govuk-breadcrumbs
   %ol.govuk-breadcrumbs__list

--- a/app/views/staff/defects/show.html.haml
+++ b/app/views/staff/defects/show.html.haml
@@ -12,6 +12,7 @@
   .govuk-grid-column-two-thirds
     %h1.govuk-heading-xl
       = I18n.t('page_title.staff.defects.show', reference_number: @defect.reference_number)
+    = link_to(I18n.t('generic.button.edit', resource: 'Defect'), edit_property_defect_path(@defect.property, @defect), class: 'govuk-button mb0')
     = render partial: '/shared/defects/information', locals: { defect: @defect }
 
   .govuk-grid-column-one-third

--- a/app/views/staff/defects/show.html.haml
+++ b/app/views/staff/defects/show.html.haml
@@ -1,5 +1,13 @@
 - content_for :page_title_prefix, I18n.t('page_title.staff.defects.create')
 
+.govuk-breadcrumbs
+  %ol.govuk-breadcrumbs__list
+    = breadcrumb_link_to('Home', root_path)
+    = breadcrumb_link_to(I18n.t('page_title.staff.estates.show', name: @defect.property.scheme.estate.name), estate_path(@defect.property.scheme.estate))
+    = breadcrumb_link_to(I18n.t('page_title.staff.schemes.show', name: @defect.property.scheme.name), estate_scheme_path(@defect.property.scheme.estate, @defect.property.scheme))
+    = breadcrumb_link_to(I18n.t('page_title.staff.properties.show', name: @defect.property.address), property_path(@defect.property))
+    = breadcrumb_current(I18n.t('page_title.staff.defects.show', reference_number: @defect.reference_number))
+
 .govuk-grid-row
   .govuk-grid-column-two-thirds
     %h1.govuk-heading-xl

--- a/app/views/staff/defects/show.html.haml
+++ b/app/views/staff/defects/show.html.haml
@@ -1,0 +1,8 @@
+- content_for :page_title_prefix, I18n.t('page_title.staff.defects.create')
+
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    %h1.govuk-heading-xl
+      = I18n.t('page_title.staff.defects.show', reference_number: @defect.reference_number)
+
+    = render partial: '/shared/defects/information', locals: { defect: @defect }

--- a/app/views/staff/defects/show.html.haml
+++ b/app/views/staff/defects/show.html.haml
@@ -4,5 +4,13 @@
   .govuk-grid-column-two-thirds
     %h1.govuk-heading-xl
       = I18n.t('page_title.staff.defects.show', reference_number: @defect.reference_number)
-
     = render partial: '/shared/defects/information', locals: { defect: @defect }
+
+  .govuk-grid-column-one-third
+    %h2.govuk-heading-l
+      Scheme
+    = render partial: '/shared/schemes/information', locals: { scheme: @defect.property.scheme }
+
+    %h2.govuk-heading-l
+      Property
+    = render partial: '/shared/properties/information', locals: { property: @defect.property }

--- a/app/views/staff/properties/show.html.haml
+++ b/app/views/staff/properties/show.html.haml
@@ -11,9 +11,17 @@
   .govuk-grid-column-full
     %h1.govuk-heading-xl
       = I18n.t('page_title.staff.properties.show', name: @property.address)
-
+  .govuk-grid-column-one-half
+    %h2.govuk-heading-l
+      Property
     = render partial: '/shared/properties/information', locals: { property: @property }
+  .govuk-grid-column-one-half
+    %h2.govuk-heading-l
+      Scheme
+    = render partial: '/shared/schemes/information', locals: { scheme: @property.scheme }
 
+  .govuk-grid-column-full
+    %h1.govuk-heading-xl
+      Defects
     = link_to(I18n.t('generic.button.create', resource: 'Defect'), new_property_defect_path(@property), class: 'govuk-button mb0')
-
     = render partial: '/shared/defects/table', locals: { defects: @property.defects }

--- a/app/views/staff/properties/show.html.haml
+++ b/app/views/staff/properties/show.html.haml
@@ -16,29 +16,4 @@
 
     = link_to(I18n.t('generic.button.create', resource: 'Defect'), new_property_defect_path(@property), class: 'govuk-button mb0')
 
-    %table.govuk-table.defects
-      %thead.govuk-table__head
-        %tr.govuk-table__row
-          %th.govuk-table__header
-            %h2.govuk-heading-m
-              Reference number
-          %th.govuk-table__header
-            %h2.govuk-heading-m
-              Status
-          %th.govuk-table__header
-            %h2.govuk-heading-m
-              Priority
-          %th.govuk-table__header
-            %h2.govuk-heading-m
-              Target completion date
-          %th.govuk-table__header
-            %h2.govuk-heading-m
-              Trade
-      %tbody.govuk-table__body
-        - @property.defects.each do |defect|
-          %tr.govuk-table__row
-            %td.govuk-table__cell= defect.reference_number
-            %td.govuk-table__cell= defect.status
-            %td.govuk-table__cell= defect.priority.name
-            %td.govuk-table__cell= defect.target_completion_date
-            %td.govuk-table__cell= defect.trade
+    = render partial: '/shared/defects/table', locals: { defects: @property.defects }

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -195,6 +195,20 @@ SimpleForm.setup do |config|
     field.use :input, as: :select, class: 'govuk-select'
   end
 
+  config.wrappers :radio_buttons, tag: 'div',
+                                  class: 'govuk-form-group',
+                                  error_class: 'govuk-form-group--error' do |radio|
+    radio.use :hint, wrap_with: { tag: 'div', class: 'govuk-hint' }
+    radio.use :error, wrap_with: { tag: 'div', class: 'govuk-error-message' }
+    radio.use :label, wrap_with: { tag: 'span', class: 'govuk-label govuk-label' }
+
+    radio.use :html5
+
+    radio.wrapper class: 'govuk-radios' do |govuk_radios|
+      govuk_radios.use :input, class: 'govuk-radios__input'
+    end
+  end
+
   config.wrappers :textarea, tag: 'div',
                              class: 'govuk-form-group',
                              error_class: 'govuk-form-group--error' do |field|

--- a/config/initializers/time_formats.rb
+++ b/config/initializers/time_formats.rb
@@ -1,1 +1,2 @@
+Date::DATE_FORMATS[:default] = '%e %B %Y'
 Time::DATE_FORMATS[:date] = '%d/%m/%Y'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,6 +23,7 @@ en:
       defects:
         create: 'Create Defect'
         show: 'Defect %{reference_number}'
+        edit: 'Update defect'
   generic:
     link:
       show: 'View'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -22,6 +22,7 @@ en:
         show: '%{name}'
       defects:
         create: 'Create Defect'
+        show: 'Defect %{reference_number}'
   generic:
     link:
       show: 'View'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,6 @@ Rails.application.routes.draw do
   end
 
   resources :properties, controller: 'staff/properties', only: %i[index show] do
-    resources :defects, controller: 'staff/defects', only: %i[new create show]
+    resources :defects, controller: 'staff/defects', only: %i[new create show edit update]
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,6 @@ Rails.application.routes.draw do
   end
 
   resources :properties, controller: 'staff/properties', only: %i[index show] do
-    resources :defects, controller: 'staff/defects', only: %i[new create]
+    resources :defects, controller: 'staff/defects', only: %i[new create show]
   end
 end

--- a/spec/factories/defects.rb
+++ b/spec/factories/defects.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :defect do
-    description { Faker::Lorem.sentences(2).to_sentence }
+    description { Faker::Lorem.paragraph_by_chars(750) }
     contact_name { Faker::Name.name }
     contact_email_address { Faker::Internet.email }
     contact_phone_number { Faker::Base.numerify('###########') }

--- a/spec/factories/defects.rb
+++ b/spec/factories/defects.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :defect do
-    description { Faker::Lorem.sentences(2) }
+    description { Faker::Lorem.sentences(2).to_sentence }
     contact_name { Faker::Name.name }
     contact_email_address { Faker::Internet.email }
     contact_phone_number { Faker::Base.numerify('###########') }

--- a/spec/factories/schemes.rb
+++ b/spec/factories/schemes.rb
@@ -6,5 +6,11 @@ FactoryBot.define do
     employer_agent_name { Faker::GreekPhilosophers.name }
     employer_agent_email_address { Faker::Internet.email }
     association :estate, factory: :estate
+
+    trait :with_priorities do
+      after(:create) do |scheme|
+        create_list(:priority, 3, scheme: scheme)
+      end
+    end
   end
 end

--- a/spec/features/anyone_can_create_a_defect_spec.rb
+++ b/spec/features/anyone_can_create_a_defect_spec.rb
@@ -28,14 +28,14 @@ RSpec.feature 'Anyone can create a defect' do
       expect(page).to have_content(property.core_name)
       expect(page).to have_content(property.postcode)
     end
-    
+
     within('form.new_defect') do
       fill_in 'defect[description]', with: 'None of the electrics work'
       fill_in 'defect[contact_name]', with: 'Alex Stone'
       fill_in 'defect[contact_email_address]', with: 'email@example.com'
       fill_in 'defect[contact_phone_number]', with: '07123456789'
       select 'Electrical', from: 'defect[trade]'
-      select priority.name, from: 'defect[priority]'
+      choose priority.name
       click_on(I18n.t('generic.button.create', resource: 'Defect'))
     end
 

--- a/spec/features/anyone_can_create_a_defect_spec.rb
+++ b/spec/features/anyone_can_create_a_defect_spec.rb
@@ -23,12 +23,12 @@ RSpec.feature 'Anyone can create a defect' do
     expect(page).to have_content(I18n.t('page_title.staff.defects.create'))
 
     within('.property_information') do
-      expect(page).to have_content(property.scheme.estate.name)
-      expect(page).to have_content(property.scheme.name)
+      expect(page).to have_content(property.uprn)
       expect(page).to have_content(property.address)
       expect(page).to have_content(property.core_name)
+      expect(page).to have_content(property.postcode)
     end
-
+    
     within('form.new_defect') do
       fill_in 'defect[description]', with: 'None of the electrics work'
       fill_in 'defect[contact_name]', with: 'Alex Stone'

--- a/spec/features/anyone_can_update_a_defect_spec.rb
+++ b/spec/features/anyone_can_update_a_defect_spec.rb
@@ -1,45 +1,86 @@
 require 'rails_helper'
 
 RSpec.feature 'Anyone can update a defect' do
-  let!(:scheme) { create(:scheme) }
+  let(:scheme) { create(:scheme, :with_priorities) }
+  let(:property) { create(:property, scheme: scheme) }
 
   scenario 'a defect can be updated' do
-    defect = create(:defect)
+    defect = create(:defect, property: property)
+    priority = defect.property.scheme.priorities.first
 
-    visit defect_path(defect)
+    visit property_defect_path(defect.property, defect)
 
-    expect(page).to have_content(I18n.t('page_title.staff.defects.show', name: defect))
+    expect(page).to have_content(I18n.t('page_title.staff.defects.show', reference_number: defect.reference_number))
 
-    within('table.properties') do
-      click_on(I18n.t('generic.link.edit'))
-    end
+    click_on(I18n.t('generic.link.edit'))
 
     within('form.edit_defect') do
-      fill_in 'defect[core_name]', with: 'A name for a collection of blocks'
-      click_on(I18n.t('generic.button.update', resource: 'Property'))
+      fill_in 'defect[description]', with: 'New description'
+      fill_in 'defect[contact_name]', with: 'New name'
+      fill_in 'defect[contact_email_address]', with: 'email@foo.com'
+      fill_in 'defect[contact_phone_number]', with: '0123456789'
+      select 'Brickwork', from: 'defect[trade]'
+
+      expect(page).to have_content(defect.target_completion_date)
+
+      choose "#{priority.name} - #{priority.days} days from now"
+      click_on(I18n.t('generic.button.update', resource: 'Defect'))
     end
+
+    expect(page).to have_content(I18n.t('generic.notice.update.success', resource: 'defect'))
+
+    expect(page).to have_content('New description')
+    expect(page).to have_content('New name')
+    expect(page).to have_content('email@foo.com')
+    expect(page).to have_content('0123456789')
+    expect(page).to have_content('Brickwork')
+    expect(page).to have_content(priority.name)
+
     expect(page).to have_content((Time.zone.now + priority.days.days).to_date)
   end
 
   scenario 'an invalid defect cannot be updated' do
-    create(:defect, scheme: scheme)
+    defect = create(:defect, property: property)
 
-    visit estate_scheme_path(scheme.estate, scheme)
+    visit property_defect_path(defect.property, defect)
 
-    expect(page).to have_content(I18n.t('page_title.staff.schemes.show', name: scheme.name))
+    expect(page).to have_content(I18n.t('page_title.staff.defects.show', reference_number: defect.reference_number))
 
-    within('table.properties') do
-      click_on(I18n.t('generic.link.edit'))
+    click_on(I18n.t('generic.link.edit'))
+
+    within('form.edit_defect') do
+      fill_in 'defect[description]', with: ''
+      select '', from: 'defect[trade]'
+
+      click_on(I18n.t('generic.button.update', resource: 'Defect'))
+    end
+
+    within('.defect_description') do
+      expect(page).to have_content("can't be blank")
+    end
+
+    within('.defect_trade') do
+      expect(page).to have_content("can't be blank")
+    end
+  end
+
+  scenario 'updating the priority is optional' do
+    defect = create(:defect, property: property)
+
+    visit edit_property_defect_path(defect.property, defect)
+
+    within('.existing-priority-information') do
+      expect(page).to have_content('Priority status')
+      expect(page).to have_content(defect.priority.name)
+      expect(page).to have_content('Target date for completion')
+      expect(page).to have_content(defect.target_completion_date)
     end
 
     within('form.edit_defect') do
-      fill_in 'defect[core_name]', with: ''
-
-      click_on(I18n.t('generic.button.update', resource: 'Property'))
+      # Do not choose a new priority
+      click_on(I18n.t('generic.button.update', resource: 'Defect'))
     end
 
-    within('.defect_core_name') do
-      expect(page).to have_content("can't be blank")
-    end
+    expect(page).to have_content(I18n.t('generic.notice.update.success', resource: 'defect'))
   end
 end

--- a/spec/features/anyone_can_update_a_defect_spec.rb
+++ b/spec/features/anyone_can_update_a_defect_spec.rb
@@ -18,6 +18,7 @@ RSpec.feature 'Anyone can update a defect' do
       fill_in 'defect[core_name]', with: 'A name for a collection of blocks'
       click_on(I18n.t('generic.button.update', resource: 'Property'))
     end
+    expect(page).to have_content((Time.zone.now + priority.days.days).to_date)
   end
 
   scenario 'an invalid defect cannot be updated' do

--- a/spec/features/anyone_can_update_a_defect_spec.rb
+++ b/spec/features/anyone_can_update_a_defect_spec.rb
@@ -39,6 +39,20 @@ RSpec.feature 'Anyone can update a defect' do
     expect(page).to have_content((Time.zone.now + priority.days.days).to_date)
   end
 
+  scenario 'a defect status can be updated' do
+    defect = create(:defect, property: property)
+
+    visit edit_property_defect_path(defect.property, defect)
+
+    within('form.edit_defect') do
+      select 'Completed', from: 'defect[status]'
+      click_on(I18n.t('generic.button.update', resource: 'Defect'))
+    end
+
+    expect(page).to have_content(I18n.t('generic.notice.update.success', resource: 'defect'))
+    expect(page).to have_content('Completed')
+  end
+
   scenario 'an invalid defect cannot be updated' do
     defect = create(:defect, property: property)
 

--- a/spec/features/anyone_can_update_a_defect_spec.rb
+++ b/spec/features/anyone_can_update_a_defect_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.feature 'Anyone can update a defect' do
+  let!(:scheme) { create(:scheme) }
+
+  scenario 'a defect can be updated' do
+    defect = create(:defect)
+
+    visit defect_path(defect)
+
+    expect(page).to have_content(I18n.t('page_title.staff.defects.show', name: defect))
+
+    within('table.properties') do
+      click_on(I18n.t('generic.link.edit'))
+    end
+
+    within('form.edit_defect') do
+      fill_in 'defect[core_name]', with: 'A name for a collection of blocks'
+      click_on(I18n.t('generic.button.update', resource: 'Property'))
+    end
+  end
+
+  scenario 'an invalid defect cannot be updated' do
+    create(:defect, scheme: scheme)
+
+    visit estate_scheme_path(scheme.estate, scheme)
+
+    expect(page).to have_content(I18n.t('page_title.staff.schemes.show', name: scheme.name))
+
+    within('table.properties') do
+      click_on(I18n.t('generic.link.edit'))
+    end
+
+    within('form.edit_defect') do
+      fill_in 'defect[core_name]', with: ''
+
+      click_on(I18n.t('generic.button.update', resource: 'Property'))
+    end
+
+    within('.defect_core_name') do
+      expect(page).to have_content("can't be blank")
+    end
+  end
+end

--- a/spec/features/anyone_can_view_a_defect_spec.rb
+++ b/spec/features/anyone_can_view_a_defect_spec.rb
@@ -28,13 +28,13 @@ RSpec.feature 'Anyone can view a defect' do
       expect(page).to have_content(defect.contact_phone_number)
       expect(page).to have_content(defect.contact_email_address)
       expect(page).to have_content(defect.trade)
-      expect(page).to have_content(defect.property.address)
       expect(page).to have_content(defect.priority.name)
       expect(page).to have_content(defect.target_completion_date)
       expect(page).to have_content(defect.status)
     end
 
     within('.scheme_information') do
+      expect(page).to have_content(defect.property.scheme.estate.name)
       expect(page).to have_content(defect.property.scheme.name)
       expect(page).to have_content(defect.property.scheme.contractor_name)
       expect(page).to have_content(defect.property.scheme.contractor_email_address)
@@ -43,15 +43,10 @@ RSpec.feature 'Anyone can view a defect' do
     end
 
     within('.property_information') do
-      expect(page).to have_content(defect.property.scheme.estate.name)
-      expect(page).to have_content(defect.property.scheme.name)
-      expect(page).to have_content(defect.property.scheme.contractor_name)
-      expect(page).to have_content(defect.property.scheme.contractor_email_address)
-      expect(page).to have_content(defect.property.scheme.employer_agent_name)
-      expect(page).to have_content(defect.property.scheme.employer_agent_email_address)
       expect(page).to have_content(defect.property.uprn)
       expect(page).to have_content(defect.property.address)
       expect(page).to have_content(defect.property.core_name)
+      expect(page).to have_content(defect.property.postcode)
     end
   end
 

--- a/spec/features/anyone_can_view_a_defect_spec.rb
+++ b/spec/features/anyone_can_view_a_defect_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+RSpec.feature 'Anyone can view a defect' do
+  scenario 'a defect can be found and viewed' do
+    defect = create(:defect)
+
+    visit root_path
+
+    expect(page).to have_content(I18n.t('page_title.staff.dashboard'))
+
+    within('form.property-search') do
+      fill_in 'address', with: defect.property.address
+      click_on(I18n.t('generic.button.find'))
+    end
+
+    click_on(I18n.t('generic.link.show'))
+
+    within('.defects') do
+      click_on(I18n.t('generic.link.show'))
+    end
+
+    expect(page).to have_content(I18n.t('page_title.staff.defects.show', reference_number: defect.reference_number))
+
+    within('.defect_information') do
+      expect(page).to have_content(defect.reference_number)
+      expect(page).to have_content(defect.description)
+      expect(page).to have_content(defect.contact_name)
+      expect(page).to have_content(defect.contact_phone_number)
+      expect(page).to have_content(defect.contact_email_address)
+      expect(page).to have_content(defect.trade)
+      expect(page).to have_content(defect.property.address)
+      expect(page).to have_content(defect.priority.name)
+      expect(page).to have_content(defect.target_completion_date)
+      expect(page).to have_content(defect.status)
+    end
+  end
+
+  scenario 'can use breadcrumbs to navigate' do
+    # defect = create(:defect)
+    #
+    # visit defects_path(defect)
+    #
+    # within('.govuk-breadcrumbs') do
+    #   expect(page).to have_link('Home', href: '/')
+    #   expect(page).to have_link(
+    #     I18n.t('page_title.staff.estates.show', name: defect.scheme.estate.name),
+    #     href: estate_path(defect.scheme.estate)
+    #   )
+    #   expect(page).to have_link(
+    #     I18n.t('page_title.staff.schemes.show', name: defect.scheme.name),
+    #     href: estate_scheme_path(defect.scheme.estate, defect.scheme)
+    #   )
+    # end
+  end
+end

--- a/spec/features/anyone_can_view_a_defect_spec.rb
+++ b/spec/features/anyone_can_view_a_defect_spec.rb
@@ -33,6 +33,26 @@ RSpec.feature 'Anyone can view a defect' do
       expect(page).to have_content(defect.target_completion_date)
       expect(page).to have_content(defect.status)
     end
+
+    within('.scheme_information') do
+      expect(page).to have_content(defect.property.scheme.name)
+      expect(page).to have_content(defect.property.scheme.contractor_name)
+      expect(page).to have_content(defect.property.scheme.contractor_email_address)
+      expect(page).to have_content(defect.property.scheme.employer_agent_name)
+      expect(page).to have_content(defect.property.scheme.employer_agent_email_address)
+    end
+
+    within('.property_information') do
+      expect(page).to have_content(defect.property.scheme.estate.name)
+      expect(page).to have_content(defect.property.scheme.name)
+      expect(page).to have_content(defect.property.scheme.contractor_name)
+      expect(page).to have_content(defect.property.scheme.contractor_email_address)
+      expect(page).to have_content(defect.property.scheme.employer_agent_name)
+      expect(page).to have_content(defect.property.scheme.employer_agent_email_address)
+      expect(page).to have_content(defect.property.uprn)
+      expect(page).to have_content(defect.property.address)
+      expect(page).to have_content(defect.property.core_name)
+    end
   end
 
   scenario 'can use breadcrumbs to navigate' do

--- a/spec/features/anyone_can_view_a_defect_spec.rb
+++ b/spec/features/anyone_can_view_a_defect_spec.rb
@@ -51,20 +51,28 @@ RSpec.feature 'Anyone can view a defect' do
   end
 
   scenario 'can use breadcrumbs to navigate' do
-    # defect = create(:defect)
-    #
-    # visit defects_path(defect)
-    #
-    # within('.govuk-breadcrumbs') do
-    #   expect(page).to have_link('Home', href: '/')
-    #   expect(page).to have_link(
-    #     I18n.t('page_title.staff.estates.show', name: defect.scheme.estate.name),
-    #     href: estate_path(defect.scheme.estate)
-    #   )
-    #   expect(page).to have_link(
-    #     I18n.t('page_title.staff.schemes.show', name: defect.scheme.name),
-    #     href: estate_scheme_path(defect.scheme.estate, defect.scheme)
-    #   )
-    # end
+    defect = create(:defect)
+
+    visit property_defect_path(defect.property, defect)
+
+    within('.govuk-breadcrumbs') do
+      expect(page).to have_link('Home', href: '/')
+
+      expect(page).to have_link(
+        I18n.t('page_title.staff.estates.show', name: defect.property.scheme.estate.name),
+        href: estate_path(defect.property.scheme.estate)
+      )
+      expect(page).to have_link(
+        I18n.t('page_title.staff.schemes.show', name: defect.property.scheme.name),
+        href: estate_scheme_path(defect.property.scheme.estate, defect.property.scheme)
+      )
+      expect(page).to have_link(
+        I18n.t('page_title.staff.properties.show', name: defect.property.address),
+        href: property_path(defect.property)
+      )
+      expect(page).to have_content(
+        I18n.t('page_title.staff.defects.show', reference_number: defect.reference_number)
+      )
+    end
   end
 end

--- a/spec/features/anyone_can_view_a_property_spec.rb
+++ b/spec/features/anyone_can_view_a_property_spec.rb
@@ -17,16 +17,20 @@ RSpec.feature 'Anyone can view a property' do
 
     expect(page).to have_content(I18n.t('page_title.staff.properties.show', name: property.address))
 
-    within('.property_information') do
+    within('.scheme_information') do
       expect(page).to have_content(property.scheme.estate.name)
       expect(page).to have_content(property.scheme.name)
       expect(page).to have_content(property.scheme.contractor_name)
       expect(page).to have_content(property.scheme.contractor_email_address)
       expect(page).to have_content(property.scheme.employer_agent_name)
       expect(page).to have_content(property.scheme.employer_agent_email_address)
+    end
+
+    within('.property_information') do
       expect(page).to have_content(property.uprn)
       expect(page).to have_content(property.address)
       expect(page).to have_content(property.core_name)
+      expect(page).to have_content(property.postcode)
     end
   end
 

--- a/spec/helpers/date_format_helper_spec.rb
+++ b/spec/helpers/date_format_helper_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe DateHelper, type: :helper do
+  describe '#format_date' do
+    it 'returns the date in the default format' do
+      expect(helper.format_date(Date.new(2017, 10, 7))).to eq '7 October 2017'
+    end
+  end
+end

--- a/spec/helpers/defect_helper_spec.rb
+++ b/spec/helpers/defect_helper_spec.rb
@@ -24,4 +24,16 @@ RSpec.describe DefectHelper, type: :helper do
       end
     end
   end
+
+  describe '#status_form_label' do
+    it 'returns a capitalized string' do
+      result = helper.status_form_label(option_array: ['outstanding', 0])
+      expect(result).to eql('Outstanding')
+    end
+
+    it 'returns a string without underscores' do
+      result = helper.status_form_label(option_array: ['end_of_year', 1])
+      expect(result).to eql('End of year')
+    end
+  end
 end

--- a/spec/helpers/defect_helper_spec.rb
+++ b/spec/helpers/defect_helper_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe DefectHelper, type: :helper do
+  describe '#priority_form_label' do
+    it 'returns a string that combines name and how many days in the future it will be' do
+      travel_to Time.zone.parse('2019-05-23')
+
+      priority = create(:priority, name: 'P1', days: 3)
+      result = helper.priority_form_label(priority: priority)
+      expect(result).to eq('P1 - 3 days from now')
+
+      travel_back
+    end
+
+    context 'when the target completion date is tomorrow' do
+      it 'returns the singular for days' do
+        travel_to Time.zone.parse('2019-05-23')
+
+        priority = create(:priority, name: 'P1', days: 1)
+        result = helper.priority_form_label(priority: priority)
+        expect(result).to eq('P1 - 1 day from now')
+
+        travel_back
+      end
+    end
+  end
+end

--- a/spec/models/defect_spec.rb
+++ b/spec/models/defect_spec.rb
@@ -64,4 +64,22 @@ RSpec.describe Defect, type: :model do
       expect(defect.status).to eq('Follow on')
     end
   end
+
+  describe '#set_completion_date' do
+    it 'sets the completion date to the number of priority days in the future' do
+      travel_to Time.zone.parse('2019-05-23')
+
+      previous_priority = create(:priority, days: 2)
+      new_priority = create(:priority, days: 3)
+
+      defect = create(:defect, priority: previous_priority)
+      defect.reload.priority = new_priority
+
+      defect.set_completion_date
+
+      expect(defect.reload.target_completion_date).to eq(Date.new(2019, 5, 25))
+
+      travel_back
+    end
+  end
 end

--- a/spec/models/priority_spec.rb
+++ b/spec/models/priority_spec.rb
@@ -24,15 +24,4 @@ RSpec.describe Priority, type: :model do
     errors = priority.errors.full_messages
     expect(errors).to include('Days is not a number')
   end
-
-  describe '#form_label' do
-    it 'returns a string that combines name and what the expected completion date would be' do
-      travel_to Time.zone.parse('2019-05-23')
-
-      priority = create(:priority, name: 'P1', days: 3)
-      expect(priority.form_label).to eq('P1 - target completion: 26/05/2019')
-
-      travel_back
-    end
-  end
 end


### PR DESCRIPTION
## Changes in this PR:
- view an individual defect
- update an individual defect
- defect pages have breadcrumbs
- property and scheme information partials reused and deduplicated 
- selecting priority changed from a select to radio for readability of the composite value
- priority selection includes days in the future: '1 day from now' rather than that specific date due to complexities making this make sense during the edit journey
- target completion dates have a human readable format
- agents can edit the status field of a defect

## Screenshots of UI changes:

![Screenshot 2019-06-04 at 12 52 57](https://user-images.githubusercontent.com/912473/58877088-d0ba6080-86c7-11e9-8bbe-da2b2bfb855f.png)
![Screenshot 2019-06-04 at 12 53 03](https://user-images.githubusercontent.com/912473/58877089-d152f700-86c7-11e9-9936-e7fb69633adf.png)
![Screenshot 2019-06-04 at 12 53 17](https://user-images.githubusercontent.com/912473/58877090-d152f700-86c7-11e9-8f6f-7edd8cd9a81b.png)
![Screenshot 2019-06-04 at 12 53 25](https://user-images.githubusercontent.com/912473/58877091-d152f700-86c7-11e9-980a-b53c56a6d14d.png)
![Screenshot 2019-06-04 at 12 52 53](https://user-images.githubusercontent.com/912473/58877094-d1eb8d80-86c7-11e9-834e-00ace87ca3b7.png)
