### PR TITLE
[115] Contractor can accept receipt of a defect

### DIFF
--- a/app/controllers/contractor/base_controller.rb
+++ b/app/controllers/contractor/base_controller.rb
@@ -1,0 +1,2 @@
+class Contractor::BaseController < ApplicationController
+end

--- a/app/controllers/contractor/defects_controller.rb
+++ b/app/controllers/contractor/defects_controller.rb
@@ -2,7 +2,12 @@ class Contractor::DefectsController < Contractor::BaseController
   def accept
     defect_id = MessageVerifier.verifier.verify(defect_token, purpose: :accept_defect_ownership)
     @defect = Defect.find(defect_id)
-    @defect.create_activity(key: 'defect.accepted')
+
+    if @defect.activities.find_by(key: 'defect.accepted')
+      render 'unprocessable_entity', status: :unprocessable_entity
+    else
+      @defect.create_activity(key: 'defect.accepted')
+    end
   rescue ActiveSupport::MessageVerifier::InvalidSignature
     render 'unprocessable_entity', status: :unprocessable_entity
   end

--- a/app/controllers/contractor/defects_controller.rb
+++ b/app/controllers/contractor/defects_controller.rb
@@ -3,6 +3,8 @@ class Contractor::DefectsController < Contractor::BaseController
     defect_id = MessageVerifier.verifier.verify(defect_token, purpose: :accept_defect_ownership)
     @defect = Defect.find(defect_id)
     @defect.create_activity(key: 'defect.accepted')
+  rescue ActiveSupport::MessageVerifier::InvalidSignature
+    render 'unprocessable_entity', status: :unprocessable_entity
   end
 
   def defect_token

--- a/app/controllers/contractor/defects_controller.rb
+++ b/app/controllers/contractor/defects_controller.rb
@@ -1,0 +1,11 @@
+class Contractor::DefectsController < Contractor::BaseController
+  def accept
+    defect_id = MessageVerifier.verifier.verify(defect_token, purpose: :accept_defect_ownership)
+    @defect = Defect.find(defect_id)
+    @defect.create_activity(key: 'defect.accepted')
+  end
+
+  def defect_token
+    params[:defect_id]
+  end
+end

--- a/app/controllers/contractors/base_controller.rb
+++ b/app/controllers/contractors/base_controller.rb
@@ -1,2 +1,0 @@
-class Contractors::BaseController < ApplicationController
-end

--- a/app/helpers/notify_view_helper.rb
+++ b/app/helpers/notify_view_helper.rb
@@ -1,0 +1,10 @@
+module NotifyViewHelper
+  def notify_link(url, text = url)
+    "[#{text}](#{url})"
+  end
+
+  def accept_defect_ownership_link(token)
+    link_text = I18n.t('email.defect.forward.accept.link')
+    notify_link(defect_accept_url(token), link_text)
+  end
+end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,2 +1,3 @@
 class ApplicationMailer < Mail::Notify::Mailer
+  add_template_helper(NotifyViewHelper)
 end

--- a/app/mailers/defect_mailer.rb
+++ b/app/mailers/defect_mailer.rb
@@ -1,10 +1,20 @@
 class DefectMailer < ApplicationMailer
-  def forward(defect_id, recipient)
+  def forward_to_contractor(defect_id)
     @defect = Defect.find(defect_id)
 
     view_mail(
       NOTIFY_FORWARD_DEFECT_TEMPLATE,
-      to: recipient,
+      to: @defect.property.scheme.contractor_email_address,
+      subject: I18n.t('email.defect.forward.subject', reference: @defect.reference_number),
+    )
+  end
+
+  def forward_to_employer_agent(defect_id)
+    @defect = Defect.find(defect_id)
+
+    view_mail(
+      NOTIFY_FORWARD_DEFECT_TEMPLATE,
+      to: @defect.property.scheme.employer_agent_email_address,
       subject: I18n.t('email.defect.forward.subject', reference: @defect.reference_number),
     )
   end

--- a/app/models/defect.rb
+++ b/app/models/defect.rb
@@ -72,7 +72,7 @@ class Defect < ApplicationRecord
   def set_completion_date
     return unless priority
 
-    self.target_completion_date = Time.zone.now + priority.days.days
+    self.target_completion_date = Time .zone.now + priority.days.days
   end
 
   def status
