### PR TITLE
(chore) Make FactoryBot available in prod

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem 'uglifier', '>= 1.3.0'
 gem 'sentry-raven'
 gem 'newrelic_rpm'
 gem 'figaro'
+gem 'factory_bot_rails'
 
 group :development, :test do
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
@@ -41,7 +42,6 @@ group :development do
 end
 
 group :development, :test do
-  gem 'factory_bot_rails'
   gem 'faker'
   gem 'rspec-rails'
 end


### PR DESCRIPTION
* This will allow us to seed data quickly to facilitate usability testing sessions. There is still the guard in db/seeds to prevent the use via rake, this will be able us to perform deliberate actions using `rails c`
