### PR TITLE
[74] Defects are commentable

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -23,6 +23,6 @@ class ApplicationController < ActionController::Base
   # rubocop:enable Rails/UnknownEnv
 
   def current_user
-    User.find_or_create_by(identifier: 'dxw')
+    User.find_or_create_by(identifier: 'dxw', name: 'Generic team user')
   end
 end

--- a/app/controllers/staff/comments_controller.rb
+++ b/app/controllers/staff/comments_controller.rb
@@ -1,0 +1,31 @@
+class Staff::CommentsController < Staff::BaseController
+  def new
+    @defect = Defect.find(defect_id)
+    @comment = Comment.new
+  end
+
+  def create
+    @defect = Defect.find(defect_id)
+    @comment = Comment.new(comment_params)
+    @comment.user = current_user
+    @comment.defect = @defect
+
+    if @comment.valid?
+      @comment.save
+      flash[:success] = I18n.t('generic.notice.create.success', resource: 'comment')
+      redirect_to property_defect_path(@defect.property, @defect)
+    else
+      render :new
+    end
+  end
+
+  private
+
+  def defect_id
+    params[:defect_id]
+  end
+
+  def comment_params
+    params.require(:comment).permit(:message)
+  end
+end

--- a/app/controllers/staff/comments_controller.rb
+++ b/app/controllers/staff/comments_controller.rb
@@ -19,7 +19,30 @@ class Staff::CommentsController < Staff::BaseController
     end
   end
 
+  def edit
+    @defect = Defect.find(defect_id)
+    @comment = Comment.find(id)
+  end
+
+  def update
+    @defect = Defect.find(defect_id)
+    @comment = Comment.find(id)
+    @comment.assign_attributes(comment_params)
+
+    if @comment.valid?
+      @comment.save
+      flash[:success] = I18n.t('generic.notice.update.success', resource: 'comment')
+      redirect_to property_defect_path(@defect.property, @defect)
+    else
+      render :edit
+    end
+  end
+
   private
+
+  def id
+    params[:id]
+  end
 
   def defect_id
     params[:defect_id]

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,7 @@
+class Comment < ApplicationRecord
+  belongs_to :user, dependent: false
+  belongs_to :defect, dependent: :destroy
+
+  include PublicActivity::Model
+  tracked owner: ->(controller, _) { controller.current_user if controller }
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,4 +1,6 @@
 class Comment < ApplicationRecord
+  validates :message, presence: true
+
   belongs_to :user, dependent: false
   belongs_to :defect, dependent: :destroy
 

--- a/app/models/defect.rb
+++ b/app/models/defect.rb
@@ -29,6 +29,7 @@ class Defect < ApplicationRecord
 
   belongs_to :property
   belongs_to :priority
+  has_many :comments, dependent: :destroy
 
   include PublicActivity::Model
   tracked owner: ->(controller, _) { controller.current_user if controller }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,2 +1,6 @@
 class User < ApplicationRecord
+  has_many :comments, dependent: false
+
+  include PublicActivity::Model
+  tracked owner: ->(controller, _) { controller.current_user if controller }
 end

--- a/app/views/shared/comments/_list.html.haml
+++ b/app/views/shared/comments/_list.html.haml
@@ -1,0 +1,8 @@
+.defect-comments
+  - if comments.empty?
+    %p Add the first comment by clicking the link.
+  - comments.each do |comment|
+    %div.govuk-inset-text
+      %p= comment.message
+      %p= comment.user.name
+      %p= comment.created_at

--- a/app/views/shared/comments/_list.html.haml
+++ b/app/views/shared/comments/_list.html.haml
@@ -2,7 +2,8 @@
   - if comments.empty?
     %p Add the first comment by clicking the link.
   - comments.each do |comment|
-    %div.govuk-inset-text
+    %div.govuk-inset-text.comment
       %p= comment.message
       %p= comment.user.name
       %p= comment.created_at
+      = link_to(I18n.t('generic.button.edit', resource: ''), edit_property_defect_comment_path(comment.defect.property, comment.defect, comment), class: 'govuk-button govuk-button--secondary')

--- a/app/views/shared/comments/_list.html.haml
+++ b/app/views/shared/comments/_list.html.haml
@@ -1,4 +1,4 @@
-.defect-comments
+.comments
   - if comments.empty?
     %p Add the first comment by clicking the link.
   - comments.each do |comment|