@@ -84,6 +84,10 @@ class Defect < ApplicationRecord
   end
 
   def token
-    MessageVerifier.verifier.generate(id, purpose: :accept_defect_ownership)
+    MessageVerifier.verifier.generate(
+      id,
+      purpose: :accept_defect_ownership,
+      expires_in: 3.months
+    )
   end
 end

--- a/app/models/defect.rb
+++ b/app/models/defect.rb
@@ -82,4 +82,8 @@ class Defect < ApplicationRecord
   def contact_phone_number=(value)
     super(value.tr(' ', ''))
   end
+
+  def token
+    MessageVerifier.verifier.generate(id, purpose: :accept_defect_ownership)
+  end
 end

--- a/app/services/message_verifier.rb
+++ b/app/services/message_verifier.rb
@@ -1,0 +1,8 @@
+class MessageVerifier
+  def self.verifier
+    ActiveSupport::MessageVerifier.new(
+      Rails.application.secrets.secret_key_base,
+      digest: 'SHA256'
+    )
+  end
+end

--- a/app/services/save_defect.rb
+++ b/app/services/save_defect.rb
@@ -15,12 +15,12 @@ class SaveDefect
   private
 
   def send_to_contractor
-    DefectMailer.forward(defect.id, defect.property.scheme.contractor_email_address).deliver_now
+    DefectMailer.forward_to_contractor(defect.id).deliver_now
     defect.create_activity key: 'defect.forwarded_to_contractor', owner: nil
   end
 
   def send_to_employer_agent
-    DefectMailer.forward(defect.id, defect.property.scheme.employer_agent_email_address).deliver_now
+    DefectMailer.forward_to_employer_agent(defect.id).deliver_now
     defect.create_activity key: 'defect.forwarded_to_employer_agent', owner: nil
   end
 end

--- a/app/views/contractor/defects/accept.html.haml
+++ b/app/views/contractor/defects/accept.html.haml
@@ -1,0 +1,16 @@
+- content_for :page_title_prefix, I18n.t('page_title.contractor.defects.accepted.title')
+
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    .govuk-panel.govuk-panel--confirmation
+      %h1.govuk-panel__title
+        = I18n.t('page_title.contractor.defects.accepted.title')
+      .govuk-panel__body
+        = I18n.t('page_title.contractor.defects.accepted.body', reference_number: @defect.reference_number)
+    %p.govuk-body
+      = succeed '.' do
+        = "If this was accepted in error please send an email to"
+        = mail_to(I18n.t('generic.email'), I18n.t('generic.email'), class: 'govuk-link')
+    .govuk-heading-m What happens next
+    %p.govuk-body
+      We've notified the person who reported this problem that you will be contact with them to arrange the next steps.

--- a/app/views/contractor/defects/accept.html.haml
+++ b/app/views/contractor/defects/accept.html.haml
@@ -10,7 +10,7 @@
     %p.govuk-body
       = succeed '.' do
         = "If this was accepted in error please send an email to"
-        = mail_to(I18n.t('generic.email'), I18n.t('generic.email'), class: 'govuk-link')
+        = mail_to(I18n.t('app.email'), I18n.t('app.email'), class: 'govuk-link')
     .govuk-heading-m What happens next
     %p.govuk-body
       We've notified the person who reported this problem that you will be contact with them to arrange the next steps.

--- a/app/views/contractor/defects/unprocessable_entity.html.haml
+++ b/app/views/contractor/defects/unprocessable_entity.html.haml
@@ -1,0 +1,8 @@
+- content_for :page_title_prefix, I18n.t('error_pages.unprocessable_entity')
+
+%h1.govuk-heading-xl= I18n.t('error_pages.unprocessable_entity')
+%p.govuk-body= I18n.t('page_title.contractor.defects.unprocessable_entity.body')
+%p.govuk-body
+  = succeed '.' do
+    = "If you believe this is incorrect please let us know by email"
+    = mail_to(I18n.t('app.email'), I18n.t('app.email'), class: 'govuk-link')

--- a/app/views/defect_mailer/forward.text.haml
+++ b/app/views/defect_mailer/forward.text.haml
@@ -16,3 +16,6 @@
 = "#{I18n.t('email.defect.forward.headings.title.contractor')}: #{@defect.property.scheme.contractor_name}"
 = "#{I18n.t('email.defect.forward.headings.title.priority_name')}: #{@defect.priority.name}"
 = "#{I18n.t('email.defect.forward.headings.title.target_completion_date')}: #{@defect.target_completion_date}"
