### PR TITLE
Design/101 scheme view

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -21,3 +21,39 @@ p {
     @include govuk-link-style-no-visited-state;
   }
 }
+
+.govuk-summary-list.no-actions {
+  .govuk-summary-list__row {
+    font-size: 1rem;
+
+    .govuk-summary-list__key {
+      width: 45%;
+    }
+    .govuk-summary-list__value {
+      width: 55%
+    }
+  }
+}
+
+.scheme-info {
+  border-right: 1px solid $lbh-border-colour;
+}
+
+@include govuk-media-query($until: desktop) {
+  .scheme-info {
+    border-right: none;
+    border-bottom: 1px solid $lbh-border-colour;
+    margin-bottom: 1em;
+  }
+}
+
+
+.section-heading {
+  border-bottom: 1px solid $lbh-border-colour;
+  border-bottom: 1px solid $lbh-primary;
+  border-right: 1px solid lighten($lbh-border-colour, 15%);
+  border-top: 1px solid lighten($lbh-border-colour, 15%);
+  border-left: 1px solid lighten($lbh-border-colour, 15%);
+  background-color: lighten($lbh-border-colour, 20%);;
+  padding: 0.5em;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -57,3 +57,17 @@ p {
   background-color: lighten($lbh-border-colour, 20%);;
   padding: 0.5em;
 }
+
+@include govuk-media-query($until: tablet) {
+  .section-heading {
+    border-bottom: 1px solid $lbh-border-colour;
+    border-right: 1px solid lighten($lbh-border-colour, 15%);
+    border-top: 1px solid lighten($lbh-border-colour, 15%);
+    border-left: 1px solid lighten($lbh-border-colour, 15%);
+    background-color: lighten($lbh-border-colour, 20%);;
+    padding: 0.5em;
+    padding-left: 1em;
+    margin-left: -1em;
+    margin-right: -1em;
+  }
+}

--- a/app/views/shared/priorities/_table.html.haml
+++ b/app/views/shared/priorities/_table.html.haml
@@ -2,11 +2,9 @@
   %thead.govuk-table__head
     %tr.govuk-table__row
       %th.govuk-table__header
-        %h2.govuk-heading-m
-          Name
+        Priority code
       %th.govuk-table__header
-        %h2.govuk-heading-m
-          Days
+        Duration in days
   %tbody.govuk-table__body
     - priorities.each do |priority|
       %tr.govuk-table__row

--- a/app/views/shared/properties/_information.html.haml
+++ b/app/views/shared/properties/_information.html.haml
@@ -3,11 +3,11 @@
     %dt.govuk-summary-list__key UPRN
     %dd.govuk-summary-list__value= property.uprn
   %div.govuk-summary-list__row
+    %dt.govuk-summary-list__key Core name
+    %dd.govuk-summary-list__value= property.core_name
+  %div.govuk-summary-list__row
     %dt.govuk-summary-list__key Property address
     %dd.govuk-summary-list__value= property.address
-  %div.govuk-summary-list__row
-    %dt.govuk-summary-list__key Property core
-    %dd.govuk-summary-list__value= property.core_name
   %div.govuk-summary-list__row
     %dt.govuk-summary-list__key Postcode
     %dd.govuk-summary-list__value= property.postcode

--- a/app/views/shared/properties/_table.html.haml
+++ b/app/views/shared/properties/_table.html.haml
@@ -2,20 +2,15 @@
   %thead.govuk-table__head
     %tr.govuk-table__row
       %th.govuk-table__header
-        %h2.govuk-heading-m
-          UPRN
+        UPRN
       %th.govuk-table__header
-        %h2.govuk-heading-m
-          Core name
+        Core name
       %th.govuk-table__header
-        %h2.govuk-heading-m
-          Address
+        Address
       %th.govuk-table__header
-        %h2.govuk-heading-m
-          Postcode
+        Postcode
       %th.govuk-table__header
-        %h2.govuk-heading-m
-          Actions
+        Actions
       %th.govuk-table__header
 
   %tbody.govuk-table__body

--- a/app/views/shared/schemes/_information.html.haml
+++ b/app/views/shared/schemes/_information.html.haml
@@ -1,19 +1,19 @@
-%dl.govuk-summary-list.scheme_information
-  %div.govuk-summary-list__row
-    %dt.govuk-summary-list__key Estate
-    %dd.govuk-summary-list__value= scheme.estate.name
-  %div.govuk-summary-list__row
-    %dt.govuk-summary-list__key Scheme
-    %dd.govuk-summary-list__value= scheme.name
-  %div.govuk-summary-list__row
-    %dt.govuk-summary-list__key Contractor name
-    %dd.govuk-summary-list__value= scheme.contractor_name
-  %div.govuk-summary-list__row
-    %dt.govuk-summary-list__key Contractor email address
-    %dd.govuk-summary-list__value= scheme.contractor_email_address
-  %div.govuk-summary-list__row
-    %dt.govuk-summary-list__key Employer agent name
-    %dd.govuk-summary-list__value= scheme.employer_agent_name
-  %div.govuk-summary-list__row
-    %dt.govuk-summary-list__key Employer agent email address
-    %dd.govuk-summary-list__value= scheme.employer_agent_email_address
+.govuk-grid-column-one-half
+  %h3.govuk-heading-s Contractor details
+  %dl.govuk-summary-list.govuk-summary-list--no-border.scheme_information.no-actions.scheme_contractor
+    %div.govuk-summary-list__row
+      %dt.govuk-summary-list__key Contractor name
+      %dd.govuk-summary-list__value= scheme.contractor_name
+    %div.govuk-summary-list__row
+      %dt.govuk-summary-list__key Contractor email address
+      %dd.govuk-summary-list__value= scheme.contractor_email_address
+
+.govuk-grid-column-one-half
+  %h3.govuk-heading-s Employer agent details
+  %dl.govuk-summary-list.govuk-summary-list--no-border.no-actions.scheme_information.scheme_agent
+    %div.govuk-summary-list__row
+      %dt.govuk-summary-list__key Employer agent name
+      %dd.govuk-summary-list__value= scheme.employer_agent_name
+    %div.govuk-summary-list__row
+      %dt.govuk-summary-list__key Employer agent email address
+      %dd.govuk-summary-list__value= scheme.employer_agent_email_address

--- a/app/views/shared/schemes/_table.html.haml
+++ b/app/views/shared/schemes/_table.html.haml
@@ -2,14 +2,11 @@
   %thead.govuk-table__head
     %tr.govuk-table__row
       %th.govuk-table__header
-        %h2.govuk-heading-m
-          Name
+        Scheme name
       %th.govuk-table__header
-        %h2.govuk-heading-m
-          Contractor
+        Contractor name
       %th.govuk-table__header
-        %h2.govuk-heading-m
-          Actions
+        Actions
   %tbody.govuk-table__body
     - estate.schemes.each do |scheme|
       %tr.govuk-table__row

--- a/app/views/staff/defects/show.html.haml
+++ b/app/views/staff/defects/show.html.haml
@@ -10,18 +10,12 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    %h1.govuk-heading-xl
+    %h1.govuk-heading-l
       = I18n.t('page_title.staff.defects.show', reference_number: @defect.reference_number)
     = link_to(I18n.t('generic.button.edit', resource: 'Defect'), edit_property_defect_path(@defect.property, @defect), class: 'govuk-button mb0')
     = render partial: '/shared/defects/information', locals: { defect: @defect }
 
-  .govuk-grid-column-one-third
-    %h2.govuk-heading-l
-      Comments
-    = link_to(I18n.t('generic.button.create', resource: 'Comment'), new_property_defect_comment_path(@defect.property, @defect), class: 'govuk-button mb0')
-    = render partial: '/shared/comments/list', locals: { comments: @defect.comments }
-
-    %h2.govuk-heading-l
+    %h2.govuk-heading-m
       Scheme
 
     %p.scheme_information.scheme_name_and_estate
@@ -29,10 +23,16 @@
 
     = render partial: '/shared/schemes/information', locals: { scheme: @defect.property.scheme }
 
-    %h2.govuk-heading-l
+  .govuk-grid-column-one-third
+    %h2.govuk-heading-m
+      Comments
+    = link_to(I18n.t('generic.button.create', resource: 'Comment'), new_property_defect_comment_path(@defect.property, @defect), class: 'govuk-button mb0')
+    = render partial: '/shared/comments/list', locals: { comments: @defect.comments }
+
+    %h2.govuk-heading-m
       Property
     = render partial: '/shared/properties/information', locals: { property: @defect.property }
 
-    %h2.govuk-heading-l
+    %h2.govuk-heading-m
       Events
     = render partial: '/shared/events/list', locals: { events: @defect.activities }

--- a/app/views/staff/defects/show.html.haml
+++ b/app/views/staff/defects/show.html.haml
@@ -23,6 +23,10 @@
 
     %h2.govuk-heading-l
       Scheme
+
+    %p.scheme_information.scheme_name_and_estate
+      #{I18n.t('page_title.staff.schemes.show', name: @defect.property.scheme.name)} belongs to #{I18n.t('page_title.staff.estates.show', name: @defect.property.scheme.estate.name)}
+
     = render partial: '/shared/schemes/information', locals: { scheme: @defect.property.scheme }
 
     %h2.govuk-heading-l

--- a/app/views/staff/estates/show.html.haml
+++ b/app/views/staff/estates/show.html.haml
@@ -7,7 +7,11 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    %h1.govuk-heading-xl= I18n.t('page_title.staff.estates.show', name: @estate.name)
+    %h1.govuk-heading-l= I18n.t('page_title.staff.estates.show', name: @estate.name)
     = link_to(I18n.t('generic.button.create', resource: 'Scheme'), new_estate_scheme_path(@estate), class: 'govuk-button mb0')
+
+
+    %h2.govuk-heading-m.section-heading
+      List of schemes
 
     = render partial: '/shared/schemes/table', locals: { estate: @estate }

--- a/app/views/staff/priorities/new.html.haml
+++ b/app/views/staff/priorities/new.html.haml
@@ -10,6 +10,17 @@
 
     = simple_form_for [@scheme.estate, @scheme, @priority] do |f|
       .govuk-form-group
-        = f.input :name, label: 'Priority code', input_html: { class: 'govuk-input--width-3' }
-        = f.input :days, as: :integer, placeholder: '1', label: 'Duration in days', input_html: { class: 'govuk-input--width-3' }
+        = f.input :name,
+                  label: I18n.t('form.priority.code.label'),
+                  hint: I18n.t('form.priority.code.hint'),
+                  label_html: { class: 'govuk-label'},
+                  input_html: { class: 'govuk-input--width-3' }
+
+        = f.input :days,
+                  as: :integer,
+                  label: I18n.t('form.priority.days.label'),
+                  hint: I18n.t('form.priority.days.hint'),
+                  label_html: { class: 'govuk-label'},
+                  input_html: { class: 'govuk-input--width-3' }
+
       = f.button :submit, I18n.t('generic.button.create', resource: 'Priority')

--- a/app/views/staff/priorities/new.html.haml
+++ b/app/views/staff/priorities/new.html.haml
@@ -10,6 +10,6 @@
 
     = simple_form_for [@scheme.estate, @scheme, @priority] do |f|
       .govuk-form-group
-        = f.input :name
-        = f.input :days, as: :integer, placeholder: '1'
+        = f.input :name, label: 'Priority code', input_html: { class: 'govuk-input--width-3' }
+        = f.input :days, as: :integer, placeholder: '1', label: 'Duration in days', input_html: { class: 'govuk-input--width-3' }
       = f.button :submit, I18n.t('generic.button.create', resource: 'Priority')

--- a/app/views/staff/properties/show.html.haml
+++ b/app/views/staff/properties/show.html.haml
@@ -18,6 +18,9 @@
   .govuk-grid-column-one-half
     %h2.govuk-heading-l
       Scheme
+    %p.scheme_information.scheme_name_and_estate
+      #{I18n.t('page_title.staff.schemes.show', name: @property.scheme.name)} belongs to #{I18n.t('page_title.staff.estates.show', name: @property.scheme.estate.name)}
+
     = render partial: '/shared/schemes/information', locals: { scheme: @property.scheme }
 
   .govuk-grid-column-full

--- a/app/views/staff/schemes/show.html.haml
+++ b/app/views/staff/schemes/show.html.haml
@@ -8,12 +8,40 @@
 
 .govuk-grid-row
   .govuk-grid-column-full
-    %h1.govuk-heading-xl= I18n.t('page_title.staff.schemes.show', name: @scheme.name)
-    = link_to(I18n.t('generic.button.edit', resource: 'Scheme'), edit_estate_scheme_path(@scheme.estate, @scheme), class: 'govuk-button mb0')
-    = render partial: '/shared/schemes/information', locals: { scheme: @scheme }
+    %h1.govuk-heading-l= I18n.t('page_title.staff.schemes.show', name: @scheme.name)
+    %p.scheme_information.scheme_name_and_estate
+      #{I18n.t('page_title.staff.schemes.show', name: @scheme.name)} belongs to #{I18n.t('page_title.staff.estates.show', name: @scheme.estate.name)}
 
-    = link_to(I18n.t('generic.button.create', resource: 'Priority'), new_estate_scheme_priority_path(@scheme.estate, @scheme), class: 'govuk-button mb0')
-    = render partial: '/shared/priorities/table', locals: { priorities: @scheme.priorities }
+%div{class:'govuk-grid-row govuk-!-padding-bottom-4'}
+  .govuk-grid-column-full
+    %h2.govuk-heading-m.section-heading
+      Scheme information
+
+  .govuk-grid-column-full.govuk-grid-column-two-thirds-from-desktop.scheme-info
+    .govuk-grid-row
+
+      = render partial: '/shared/schemes/information', locals: { scheme: @scheme }
+
+    .govuk-grid-row
+      .govuk-grid-column-full
+        = link_to(I18n.t('generic.button.edit', resource: 'Scheme'), edit_estate_scheme_path(@scheme.estate, @scheme), class: 'govuk-button govuk-button--secondary mb0')
+
+  .govuk-grid-column-full.govuk-grid-column-one-third-from-desktop.scheme-priorities
+    %h3.govuk-heading-s
+      Contracted priority times
+
+    - if @scheme.priorities.present?
+      = render partial: '/shared/priorities/table', locals: { priorities: @scheme.priorities }
+    - else
+      %p.govuk-body
+        There are no priotities set yet. You need to create them.
+
+    = link_to(I18n.t('generic.button.create', resource: 'Priority'), new_estate_scheme_priority_path(@scheme.estate, @scheme), class: 'govuk-button govuk-button--secondary mb0')
+
+.govuk-grid-row
+  .govuk-grid-column-full
+    %h2.govuk-heading-m.section-heading
+      Properites in #{I18n.t('page_title.staff.schemes.show', name: @scheme.name)}
 
     = link_to(I18n.t('generic.button.create', resource: 'Property'), new_estate_scheme_property_path(@scheme.estate, @scheme), class: 'govuk-button mb0')
     = render partial: '/shared/properties/table', locals: { properties: @scheme.properties }

--- a/app/views/staff/schemes/show.html.haml
+++ b/app/views/staff/schemes/show.html.haml
@@ -28,13 +28,13 @@
 
   .govuk-grid-column-full.govuk-grid-column-one-third-from-desktop.scheme-priorities
     %h3.govuk-heading-s
-      Contracted priority times
+      Priorities
 
     - if @scheme.priorities.present?
       = render partial: '/shared/priorities/table', locals: { priorities: @scheme.priorities }
     - else
       %p.govuk-body
-        There are no priotities set yet. You need to create them.
+        = I18n.t('page_content.scheme.show.priorities.no_priorities')
 
     = link_to(I18n.t('generic.button.create', resource: 'Priority'), new_estate_scheme_priority_path(@scheme.estate, @scheme), class: 'govuk-button govuk-button--secondary mb0')
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -35,6 +35,11 @@ en:
       comments:
         create: 'Create Comment'
         edit: 'Update Comment'
+  page_content:
+    scheme:
+      show:
+        priorities:
+          no_priorities: 'There are no priotities set yet. You need to create them.'
   error_pages:
     unprocessable_entity: 'Cannot process this request'
   generic:
@@ -57,6 +62,13 @@ en:
     defect:
       title:
         description: 'This will be how this defect is described to residents in status notifications'
+    priority:
+      code:
+        label: 'Priority code'
+        hint: 'For example P1.'
+      days:
+        label: 'Duration in days'
+        hint: 'For example 1.'
   email:
     defect:
       forward:

--- a/spec/features/anyone_can_update_a_scheme_spec.rb
+++ b/spec/features/anyone_can_update_a_scheme_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature 'Anyone can update a scheme' do
 
     visit estate_scheme_path(scheme.estate, scheme)
 
-    within('.scheme_information') do
+    within('.scheme_contractor') do
       expect(page).to have_content(scheme.contractor_name)
       expect(page).to have_content(scheme.contractor_email_address)
     end

--- a/spec/features/anyone_can_view_a_defect_spec.rb
+++ b/spec/features/anyone_can_view_a_defect_spec.rb
@@ -34,11 +34,17 @@ RSpec.feature 'Anyone can view a defect' do
       expect(page).to have_content(defect.status)
     end
 
-    within('.scheme_information') do
-      expect(page).to have_content(defect.property.scheme.estate.name)
+    within('.scheme_information.scheme_name_and_estate') do
       expect(page).to have_content(defect.property.scheme.name)
+      expect(page).to have_content(defect.property.scheme.estate.name)
+    end
+
+    within('.scheme_information.scheme_contractor') do
       expect(page).to have_content(defect.property.scheme.contractor_name)
       expect(page).to have_content(defect.property.scheme.contractor_email_address)
+    end
+
+    within('.scheme_information.scheme_agent') do
       expect(page).to have_content(defect.property.scheme.employer_agent_name)
       expect(page).to have_content(defect.property.scheme.employer_agent_email_address)
     end

--- a/spec/features/anyone_can_view_a_property_spec.rb
+++ b/spec/features/anyone_can_view_a_property_spec.rb
@@ -17,11 +17,17 @@ RSpec.feature 'Anyone can view a property' do
 
     expect(page).to have_content(I18n.t('page_title.staff.properties.show', name: property.address))
 
-    within('.scheme_information') do
+    within('.scheme_information.scheme_name_and_estate') do
       expect(page).to have_content(property.scheme.estate.name)
       expect(page).to have_content(property.scheme.name)
+    end
+
+    within('.scheme_information.scheme_contractor') do
       expect(page).to have_content(property.scheme.contractor_name)
       expect(page).to have_content(property.scheme.contractor_email_address)
+    end
+
+    within('.scheme_information.scheme_agent') do
       expect(page).to have_content(property.scheme.employer_agent_name)
       expect(page).to have_content(property.scheme.employer_agent_email_address)
     end

--- a/spec/features/anyone_can_view_a_scheme_spec.rb
+++ b/spec/features/anyone_can_view_a_scheme_spec.rb
@@ -62,7 +62,9 @@ RSpec.feature 'Anyone can view a scheme' do
 
     visit estate_scheme_path(scheme.estate, scheme)
     within('.scheme-priorities') do
-      expect(page).to have_content('There are no priotities set yet. You need to create them.')
+      expect(page).to have_content(
+        I18n.t('page_content.scheme.show.priorities.no_priorities')
+      )
     end
   end
 end

--- a/spec/features/anyone_can_view_a_scheme_spec.rb
+++ b/spec/features/anyone_can_view_a_scheme_spec.rb
@@ -16,10 +16,17 @@ RSpec.feature 'Anyone can view a scheme' do
 
     expect(page).to have_content(I18n.t('page_title.staff.schemes.show', name: scheme.name))
 
-    within('.scheme_information') do
+    within('.scheme_information.scheme_name_and_estate') do
+      expect(page).to have_content(scheme.estate.name)
       expect(page).to have_content(scheme.name)
+    end
+
+    within('.scheme_information.scheme_contractor') do
       expect(page).to have_content(scheme.contractor_name)
       expect(page).to have_content(scheme.contractor_email_address)
+    end
+
+    within('.scheme_information.scheme_agent') do
       expect(page).to have_content(scheme.employer_agent_name)
       expect(page).to have_content(scheme.employer_agent_email_address)
     end
@@ -47,6 +54,15 @@ RSpec.feature 'Anyone can view a scheme' do
         I18n.t('page_title.staff.estates.show', name: scheme.estate.name),
         href: estate_path(scheme.estate)
       )
