### PR TITLE
[113] Add short title to defect

### DIFF
--- a/app/controllers/staff/defects_controller.rb
+++ b/app/controllers/staff/defects_controller.rb
@@ -57,6 +57,7 @@ class Staff::DefectsController < Staff::BaseController
 
   def defect_params
     params.require(:defect).permit(
+      :title,
       :description,
       :contact_name,
       :contact_email_address,

--- a/app/models/defect.rb
+++ b/app/models/defect.rb
@@ -1,6 +1,7 @@
 class Defect < ApplicationRecord
   before_validation :set_completion_date
-  validates :description,
+  validates :title,
+            :description,
             :trade,
             :priority,
             :reference_number,
@@ -13,7 +14,6 @@ class Defect < ApplicationRecord
   validates :contact_phone_number, numericality: true,
                                    length: { minimum: 10, maximum: 15 },
                                    allow_blank: true
-
   attribute :reference_number, :string, default: -> { SecureRandom.hex(3).upcase }
 
   enum status: %i[

--- a/app/views/shared/defects/_information.html.haml
+++ b/app/views/shared/defects/_information.html.haml
@@ -3,6 +3,9 @@
     %dt.govuk-summary-list__key Reference number
     %dd.govuk-summary-list__value= defect.reference_number
   %div.govuk-summary-list__row
+    %dt.govuk-summary-list__key Title
+    %dd.govuk-summary-list__value= defect.title
+  %div.govuk-summary-list__row
     %dt.govuk-summary-list__key Status
     %dd.govuk-summary-list__value= defect.status
   %div.govuk-summary-list__row

--- a/app/views/shared/defects/_table.html.haml
+++ b/app/views/shared/defects/_table.html.haml
@@ -6,6 +6,9 @@
           Reference number
       %th.govuk-table__header
         %h2.govuk-heading-m
+          Title
+      %th.govuk-table__header
+        %h2.govuk-heading-m
           Status
       %th.govuk-table__header
         %h2.govuk-heading-m
@@ -23,6 +26,7 @@
     - defects.each do |defect|
       %tr.govuk-table__row
         %td.govuk-table__cell= defect.reference_number
+        %td.govuk-table__cell= defect.title
         %td.govuk-table__cell= defect.status
         %td.govuk-table__cell= defect.priority.name
         %td.govuk-table__cell= format_date(defect.target_completion_date)

--- a/app/views/staff/defects/edit.html.haml
+++ b/app/views/staff/defects/edit.html.haml
@@ -10,6 +10,9 @@
 
     = simple_form_for [@defect.property, @defect] do |f|
       .govuk-form-group
+        = f.input :title,
+                  hint: I18n.t('form.defect.title.description'),
+                  label: 'Short title'
         = f.input :description,
                   wrapper: 'textarea',
                   as: :text,

--- a/app/views/staff/defects/new.html.haml
+++ b/app/views/staff/defects/new.html.haml
@@ -11,6 +11,9 @@
 
     = simple_form_for @defect, html: { class: 'new_defect' }, action: :post, url: property_defects_path(@property) do |f|
       .govuk-form-group
+        = f.input :title,
+                  hint: I18n.t('form.defect.title.description'),
+                  label: 'Short title'
         = f.input :description,
                   wrapper: 'textarea',
                   as: :text,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -53,6 +53,10 @@ en:
       update:
         success:
           'The %{resource} has successfully been updated.'
+  form:
+    defect:
+      title:
+        description: 'This will be how this defect is described to residents in status notifications'
   email:
     defect:
       forward:

--- a/db/migrate/20190611125831_add_title_to_defect.rb
+++ b/db/migrate/20190611125831_add_title_to_defect.rb
@@ -1,0 +1,5 @@
+class AddTitleToDefect < ActiveRecord::Migration[5.2]
+  def change
+    add_column :defects, :title, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_04_143132) do
+ActiveRecord::Schema.define(version: 2019_06_11_125831) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -58,6 +58,7 @@ ActiveRecord::Schema.define(version: 2019_06_04_143132) do
     t.uuid "priority_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "title"
     t.index ["priority_id"], name: "index_defects_on_priority_id"
     t.index ["property_id"], name: "index_defects_on_property_id"
   end

--- a/spec/factories/defects.rb
+++ b/spec/factories/defects.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :defect do
+    title { Faker::Lorem.paragraph_by_chars(50) }
     description { Faker::Lorem.paragraph_by_chars(750) }
     contact_name { Faker::Name.name }
     contact_email_address { Faker::Internet.email }

--- a/spec/features/anyone_can_create_a_defect_spec.rb
+++ b/spec/features/anyone_can_create_a_defect_spec.rb
@@ -30,6 +30,7 @@ RSpec.feature 'Anyone can create a defect' do
     end
 
     within('form.new_defect') do
+      fill_in 'defect[title]', with: 'Electrics failed'
       fill_in 'defect[description]', with: 'None of the electrics work'
       fill_in 'defect[contact_name]', with: 'Alex Stone'
       fill_in 'defect[contact_email_address]', with: 'email@example.com'
@@ -43,10 +44,11 @@ RSpec.feature 'Anyone can create a defect' do
     within('table.defects') do
       defect = property.reload.defects.first
 
-      expect(page).to have_content(defect.trade)
-      expect(page).to have_content(defect.priority.name)
-      expect(page).to have_content(defect.target_completion_date)
+      expect(page).to have_content('Electrics failed')
+      expect(page).to have_content('Electrical')
       expect(page).to have_content('Outstanding')
+      expect(page).to have_content(priority.name)
+      expect(page).to have_content(defect.target_completion_date)
       expect(page).to have_content(defect.reference_number)
     end
   end

--- a/spec/features/anyone_can_update_a_defect_spec.rb
+++ b/spec/features/anyone_can_update_a_defect_spec.rb
@@ -15,6 +15,7 @@ RSpec.feature 'Anyone can update a defect' do
     click_on(I18n.t('generic.link.edit'))
 
     within('form.edit_defect') do
+      fill_in 'defect[title]', with: 'New title'
       fill_in 'defect[description]', with: 'New description'
       fill_in 'defect[contact_name]', with: 'New name'
       fill_in 'defect[contact_email_address]', with: 'email@foo.com'
@@ -29,6 +30,7 @@ RSpec.feature 'Anyone can update a defect' do
 
     expect(page).to have_content(I18n.t('generic.notice.update.success', resource: 'defect'))
 
+    expect(page).to have_content('New title')
     expect(page).to have_content('New description')
     expect(page).to have_content('New name')
     expect(page).to have_content('email@foo.com')

--- a/spec/features/anyone_can_view_a_defect_spec.rb
+++ b/spec/features/anyone_can_view_a_defect_spec.rb
@@ -23,6 +23,7 @@ RSpec.feature 'Anyone can view a defect' do
 
     within('.defect_information') do
       expect(page).to have_content(defect.reference_number)
+      expect(page).to have_content(defect.title)
       expect(page).to have_content(defect.description)
       expect(page).to have_content(defect.contact_name)
       expect(page).to have_content(defect.contact_phone_number)

--- a/spec/models/defect_spec.rb
+++ b/spec/models/defect_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Defect, type: :model do
 
     errors = defect.errors.full_messages
 
+    expect(errors).to include("Title can't be blank")
     expect(errors).to include("Description can't be blank")
     expect(errors).to include("Trade can't be blank")
     expect(errors).to include("Priority can't be blank")

--- a/spec/requests/defect_creation_spec.rb
+++ b/spec/requests/defect_creation_spec.rb
@@ -14,16 +14,10 @@ RSpec.describe 'Defect creation', type: :request do
   let(:property) { create(:property) }
 
   it 'forwards the email to the contractor and employer agent' do
+    defect_attributes = build(:defect).attributes
+    defect_attributes.merge!(priority: create(:priority).id)
     params = {
-      defect: {
-        description: 'A description',
-        contact_name: 'A name',
-        contact_email_address: 'email@example.com',
-        contact_phone_number: '07123456789',
-        trade: 'Electrical',
-        status: 'outstanding',
-        priority: create(:priority).id,
-      },
+      defect: defect_attributes,
     }
 
     post property_defects_path(property), params: params


### PR DESCRIPTION
## Changes in this PR:
- add a new title to a defect
- edit an existing defect's title
- starting with no length validation on the title field to be permissive while we observe real behaviour
- title appears in defect show page
- title appears in the defect table, shown on the property page

## Screenshots of UI changes:

<img width="780" alt="Screenshot 2019-06-11 at 14 31 18" src="https://user-images.githubusercontent.com/912473/59276118-99aef680-8c55-11e9-8754-0198cbeb8dbd.png">
<img width="1681" alt="Screenshot 2019-06-11 at 14 23 02" src="https://user-images.githubusercontent.com/912473/59276074-81d77280-8c55-11e9-9b2b-c48444320bc4.png">
<img width="1681" alt="Screenshot 2019-06-11 at 14 24 57" src="https://user-images.githubusercontent.com/912473/59276075-81d77280-8c55-11e9-9470-c0a5d57309ef.png">