+
+\---
+= "#{accept_defect_ownership_link(@defect.token)}"

--- a/app/views/defect_mailer/forward_to_contractor.text.haml
+++ b/app/views/defect_mailer/forward_to_contractor.text.haml
@@ -16,6 +16,5 @@
 = "#{I18n.t('email.defect.forward.headings.title.contractor')}: #{@defect.property.scheme.contractor_name}"
 = "#{I18n.t('email.defect.forward.headings.title.priority_name')}: #{@defect.priority.name}"
 = "#{I18n.t('email.defect.forward.headings.title.target_completion_date')}: #{@defect.target_completion_date}"
-
 \---
 = "#{accept_defect_ownership_link(@defect.token)}"

--- a/app/views/defect_mailer/forward_to_employer_agent.text.haml
+++ b/app/views/defect_mailer/forward_to_employer_agent.text.haml
@@ -1,0 +1,18 @@
+\# #{t('app.title')}
+\
+= "#{I18n.t('email.defect.forward.headings.title.reference_number')} : #{@defect.reference_number}"
+= "#{I18n.t('email.defect.forward.headings.title.created_at')}: #{@defect.created_at.to_s(:default)}"
+= "#{I18n.t('email.defect.forward.headings.title.reporting_officer')}: Hackney New Build team"
+\
+= "#{I18n.t('email.defect.forward.headings.title.core_name')}: #{@defect.property.core_name}"
+= "#{I18n.t('email.defect.forward.headings.title.address')}: #{@defect.property.address}"
+= "#{I18n.t('email.defect.forward.headings.title.location')}: Property"
+\
+= "#{I18n.t('email.defect.forward.headings.title.contact_name')}: #{@defect.contact_name}"
+= "#{I18n.t('email.defect.forward.headings.title.contact_phone_number')}: #{@defect.contact_phone_number}"
+= "#{I18n.t('email.defect.forward.headings.title.contractor_email_address')}: #{@defect.contact_email_address}"
+\
+= "#{I18n.t('email.defect.forward.headings.title.description_of_defect')}: #{@defect.description}"
+= "#{I18n.t('email.defect.forward.headings.title.contractor')}: #{@defect.property.scheme.contractor_name}"
+= "#{I18n.t('email.defect.forward.headings.title.priority_name')}: #{@defect.priority.name}"
+= "#{I18n.t('email.defect.forward.headings.title.target_completion_date')}: #{@defect.target_completion_date}"

--- a/config/initializers/default_url_options.rb
+++ b/config/initializers/default_url_options.rb
@@ -1,0 +1,13 @@
+default_domains = {
+  test: 'localhost:3000',
+  development: 'localhost:3000',
+  staging: 'lbh-report-a-defect-staging.herokuapp.com',
+  production: 'lbh-report-a-defect-production.herokuapp.com',
+}
+
+DOMAIN = ENV.fetch('DOMAIN') { default_domains[Rails.env.to_sym] }
+domain = URI(DOMAIN)
+protocol = Rails.application.config.force_ssl ? 'https' : 'http'
+
+ActionMailer::Base.default_url_options = { protocol: protocol, host: domain.to_s }
+Rails.application.routes.default_url_options = ActionMailer::Base.default_url_options

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,7 +1,6 @@
 en:
   app:
     title: 'Report a Defect'
-  generic:
     email: 'newbuild@hackney.gov.uk'
   service:
     name: 'Report a Defect'
@@ -11,6 +10,8 @@ en:
         accepted:
           title: 'Defect acceptance recorded'
           body: 'Thank you for accepting defect %{reference_number}'
+        unprocessable_entity:
+          body: 'This accept link appears to be invalid. This might be because it has already accepted it or it has expired.'
     staff:
       dashboard: 'Dashboard'
       estates:
@@ -34,6 +35,8 @@ en:
       comments:
         create: 'Create Comment'
         edit: 'Update Comment'
+  error_pages:
+    unprocessable_entity: 'Cannot process this request'
   generic:
     link:
       show: 'View'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,9 +1,16 @@
 en:
   app:
     title: 'Report a Defect'