--- a/app/views/staff/comments/edit.html.haml
+++ b/app/views/staff/comments/edit.html.haml
@@ -1,0 +1,18 @@
+- content_for :page_title_prefix, I18n.t('page_title.staff.comments.edit')
+
+= link_to "Back to #{I18n.t('page_title.staff.defects.show', reference_number: @defect.reference_number)}", property_defect_path(@defect.property, @defect), class: 'govuk-back-link'
+
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    %h1.govuk-heading-xl
+      = I18n.t('page_title.staff.comments.edit')
+      %span.govuk-caption-l= 'Step 1 of 1'
+
+    = simple_form_for [@defect.property, @defect, @comment] do |f|
+      .govuk-form-group
+        = f.input :message,
+                  wrapper: 'textarea',
+                  as: :text,
+                  input_html: { rows: 10 },
+                  required: true
+      = f.button :submit, I18n.t('generic.button.update', resource: 'Comment')

--- a/app/views/staff/comments/new.html.haml
+++ b/app/views/staff/comments/new.html.haml
@@ -1,0 +1,16 @@
+- content_for :page_title_prefix, I18n.t('page_title.staff.comments.create')
+
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    %h1.govuk-heading-xl
+      = I18n.t('page_title.staff.comments.create')
+      %span.govuk-caption-l= 'Step 1 of 1'
+
+    = simple_form_for [@defect.property, @defect, @comment], html: { class: 'new_comment' } do |f|
+      .govuk-form-group
+        = f.input :message,
+                  wrapper: 'textarea',
+                  as: :text,
+                  input_html: { rows: 10 },
+                  required: true
+      = f.button :submit, I18n.t('generic.button.create', resource: 'Comment')

--- a/app/views/staff/comments/new.html.haml
+++ b/app/views/staff/comments/new.html.haml
@@ -1,5 +1,7 @@
 - content_for :page_title_prefix, I18n.t('page_title.staff.comments.create')
 
+= link_to "Back to #{I18n.t('page_title.staff.defects.show', reference_number: @defect.reference_number)}", property_defect_path(@defect.property, @defect), class: 'govuk-back-link'
+
 .govuk-grid-row
   .govuk-grid-column-two-thirds
     %h1.govuk-heading-xl

--- a/app/views/staff/defects/show.html.haml
+++ b/app/views/staff/defects/show.html.haml
@@ -18,6 +18,7 @@
   .govuk-grid-column-one-third
     %h2.govuk-heading-l
       Comments
+    = link_to(I18n.t('generic.button.create', resource: 'Comment'), new_property_defect_comment_path(@defect.property, @defect), class: 'govuk-button mb0')
     = render partial: '/shared/comments/list', locals: { comments: @defect.comments }
 
   .govuk-grid-column-one-third

--- a/app/views/staff/defects/show.html.haml
+++ b/app/views/staff/defects/show.html.haml
@@ -21,7 +21,6 @@
     = link_to(I18n.t('generic.button.create', resource: 'Comment'), new_property_defect_comment_path(@defect.property, @defect), class: 'govuk-button mb0')
     = render partial: '/shared/comments/list', locals: { comments: @defect.comments }
 
-  .govuk-grid-column-one-third
     %h2.govuk-heading-l
       Scheme
     = render partial: '/shared/schemes/information', locals: { scheme: @defect.property.scheme }

--- a/app/views/staff/defects/show.html.haml
+++ b/app/views/staff/defects/show.html.haml
@@ -17,6 +17,11 @@
 
   .govuk-grid-column-one-third
     %h2.govuk-heading-l
+      Comments
+    = render partial: '/shared/comments/list', locals: { comments: @defect.comments }
+
+  .govuk-grid-column-one-third
+    %h2.govuk-heading-l
       Scheme
     = render partial: '/shared/schemes/information', locals: { scheme: @defect.property.scheme }
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -26,6 +26,7 @@ en:
         edit: 'Update defect'
       comments:
         create: 'Create Comment'
+        edit: 'Update Comment'
   generic:
     link:
       show: 'View'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,6 +24,8 @@ en:
         create: 'Create Defect'
         show: 'Defect %{reference_number}'
         edit: 'Update defect'
+      comments:
+        create: 'Create Comment'
   generic:
     link:
       show: 'View'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
 
   resources :properties, controller: 'staff/properties', only: %i[index show] do
     resources :defects, controller: 'staff/defects', only: %i[new create show edit update] do
-      resources :comments, controller: 'staff/comments', only: %i[new create]
+      resources :comments, controller: 'staff/comments', only: %i[new create edit update]
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,8 @@ Rails.application.routes.draw do
   end
 
   resources :properties, controller: 'staff/properties', only: %i[index show] do