+    end
+  end
+
+  scenario 'when there are no priorities' do
+    scheme = create(:scheme)
+
+    visit estate_scheme_path(scheme.estate, scheme)
+    within('.scheme-priorities') do
+      expect(page).to have_content('There are no priotities set yet. You need to create them.')
     end
   end
 end


### PR DESCRIPTION
## Changes in this PR:
Design for the scheme and estates view, mobile friendly
Table headings have default styles, the h2 weren't needed

create a priority page input is shorter, improved content

## Screenshots of UI changes:

### Before

### After

#### Scheme view

![Screenshot_2019-06-19 Maple tree scheme — Report a Defect](https://user-images.githubusercontent.com/2632224/59770867-9a243e80-92a0-11e9-9186-f3ae9094b457.png)

#### Estate view

<img width="1328" alt="Screenshot 2019-06-18 at 14 25 32" src="https://user-images.githubusercontent.com/2632224/59770922-b627e000-92a0-11e9-8ca0-1d8736014c13.png">

#### Create a Priority new content and input width

<img width="1318" alt="Screenshot 2019-06-19 at 14 40 30" src="https://user-images.githubusercontent.com/2632224/59770960-c8098300-92a0-11e9-83a9-2a018d719ad1.png">

#### Scheme view when priority is not set

<img width="1350" alt="Screenshot 2019-06-19 at 15 24 47" src="https://user-images.githubusercontent.com/2632224/59773982-81b72280-92a6-11e9-8fce-f18644fe8438.png">

#### Defect view slightly changed due to changed partials

![Screenshot_2019-06-19 Defect E569F7 — Report a Defect](https://user-images.githubusercontent.com/2632224/59774143-df4b6f00-92a6-11e9-82c9-259649f0828a.png)