+  generic:
+    email: 'newbuild@hackney.gov.uk'
   service:
     name: 'Report a Defect'
   page_title:
+    contractor:
+      defects:
+        accepted:
+          title: 'Defect acceptance recorded'
+          body: 'Thank you for accepting defect %{reference_number}'
     staff:
       dashboard: 'Dashboard'
       estates:
@@ -62,6 +69,9 @@ en:
             contractor: 'Contractor'
             priority_name: 'Priority'
             target_completion_date: 'Target completion date'
+        accept:
+          link: 'Accept ownership of this defect'
+        # alternate: 'Call us if not'
   activerecord:
     attributes:
       property:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,4 +15,8 @@ Rails.application.routes.draw do
       resources :comments, controller: 'staff/comments', only: %i[new create edit update]
     end
   end
+
+  resources :defects, controller: 'contractor/defects' do
+    get :accept
+  end
 end

--- a/spec/features/contractor_can_accept_receipt_of_defect_spec.rb
+++ b/spec/features/contractor_can_accept_receipt_of_defect_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.feature 'Contractor can accept the receipt of a defect' do
+  context 'with the correct token' do
+    it 'shows a confirmation page' do
+      defect = create(:defect)
+
+      visit defect_accept_path(defect.token)
+
+      expect(page).to have_content(I18n.t('page_title.contractor.defects.accepted.title'))
+    end
+
+    it 'stores an accepted at event' do
+      travel_to Time.zone.parse('2019-05-23')
+
+      defect = create(:defect)
+
+      visit defect_accept_path(defect.token)
+
+      result = PublicActivity::Activity.find_by(
+        trackable_id: defect.id,
+        trackable_type: Defect.to_s,
+        key: 'defect.accepted'
+      )
+      expect(result).to be_kind_of(PublicActivity::Activity)
+      expect(result.trackable).to be_kind_of(Defect)
+      expect(result.created_at).to eq(Time.zone.now)
+
+      travel_back
+    end
+  end
+end

--- a/spec/features/contractor_can_accept_receipt_of_defect_spec.rb
+++ b/spec/features/contractor_can_accept_receipt_of_defect_spec.rb
@@ -54,4 +54,21 @@ RSpec.feature 'Contractor can accept the receipt of a defect' do
       travel_back
     end
   end
+
+  context 'when the token has already been used' do
+    it 'does not store an accept event' do
+      defect = create(:defect)
+
+      visit defect_accept_path(defect.token)
+
+      expect(page).to have_content(I18n.t('page_title.contractor.defects.accepted.title'))
+      expect(PublicActivity::Activity.where(key: 'defect.accepted').count).to eq(1)
+
+      # Visit again
+      visit defect_accept_path(defect.token)
+
+      expect(page).to have_content(I18n.t('page_title.contractor.defects.unprocessable_entity.body'))
+      expect(PublicActivity::Activity.where(key: 'defect.accepted').count).to eq(1)
+    end
+  end
 end

--- a/spec/features/contractor_can_accept_receipt_of_defect_spec.rb
+++ b/spec/features/contractor_can_accept_receipt_of_defect_spec.rb
@@ -29,4 +29,12 @@ RSpec.feature 'Contractor can accept the receipt of a defect' do
       travel_back
     end
   end
+
+  context 'with an incorrect token' do
+    it 'returns a custom unprocessable_entity error' do
+      visit defect_accept_path('an-unknown-token')
+      expect(page.status_code).to eq(422)
+      expect(page).to have_content(I18n.t('page_title.contractor.defects.unprocessable_entity.body'))
+    end
+  end
 end

--- a/spec/features/contractor_can_accept_receipt_of_defect_spec.rb
+++ b/spec/features/contractor_can_accept_receipt_of_defect_spec.rb
@@ -54,27 +54,4 @@ RSpec.feature 'Contractor can accept the receipt of a defect' do
       travel_back
     end
   end
-
-  context 'when this token has already been used'
-
-  context 'when the token contains suspicious characters'
-
-  #
-  # context 'with the incorrect token' do
-  #   let(:token) { subscription.id }
-  #
-  #   it 'returns not found' do
-  #     expect(page.status_code).to eq(404)
-  #   end
-  # end
-  #
-  # context 'with an old token' do
-  #   let(:token) do
-  #     Timecop.travel(-3.days) { subscription.token }
-  #   end
-  #
-  #   scenario 'still returns 200' do
-  #     expect(page.status_code).to eq(200)
-  #   end
-  # end
 end