-    resources :defects, controller: 'staff/defects', only: %i[new create show edit update]
+    resources :defects, controller: 'staff/defects', only: %i[new create show edit update] do
+      resources :comments, controller: 'staff/comments', only: %i[new create]
+    end
   end
 end

--- a/db/migrate/20190604135720_create_comments.rb
+++ b/db/migrate/20190604135720_create_comments.rb
@@ -1,0 +1,10 @@
+class CreateComments < ActiveRecord::Migration[5.2]
+  def change
+    create_table :comments, id: :uuid do |t|
+      t.string :message
+      t.references :user, foreign_key: true, index: true, type: :uuid
+      t.references :defect, foreign_key: true, index: true, type: :uuid
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190604143132_add_name_to_user.rb
+++ b/db/migrate/20190604143132_add_name_to_user.rb
@@ -1,0 +1,5 @@
+class AddNameToUser < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_04_141537) do
+ActiveRecord::Schema.define(version: 2019_06_04_143132) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -33,6 +33,16 @@ ActiveRecord::Schema.define(version: 2019_06_04_141537) do
     t.index ["recipient_type", "recipient_id"], name: "index_activities_on_recipient_type_and_recipient_id"
     t.index ["trackable_id", "trackable_type"], name: "index_activities_on_trackable_id_and_trackable_type"
     t.index ["trackable_type", "trackable_id"], name: "index_activities_on_trackable_type_and_trackable_id"
+  end
+
+  create_table "comments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "message"
+    t.uuid "user_id"
+    t.uuid "defect_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["defect_id"], name: "index_comments_on_defect_id"
+    t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
   create_table "defects", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_03_115200) do
+ActiveRecord::Schema.define(version: 2019_06_04_141537) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -95,6 +95,8 @@ ActiveRecord::Schema.define(version: 2019_06_03_115200) do
     t.string "identifier"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.uuid "comments_id"
+    t.index ["comments_id"], name: "index_users_on_comments_id"
   end
 
   add_foreign_key "defects", "priorities"
@@ -102,4 +104,5 @@ ActiveRecord::Schema.define(version: 2019_06_03_115200) do
   add_foreign_key "priorities", "schemes"
   add_foreign_key "properties", "schemes"
   add_foreign_key "schemes", "estates"
+  add_foreign_key "users", "comments", column: "comments_id"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -95,14 +95,14 @@ ActiveRecord::Schema.define(version: 2019_06_04_141537) do
     t.string "identifier"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.uuid "comments_id"
-    t.index ["comments_id"], name: "index_users_on_comments_id"
+    t.string "name"
   end
 
+  add_foreign_key "comments", "defects"
+  add_foreign_key "comments", "users"
   add_foreign_key "defects", "priorities"
   add_foreign_key "defects", "properties"
   add_foreign_key "priorities", "schemes"
   add_foreign_key "properties", "schemes"
   add_foreign_key "schemes", "estates"
-  add_foreign_key "users", "comments", column: "comments_id"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,11 +1,13 @@
 raise if Rails.env.production?
 
+Comment.delete_all
 Defect.delete_all
 Property.delete_all
 Priority.delete_all
 Scheme.delete_all
 Estate.delete_all
 PublicActivity::Activity.delete_all
+User.delete_all
 
 # Estates
 estate = FactoryBot.create(:estate, name: 'Kings Cresent')
