### PR TITLE
Track communal state explicitly

### DIFF
--- a/app/controllers/staff/communal_defects_controller.rb
+++ b/app/controllers/staff/communal_defects_controller.rb
@@ -11,7 +11,7 @@ class Staff::CommunalDefectsController < Staff::BaseController
     @defect = BuildDefect.new(defect_params: defect_params, options: options).call
 
     if @defect.valid?
-      SaveDefect.new(defect: @defect).call
+      SaveCommunalDefect.new(defect: @defect).call
       flash[:success] = I18n.t('generic.notice.create.success', resource: 'defect')
       redirect_to block_path(@block)
     else

--- a/app/controllers/staff/property_defects_controller.rb
+++ b/app/controllers/staff/property_defects_controller.rb
@@ -11,7 +11,7 @@ class Staff::PropertyDefectsController < Staff::BaseController
     @defect = BuildDefect.new(defect_params: defect_params, options: options).call
 
     if @defect.valid?
-      SaveDefect.new(defect: @defect).call
+      SavePropertyDefect.new(defect: @defect).call
       flash[:success] = I18n.t('generic.notice.create.success', resource: 'defect')
       redirect_to property_path(@property)
     else

--- a/app/services/save_defect.rb
+++ b/app/services/save_defect.rb
@@ -24,3 +24,16 @@ class SaveDefect
     defect.create_activity key: 'defect.forwarded_to_employer_agent', owner: nil
   end
 end
+
+class SavePropertyDefect < SaveDefect
+  def call
+    super
+  end
+end
+
+class SaveCommunalDefect < SaveDefect
+  def call
+    defect.communal = true
+    super
+  end
+end

--- a/db/migrate/20190624093428_add_communal_to_defects.rb
+++ b/db/migrate/20190624093428_add_communal_to_defects.rb
@@ -1,0 +1,9 @@
+class AddCommunalToDefects < ActiveRecord::Migration[5.2]
+  def up
+    add_column :defects, :communal, :boolean, default: false
+  end
+
+  def down
+    remove_column :defects, :communal
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_20_173252) do
+ActiveRecord::Schema.define(version: 2019_06_24_093428) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -69,6 +69,7 @@ ActiveRecord::Schema.define(version: 2019_06_20_173252) do
     t.string "title"
     t.uuid "block_id"
     t.string "access_information"
+    t.boolean "communal", default: false
     t.index ["block_id"], name: "index_defects_on_block_id"
     t.index ["priority_id"], name: "index_defects_on_priority_id"
     t.index ["property_id"], name: "index_defects_on_property_id"

--- a/spec/services/save_defect_spec.rb
+++ b/spec/services/save_defect_spec.rb
@@ -78,3 +78,25 @@ RSpec.describe SaveDefect do
     end
   end
 end
+
+RSpec.describe SavePropertyDefect do
+  describe '#call' do
+    let(:defect) { create(:property_defect) }
+
+    it 'leaves communal as false' do
+      described_class.new(defect: defect).call
+      expect(defect.communal).to eq(false)
+    end
+  end
+end
+
+RSpec.describe SaveCommunalDefect do
+  describe '#call' do
+    let(:defect) { create(:communal_defect) }
+
+    it 'sets communal to true' do
+      described_class.new(defect: defect).call
+      expect(defect.communal).to eq(true)
+    end
+  end
+end


### PR DESCRIPTION
* 25% of defects are not communal, so a default of false has been used
* Using inheritance to manage the different behaviours involved in creating a defect, as opposed to passing a list of options through to the same SaveDefect service. This may seem like overkill at the moment but in future will allow us to more easily extend each journey in isolation
* This data could already be acquired by checking for a present association between with a property, or a block. However this will give us explicit data that we can expose via an API back to other Hackney services