--- a/spec/features/contractor_can_accept_receipt_of_defect_spec.rb
+++ b/spec/features/contractor_can_accept_receipt_of_defect_spec.rb
@@ -37,4 +37,44 @@ RSpec.feature 'Contractor can accept the receipt of a defect' do
       expect(page).to have_content(I18n.t('page_title.contractor.defects.unprocessable_entity.body'))
     end
   end
+
+  context 'when this token has expired' do
+    it 'returns a custom unprocessable_entity error' do
+      travel_to Time.zone.parse('2019-01-01')
+
+      defect = create(:defect)
+      token = defect.token
+
+      travel_to Time.zone.parse('2019-04-01')
+
+      visit defect_accept_path(token)
+      expect(page.status_code).to eq(422)
+      expect(page).to have_content(I18n.t('page_title.contractor.defects.unprocessable_entity.body'))
+
+      travel_back
+    end
+  end
+
+  context 'when this token has already been used'
+
+  context 'when the token contains suspicious characters'
+
+  #
+  # context 'with the incorrect token' do
+  #   let(:token) { subscription.id }
+  #
+  #   it 'returns not found' do
+  #     expect(page.status_code).to eq(404)
+  #   end
+  # end
+  #
+  # context 'with an old token' do
+  #   let(:token) do
+  #     Timecop.travel(-3.days) { subscription.token }
+  #   end
+  #
+  #   scenario 'still returns 200' do
+  #     expect(page.status_code).to eq(200)
+  #   end
+  # end
 end

--- a/spec/helpers/notify_view_helper_spec.rb
+++ b/spec/helpers/notify_view_helper_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe NotifyViewHelper, type: :helper do
+  describe '#notify_link' do
+    it 'returns back a markdown link' do
+      result = helper.notify_link('http://localhost:3000/hello', 'A bit of text')
+      expect(result).to eql('[A bit of text](http://localhost:3000/hello)')
+    end
+
+    context 'when no text is given' do
+      it 'sets the link text to the same as the link' do
+        result = helper.notify_link('http://localhost:3000/hello')
+        expect(result).to eq('[http://localhost:3000/hello](http://localhost:3000/hello)')
+      end
+    end
+  end
+
+  describe '#accept_defect_ownership_link' do
+    it 'returns a capitalized string' do
+      result = helper.accept_defect_ownership_link('foo')
+      expect(result).to eql("[#{I18n.t('email.defect.forward.accept.link')}](http://test.host/defects/foo/accept)")
+    end
+  end
+end

--- a/spec/mailers/defect_spec.rb
+++ b/spec/mailers/defect_spec.rb
@@ -10,25 +10,51 @@ RSpec.describe DefectMailer, type: :mailer do
 
   let(:recipient) { 'email@example.com' }
   let(:defect) { create(:defect) }
-  let(:mail) { DefectMailer.forward(defect.id, recipient) }
-  let(:body_lines) { mail.body.raw_source.lines }
 