@@ -38,6 +40,7 @@ property4 = FactoryBot.create(
   FactoryBot.create_list(
     :defect,
     10,
+    :with_comments,
     property: property,
     priority: [priority1, priority2, priority3, priority4].sample
   )

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :comment do
+    message { Faker::Lorem.paragraph }
+    association :user, factory: :user
+    association :defect, factory: :defect
+  end
+end

--- a/spec/factories/defects.rb
+++ b/spec/factories/defects.rb
@@ -11,5 +11,11 @@ FactoryBot.define do
 
     association :property, factory: :property
     association :priority, factory: :priority
+
+    trait :with_comments do
+      after(:create) do |defect|
+        create_list(:comment, 3, defect: defect)
+      end
+    end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :user do
+    identifier { SecureRandom.uuid }
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :user do
     identifier { SecureRandom.uuid }
+    name { Faker::GreekPhilosophers.name }
   end
 end

--- a/spec/features/anyone_can_create_a_comment_spec.rb
+++ b/spec/features/anyone_can_create_a_comment_spec.rb
@@ -1,0 +1,73 @@
+require 'rails_helper'
+
+RSpec.feature 'Anyone can create a comment' do
+  let!(:property) { create(:property, address: '1 Hackney Street') }
+  let!(:defect) { create(:defect, property: property) }
+
+  scenario 'a property can be found and comment can be created' do
+    visit root_path
+
+    expect(page).to have_content(I18n.t('page_title.staff.dashboard'))
+
+    within('form.property-search') do
+      fill_in 'address', with: 'Hackney'
+      click_on(I18n.t('generic.button.find'))
+    end
+
+    within('.properties') do
+      click_on(I18n.t('generic.link.show'))
+    end
+
+    expect(page).to have_content(I18n.t('page_title.staff.properties.show', name: property.address))
+
+    within('.defects') do
+      click_on(I18n.t('generic.link.show'))
+    end
+
+    expect(page).to have_content(I18n.t('page_title.staff.comments.create'))
+
+    click_on(I18n.t('generic.button.create', resource: 'Comment'))
+
+    within('form.new_comment') do
+      fill_in 'comment[message]', with: 'None of the electrics work'
+      click_on(I18n.t('generic.button.create', resource: 'Comment'))
+    end
+
+    expect(page).to have_content(I18n.t('generic.notice.create.success', resource: 'comment'))
+
+    within('.comments') do
+      comment = Comment.first
+      expect(page).to have_content(comment.message)
+      expect(page).to have_content(comment.created_at)
+      expect(page).to have_content(comment.message)
+    end
+  end
+
+  # scenario 'an invalid comment cannot be submitted' do
+  #   property = create(:property)
+  #
+  #   visit property_path(property)
+  #
+  #   click_on(I18n.t('generic.button.create', resource: 'Defect'))
+  #
+  #   expect(page).to have_content(I18n.t('page_title.staff.comments.create'))
+  #   within('form.new_comment') do
+  #     # Deliberately forget to fill out the required name field
+  #     click_on(I18n.t('generic.button.create', resource: 'Defect'))
+  #   end
+  #
+  #   within('.comment_description') do
+  #     expect(page).to have_content("can't be blank")
+  #   end
+  #
+  #   within('.comment_trade') do
+  #     expect(page).to have_content("can't be blank")
+  #   end
+  #
+  #   within('.comment_priority') do
+  #     expect(page).to have_content("can't be blank")
+  #   end
+  # end
+
+  # TODO: navigation back button
+end

--- a/spec/features/anyone_can_create_a_comment_spec.rb
+++ b/spec/features/anyone_can_create_a_comment_spec.rb
@@ -57,5 +57,12 @@ RSpec.feature 'Anyone can create a comment' do
     end
   end
 
-  # TODO: navigation back button
+  scenario 'can use breadcrumbs to navigate' do
+    visit new_property_defect_comment_path(property, defect)
+
+    expect(page).to have_link(
+      "Back to #{I18n.t('page_title.staff.defects.show', reference_number: defect.reference_number)}",
+      href: property_defect_path(property, defect)
+    )
+  end
 end

--- a/spec/features/anyone_can_create_a_comment_spec.rb
+++ b/spec/features/anyone_can_create_a_comment_spec.rb
@@ -43,31 +43,19 @@ RSpec.feature 'Anyone can create a comment' do
     end
   end
 
-  # scenario 'an invalid comment cannot be submitted' do
-  #   property = create(:property)
-  #
-  #   visit property_path(property)
-  #
-  #   click_on(I18n.t('generic.button.create', resource: 'Defect'))
-  #
-  #   expect(page).to have_content(I18n.t('page_title.staff.comments.create'))
-  #   within('form.new_comment') do
-  #     # Deliberately forget to fill out the required name field
-  #     click_on(I18n.t('generic.button.create', resource: 'Defect'))
-  #   end
-  #
-  #   within('.comment_description') do
-  #     expect(page).to have_content("can't be blank")
-  #   end
-  #
-  #   within('.comment_trade') do
-  #     expect(page).to have_content("can't be blank")
-  #   end
-  #
-  #   within('.comment_priority') do
-  #     expect(page).to have_content("can't be blank")
-  #   end
-  # end
+  scenario 'an invalid comment cannot be submitted' do
+    visit new_property_defect_comment_path(property, defect)
+
+    expect(page).to have_content(I18n.t('page_title.staff.comments.create'))
+    within('form.new_comment') do
+      # Deliberately forget to fill out the required name field
+      click_on(I18n.t('generic.button.create', resource: 'Comment'))
+    end
+
+    within('.comment_message') do
+      expect(page).to have_content("can't be blank")
+    end
+  end
 
   # TODO: navigation back button
 end

--- a/spec/features/anyone_can_update_comments_spec.rb
+++ b/spec/features/anyone_can_update_comments_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.feature 'anyone can update comments' do
+  let(:property) { create(:property) }
+  let(:defect) { create(:defect, property: property) }
+
+  scenario 'a comment can be edited' do
+    create(:comment, defect: defect)
+
+    visit property_defect_path(property, defect)
+
+    within('.comment') do
+      click_on(I18n.t('generic.link.edit'))
+    end
+
+    expect(page).to have_content(I18n.t('page_title.staff.comments.edit'))
+
+    within('form.edit_comment') do
+      fill_in 'comment[message]', with: 'None of the electrics work'
+      click_on(I18n.t('generic.button.update', resource: 'Comment'))
+    end
+
+    expect(page).to have_content(I18n.t('generic.notice.update.success', resource: 'comment'))
+
+    within('.comment') do
+      expect(page).to have_content('None of the electrics work')
+    end
+  end
+end

--- a/spec/features/anyone_can_view_a_defect_spec.rb
+++ b/spec/features/anyone_can_view_a_defect_spec.rb
@@ -75,4 +75,17 @@ RSpec.feature 'Anyone can view a defect' do
       )
     end
   end
