### PR TITLE
(feature) Send defect email to the employer agent as well

### DIFF
--- a/app/mailers/defect_mailer.rb
+++ b/app/mailers/defect_mailer.rb
@@ -1,10 +1,10 @@
 class DefectMailer < ApplicationMailer
-  def forward(defect_id)
+  def forward(defect_id, recipient)
     @defect = Defect.find(defect_id)
 
     view_mail(
       NOTIFY_FORWARD_DEFECT_TEMPLATE,
-      to: @defect.property.scheme.contractor_email_address,
+      to: recipient,
       subject: I18n.t('email.defect.forward.subject', reference: @defect.reference_number),
     )
   end

--- a/app/services/save_defect.rb
+++ b/app/services/save_defect.rb
@@ -7,7 +7,20 @@ class SaveDefect
 
   def call
     defect.save
-    DefectMailer.forward(defect.id).deliver_now
+
+    send_to_contractor
+    send_to_employer_agent
+  end
+
+  private
+
+  def send_to_contractor
+    DefectMailer.forward(defect.id, defect.property.scheme.contractor_email_address).deliver_now
     defect.create_activity key: 'defect.forwarded_to_contractor', owner: nil
+  end
+
+  def send_to_employer_agent
+    DefectMailer.forward(defect.id, defect.property.scheme.employer_agent_email_address).deliver_now
+    defect.create_activity key: 'defect.forwarded_to_employer_agent', owner: nil
   end
 end

--- a/spec/mailers/defect_spec.rb
+++ b/spec/mailers/defect_spec.rb
@@ -8,13 +8,14 @@ RSpec.describe DefectMailer, type: :mailer do
 
   after(:each) { travel_back }
 
+  let(:recipient) { 'email@example.com' }
   let(:defect) { create(:defect) }
-  let(:mail) { DefectMailer.forward(defect.id) }
+  let(:mail) { DefectMailer.forward(defect.id, recipient) }
   let(:body_lines) { mail.body.raw_source.lines }
 
-  it 'sends an email to the contractor' do
+  it 'sends an email to the email address provided' do
     expect(mail.subject).to eq(I18n.t('email.defect.forward.subject', reference: defect.reference_number))
-    expect(mail.to).to eq([defect.property.scheme.contractor_email_address])
+    expect(mail.to).to eq([recipient])
     expect(body_lines[0].strip).to match(/# #{I18n.t('app.title')}/)
     expect(body_lines[2].strip).to match("#{I18n.t('email.defect.forward.headings.title.reference_number')} : #{defect.reference_number}")
     expect(body_lines[3].strip).to match("#{I18n.t('email.defect.forward.headings.title.created_at')}: #{defect.created_at.to_s(:default)}")

--- a/spec/services/save_defect_spec.rb
+++ b/spec/services/save_defect_spec.rb
@@ -1,6 +1,16 @@
 require 'rails_helper'
 
 RSpec.describe SaveDefect do
+  before(:each) do
+    ActionMailer::Base.delivery_method = :test
+    ActionMailer::Base.perform_deliveries = true
+    ActionMailer::Base.deliveries = []
+  end
+
+  after(:each) do
+    ActionMailer::Base.deliveries.clear
+  end
+
   describe '.initialize' do
     it 'accepts and stores the defect' do
       defect = create(:defect)
@@ -19,21 +29,46 @@ RSpec.describe SaveDefect do
       described_class.new(defect: defect).call
     end
 
-    it 'emails a copy of the defect to the contractor' do
-      message_delivery = instance_double(ActionMailer::MessageDelivery)
-      expect(DefectMailer).to receive(:forward).with(defect.id) { message_delivery }
-      expect(message_delivery).to receive(:deliver_now)
+    it 'emails a copy of the defect to the contractor and employer agent' do
+      scheme = create(:scheme,
+                      contractor_email_address: 'contractor@email.com',
+                      employer_agent_email_address: 'employeragent@email.com')
+      property = create(:property, scheme: scheme)
+      defect = create(:defect, property: property)
 
       described_class.new(defect: defect).call
+
+      first_delivery = ActionMailer::Base.deliveries[0]
+      expect(first_delivery.to).to eq([defect.property.scheme.contractor_email_address])
+      expect(first_delivery.subject).to eq(I18n.t('email.defect.forward.subject', reference: defect.reference_number))
+
+      second_delivery = ActionMailer::Base.deliveries[1]
+      expect(second_delivery.to).to eq([defect.property.scheme.employer_agent_email_address])
+      expect(second_delivery.subject).to eq(I18n.t('email.defect.forward.subject', reference: defect.reference_number))
     end
 
-    it 'stores sending of an email in a custom activity record' do
+    it 'stores sending of an email to the contractor in a custom activity record' do
       travel_to Time.zone.parse('2019-05-23')
 
       described_class.new(defect: defect).call
 
       result = PublicActivity::Activity.find_by(
         trackable_id: defect.id, trackable_type: Defect.to_s, key: 'defect.forwarded_to_contractor'
+      )
+      expect(result).to be_kind_of(PublicActivity::Activity)
+      expect(result.trackable).to be_kind_of(Defect)
+      expect(result.created_at).to eq(Time.zone.now)
+
+      travel_back
+    end
+
+    it 'stores sending of an email to the employer agent in a custom activity record' do
+      travel_to Time.zone.parse('2019-05-23')
+
+      described_class.new(defect: defect).call
+
+      result = PublicActivity::Activity.find_by(
+        trackable_id: defect.id, trackable_type: Defect.to_s, key: 'defect.forwarded_to_employer_agent'
       )
       expect(result).to be_kind_of(PublicActivity::Activity)
       expect(result.trackable).to be_kind_of(Defect)


### PR DESCRIPTION
## Changes in this PR:

* Notify and mail-notify do not explicitly reference the use of sending a single email to multiple recipients using CC or BCC
* I have attempted to test this by using a comma separated string and an array of 2 values however mail-notify is choosing only the first value: https://github.com/dxw/mail-notify/blob/master/lib/mail/notify/delivery_method.rb#L32
* I've tried using the ActionMailer `cc` setting but it does not appear to be referenced in mail-notify in order to forward the value to Notify
* Notify documentation does not reference multiple recipients at all, it includes only a field or `email_address` (singular) https://docs.notifications.service.gov.uk/ruby.html#email-address-required
* Based on this, it seems the only way forward short of using another mailer is to send the same email twice. Consequences could include the employer agent needing to see proof that the contractor got it, and they could be doing that by checking their own email headers