-  it 'sends an email to the email address provided' do
-    expect(mail.subject).to eq(I18n.t('email.defect.forward.subject', reference: defect.reference_number))
-    expect(mail.to).to eq([recipient])
-    expect(body_lines[0].strip).to match(/# #{I18n.t('app.title')}/)
-    expect(body_lines[2].strip).to match("#{I18n.t('email.defect.forward.headings.title.reference_number')} : #{defect.reference_number}")
-    expect(body_lines[3].strip).to match("#{I18n.t('email.defect.forward.headings.title.created_at')}: #{defect.created_at.to_s(:default)}")
-    expect(body_lines[4].strip).to match("#{I18n.t('email.defect.forward.headings.title.reporting_officer')}: Hackney New Build team")
-    expect(body_lines[6].strip).to match("#{I18n.t('email.defect.forward.headings.title.core_name')}: #{defect.property.core_name}")
-    expect(body_lines[7].strip).to match("#{I18n.t('email.defect.forward.headings.title.address')}: #{defect.property.address}")
-    expect(body_lines[8].strip).to match("#{I18n.t('email.defect.forward.headings.title.location')}: Property")
-    expect(body_lines[10].strip).to match("#{I18n.t('email.defect.forward.headings.title.contact_name')}: #{defect.contact_name}")
-    expect(body_lines[11].strip).to match("#{I18n.t('email.defect.forward.headings.title.contact_phone_number')}: #{defect.contact_phone_number}")
-    expect(body_lines[12].strip).to match("#{I18n.t('email.defect.forward.headings.title.contractor_email_address')}: #{defect.contact_email_address}")
-    expect(body_lines[14].strip).to match("#{I18n.t('email.defect.forward.headings.title.description_of_defect')}: #{defect.description}")
-    expect(body_lines[15].strip).to match("#{I18n.t('email.defect.forward.headings.title.contractor')}: #{defect.property.scheme.contractor_name}")
-    expect(body_lines[16].strip).to match("#{I18n.t('email.defect.forward.headings.title.priority_name')}: #{defect.priority.name}")
-    expect(body_lines[17].strip).to match("#{I18n.t('email.defect.forward.headings.title.target_completion_date')}: #{defect.target_completion_date}")
+  describe('#forward_to_contractor') do
+    it 'sends an email to the scheme contractor' do
+      mail = DefectMailer.forward_to_contractor(defect.id)
+      body_lines = mail.body.raw_source.lines
+      expect(mail.subject).to eq(I18n.t('email.defect.forward.subject', reference: defect.reference_number))
+      expect(mail.to).to eq([defect.property.scheme.contractor_email_address])
+      expect(body_lines[0].strip).to match(/# #{I18n.t('app.title')}/)
+      expect(body_lines[2].strip).to match("#{I18n.t('email.defect.forward.headings.title.reference_number')} : #{defect.reference_number}")
+      expect(body_lines[3].strip).to match("#{I18n.t('email.defect.forward.headings.title.created_at')}: #{defect.created_at.to_s(:default)}")
+      expect(body_lines[4].strip).to match("#{I18n.t('email.defect.forward.headings.title.reporting_officer')}: Hackney New Build team")
+      expect(body_lines[6].strip).to match("#{I18n.t('email.defect.forward.headings.title.core_name')}: #{defect.property.core_name}")
+      expect(body_lines[7].strip).to match("#{I18n.t('email.defect.forward.headings.title.address')}: #{defect.property.address}")
+      expect(body_lines[8].strip).to match("#{I18n.t('email.defect.forward.headings.title.location')}: Property")
+      expect(body_lines[10].strip).to match("#{I18n.t('email.defect.forward.headings.title.contact_name')}: #{defect.contact_name}")
+      expect(body_lines[11].strip).to match("#{I18n.t('email.defect.forward.headings.title.contact_phone_number')}: #{defect.contact_phone_number}")
+      expect(body_lines[12].strip).to match("#{I18n.t('email.defect.forward.headings.title.contractor_email_address')}: #{defect.contact_email_address}")
+      expect(body_lines[14].strip).to match("#{I18n.t('email.defect.forward.headings.title.description_of_defect')}: #{defect.description}")
+      expect(body_lines[15].strip).to match("#{I18n.t('email.defect.forward.headings.title.contractor')}: #{defect.property.scheme.contractor_name}")
+      expect(body_lines[16].strip).to match("#{I18n.t('email.defect.forward.headings.title.priority_name')}: #{defect.priority.name}")
+      expect(body_lines[17].strip).to match("#{I18n.t('email.defect.forward.headings.title.target_completion_date')}: #{defect.target_completion_date}")
+      expect(body_lines[19]).to match(%r{http:\/\/localhost:3000\/defects\/#{defect.token}\/accept})
+    end
+  end
+
+  describe('#forward_to_employer_agent') do
+    it 'sends an email to the scheme employer_agent' do
+      mail = DefectMailer.forward_to_employer_agent(defect.id)
+      body_lines = mail.body.raw_source.lines
+      expect(mail.subject).to eq(I18n.t('email.defect.forward.subject', reference: defect.reference_number))
+      expect(mail.to).to eq([defect.property.scheme.employer_agent_email_address])
+      expect(body_lines[0].strip).to match(/# #{I18n.t('app.title')}/)
+      expect(body_lines[2].strip).to match("#{I18n.t('email.defect.forward.headings.title.reference_number')} : #{defect.reference_number}")
+      expect(body_lines[3].strip).to match("#{I18n.t('email.defect.forward.headings.title.created_at')}: #{defect.created_at.to_s(:default)}")
+      expect(body_lines[4].strip).to match("#{I18n.t('email.defect.forward.headings.title.reporting_officer')}: Hackney New Build team")
+      expect(body_lines[6].strip).to match("#{I18n.t('email.defect.forward.headings.title.core_name')}: #{defect.property.core_name}")
+      expect(body_lines[7].strip).to match("#{I18n.t('email.defect.forward.headings.title.address')}: #{defect.property.address}")
+      expect(body_lines[8].strip).to match("#{I18n.t('email.defect.forward.headings.title.location')}: Property")
+      expect(body_lines[10].strip).to match("#{I18n.t('email.defect.forward.headings.title.contact_name')}: #{defect.contact_name}")
+      expect(body_lines[11].strip).to match("#{I18n.t('email.defect.forward.headings.title.contact_phone_number')}: #{defect.contact_phone_number}")
+      expect(body_lines[12].strip).to match("#{I18n.t('email.defect.forward.headings.title.contractor_email_address')}: #{defect.contact_email_address}")
+      expect(body_lines[14].strip).to match("#{I18n.t('email.defect.forward.headings.title.description_of_defect')}: #{defect.description}")
+      expect(body_lines[15].strip).to match("#{I18n.t('email.defect.forward.headings.title.contractor')}: #{defect.property.scheme.contractor_name}")
+      expect(body_lines[16].strip).to match("#{I18n.t('email.defect.forward.headings.title.priority_name')}: #{defect.priority.name}")
+      expect(body_lines[17].strip).to match("#{I18n.t('email.defect.forward.headings.title.target_completion_date')}: #{defect.target_completion_date}")
+    end
   end
 end

--- a/spec/models/defect_spec.rb
+++ b/spec/models/defect_spec.rb
@@ -83,4 +83,17 @@ RSpec.describe Defect, type: :model do
       travel_back
     end
   end
+
+  describe '#token' do
+    it 'generates a secret token from the ID' do
+      defect = create(:defect)
+
+      verifier_double = instance_double(ActiveSupport::MessageVerifier)
+      expect(ActiveSupport::MessageVerifier).to receive(:new).and_return(verifier_double)
+      expect(verifier_double).to receive(:generate)
+        .with(defect.id, purpose: :accept_defect_ownership)
+
+      defect.token
+    end
+  end
 end

--- a/spec/models/defect_spec.rb
+++ b/spec/models/defect_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe Defect, type: :model do
       verifier_double = instance_double(ActiveSupport::MessageVerifier)
       expect(ActiveSupport::MessageVerifier).to receive(:new).and_return(verifier_double)
       expect(verifier_double).to receive(:generate)
-        .with(defect.id, purpose: :accept_defect_ownership)
+        .with(defect.id, purpose: :accept_defect_ownership, expires_in: 3.months)
 
       defect.token
     end


### PR DESCRIPTION
## Changes in this PR:
- contractors receive an accept link, employer agents do not
- contractors can only click accept once to ensure future resident notifications are not send multiple times in error
- accepting a defect does not change the status of the defect itself as there is not an existing status that can be used. Until we are more confident about what status might work overall, we are tracking the event that a contractor has accepted this defect on x date
- acceptance links expire after 3 months rather than being valid forever
- clicking a malformed link, or an acceptance link that's already been clicked will show a custom error page that is deliberately vague about what may or may not have happened. As this is a public facing endpoint we need to be mindful of what to disclose to any malicious parties trying to accept and reaccept
- Notify doesn't accommodate CC so the email templates have diverged, there is deliberate duplicate of mailers and views as I expect more distinctions to come up after testing

## Screenshots of UI changes:

### After

![Screenshot 2019-06-10 at 19 19 36](https://user-images.githubusercontent.com/912473/59217110-22c22100-8bb5-11e9-977d-70c6e13787ee.png)
![Screenshot 2019-06-10 at 19 19 45](https://user-images.githubusercontent.com/912473/59217111-22c22100-8bb5-11e9-84c9-298ce2567857.png)
![Screenshot 2019-06-10 at 19 30 24](https://user-images.githubusercontent.com/912473/59217604-36ba5280-8bb6-11e9-967b-a9236db2322f.png)