+
+  scenario 'can see comments' do
+    defect = create(:defect)
+    comment = create(:comment, defect: defect)
+
+    visit property_defect_path(defect.property, defect)
+
+    within('.defect-comments') do
+      expect(page).to have_content(comment.message)
+      expect(page).to have_content(comment.user.name)
+      expect(page).to have_content(comment.created_at)
+    end
+  end
 end

--- a/spec/features/anyone_can_view_a_defect_spec.rb
+++ b/spec/features/anyone_can_view_a_defect_spec.rb
@@ -82,7 +82,7 @@ RSpec.feature 'Anyone can view a defect' do
 
     visit property_defect_path(defect.property, defect)
 
-    within('.defect-comments') do
+    within('.comments') do
       expect(page).to have_content(comment.message)
       expect(page).to have_content(comment.user.name)
       expect(page).to have_content(comment.created_at)

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -5,4 +5,13 @@ RSpec.describe Comment, type: :model do
   it { should belong_to(:user) }
 
   it_behaves_like 'a trackable resource', resource: described_class
+
+  it 'validates presence of required fields' do
+    comment = described_class.new
+    expect(comment.valid?).to be_falsey
+
+    errors = comment.errors.full_messages
+
+    expect(errors).to include("Message can't be blank")
+  end
 end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+RSpec.describe Comment, type: :model do
+  it { should belong_to(:defect) }
+  it { should belong_to(:user) }
+
+  it_behaves_like 'a trackable resource', resource: described_class
+end

--- a/spec/models/defect_spec.rb
+++ b/spec/models/defect_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Defect, type: :model do
   it { should belong_to(:property) }
+  it { should have_many(:comments) }
 
   it_behaves_like 'a trackable resource', resource: described_class
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  it { should have_many(:comments) }
+
+  it_behaves_like 'a trackable resource', resource: described_class
+end


### PR DESCRIPTION
## Changes in this PR:
- comments are listed against each defect
- comments can be created
- comments can be edited. Since there is only 1 default user and no authentication mechanism in place is feels premature to add any logic to restricting who can edit a comment and who cannot
- I had looked at using a gem for this called [Commontator](https://github.com/lml/commontator) but it didn't work out of the box and likely needed too much fiddling for use without an auth mechanism and current users. I'm not too concerned with not having this gem as it would likely have had a lot of extra bits we don't need and have required tinkering if we wanted to change and customise parts
- user records, although while currently defaulted to 1 record, have comments associated with them and are now tracked with public activity
- user records include a human readable name as well as a machine identifier, it currently says 'Generic team user' to demonstrate that there is only 1 user and that the service doesn't currently distinguish between who added what comment

## Screenshots of UI changes:
![Screenshot 2019-06-04 at 17 11 59](https://user-images.githubusercontent.com/912473/58895557-1a1ca700-86ec-11e9-82b6-78d4eac07886.png)
![Screenshot 2019-06-04 at 17 12 02](https://user-images.githubusercontent.com/912473/58895554-1a1ca700-86ec-11e9-883b-301b53fae81c.png)
![Screenshot 2019-06-04 at 17 12 07](https://user-images.githubusercontent.com/912473/58895555-1a1ca700-86ec-11e9-8633-75b6ad561bd7.png)
![Screenshot 2019-06-04 at 17 12 12](https://user-images.githubusercontent.com/912473/58895556-1a1ca700-86ec-11e9-81c0-de610e713407.png)

