### PR TITLE
Times used in defect emails are formatted and correctly zoned

### DIFF
--- a/app/helpers/datetime_helper.rb
+++ b/app/helpers/datetime_helper.rb
@@ -8,6 +8,10 @@ module DatetimeHelper
   end
 
   def format_time(time)
+    time.in_time_zone.strftime('%H:%M%P, %-d %B %Y')
+  end
+
+  def format_time_in_sentence(time)
     time.in_time_zone.strftime('at %H:%M%P on %-d %B %Y')
   end
 end

--- a/app/presenters/defect_mail_presenter.rb
+++ b/app/presenters/defect_mail_presenter.rb
@@ -1,4 +1,6 @@
 class DefectMailPresenter < SimpleDelegator
+  include DatetimeHelper
+
   delegate :contractor_name, to: :scheme
   delegate :contractor_email_address, to: :scheme
   delegate :name, to: :priority, prefix: :priority
@@ -13,5 +15,9 @@ class DefectMailPresenter < SimpleDelegator
 
   def location
     property.present? ? 'Property' : 'Communal'
+  end
+
+  def created_time
+    format_time(created_at)
   end
 end

--- a/app/views/defect_mailer/forward_to_contractor.html.haml
+++ b/app/views/defect_mailer/forward_to_contractor.html.haml
@@ -1,7 +1,7 @@
 \# #{t('app.title')}
 \
 = "#{I18n.t('email.defect.forward.headings.title.reference_number')} : #{@presenter.reference_number}"
-= "#{I18n.t('email.defect.forward.headings.title.created_at')}: #{@presenter.created_at.to_s(:default)}"
+= "#{I18n.t('email.defect.forward.headings.title.created_at')}: #{@presenter.created_time}"
 = "#{I18n.t('email.defect.forward.headings.title.reporting_officer')}: Hackney New Build team"
 \
 = "#{I18n.t('email.defect.forward.headings.title.address')}: #{@presenter.address}"

--- a/app/views/defect_mailer/forward_to_employer_agent.html.haml
+++ b/app/views/defect_mailer/forward_to_employer_agent.html.haml
@@ -1,7 +1,7 @@
 \# #{t('app.title')}
 \
 = "#{I18n.t('email.defect.forward.headings.title.reference_number')} : #{@presenter.reference_number}"
-= "#{I18n.t('email.defect.forward.headings.title.created_at')}: #{@presenter.created_at.to_s(:default)}"
+= "#{I18n.t('email.defect.forward.headings.title.created_at')}: #{@presenter.created_time}"
 = "#{I18n.t('email.defect.forward.headings.title.reporting_officer')}: Hackney New Build team"
 \
 = "#{I18n.t('email.defect.forward.headings.title.address')}: #{@presenter.address}"

--- a/app/views/shared/comments/_list.html.haml
+++ b/app/views/shared/comments/_list.html.haml
@@ -12,6 +12,6 @@
             #{comment.user.name}
           %span.visually-hidden
             posted
-          %time.govuk-body-s= format_time(comment.created_at)
+          %time.govuk-body-s= format_time_in_sentence(comment.created_at)
       .comment-body.comment
         %p.govuk-body= comment.message

--- a/app/views/shared/events/_list.html.haml
+++ b/app/views/shared/events/_list.html.haml
@@ -5,4 +5,4 @@
         %p.govuk-body.media-heading
           %span{class: 'author govuk-body-s govuk-!-font-weight-bold'}
             = event_description_for(event: event)
-          %time.govuk-body-s= format_time(event.created_at)
+          %time.govuk-body-s= format_time_in_sentence(event.created_at)

--- a/spec/helpers/date_format_helper_spec.rb
+++ b/spec/helpers/date_format_helper_spec.rb
@@ -7,17 +7,32 @@ RSpec.describe DatetimeHelper, type: :helper do
     end
   end
 
-  describe '#format_time' do
+  describe '#format_time_in_sentence' do
     it 'returns the time and date in the default format' do
-      expect(helper.format_time(Time.zone.local(2017, 10, 7, 9, 45)))
+      expect(helper.format_time_in_sentence(Time.zone.local(2017, 10, 7, 9, 45)))
         .to eq 'at 09:45am on 7 October 2017'
     end
 
     context 'when the time zone is BST' do
       it 'renders the time +1 hour on top of UTC' do
         time = Time.utc(2017, 10, 7, 9, 45)
-        expect(helper.format_time(time))
+        expect(helper.format_time_in_sentence(time))
           .to eq 'at 10:45am on 7 October 2017'
+      end
+    end
+  end
+
+  describe '#format_time' do
+    it 'returns the time and date in the default format' do
+      expect(helper.format_time(Time.zone.local(2017, 10, 7, 9, 45)))
+        .to eq '09:45am, 7 October 2017'
+    end
+
+    context 'when the time zone is BST' do
+      it 'renders the time +1 hour on top of UTC' do
+        time = Time.utc(2017, 10, 7, 9, 45)
+        expect(helper.format_time(time))
+          .to eq '10:45am, 7 October 2017'
       end
     end
   end

--- a/spec/mailers/defect_spec.rb
+++ b/spec/mailers/defect_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe DefectMailer, type: :mailer do
       expect(mail.to).to eq([defect.scheme.contractor_email_address])
       expect(body_lines[0].strip).to match(/# #{I18n.t('app.title')}/)
       expect(body_lines[2].strip).to match("#{I18n.t('email.defect.forward.headings.title.reference_number')} : #{presenter.reference_number}")
-      expect(body_lines[3].strip).to match("#{I18n.t('email.defect.forward.headings.title.created_at')}: #{presenter.created_at.to_s(:default)}")
+      expect(body_lines[3].strip).to match("#{I18n.t('email.defect.forward.headings.title.created_at')}: #{presenter.created_time}")
       expect(body_lines[4].strip).to match("#{I18n.t('email.defect.forward.headings.title.reporting_officer')}: #{presenter.reporting_officer}")
       expect(body_lines[6].strip).to match("#{I18n.t('email.defect.forward.headings.title.address')}: #{presenter.address}")
       expect(body_lines[7].strip).to match("#{I18n.t('email.defect.forward.headings.title.location')}: #{presenter.location}")

--- a/spec/presenters/defect_mail_presenter_spec.rb
+++ b/spec/presenters/defect_mail_presenter_spec.rb
@@ -12,10 +12,24 @@ RSpec.describe DefectMailPresenter do
     end
   end
 
-  describe '#created_at' do
+  describe '#created_time' do
     it 'returns the created at timestamp' do
       result = described_class.new(property_defect).created_at
       expect(result).to eq(property_defect.created_at)
+    end
+
+    context 'when the time is UTC' do
+      it 'returns the time in GMT' do
+        # rubocop:disable Rails/TimeZone
+        utc_time = Time.new(2017, 10, 30, 13)
+        # rubocop:enable Rails/TimeZone
+
+        property_defect.update(created_at: utc_time)
+
+        result = described_class.new(property_defect).created_time
+
+        expect(result).to eql('13:00pm, 30 October 2017')
+      end
     end
   end
 


### PR DESCRIPTION
## Screenshots of UI changes:

### Before
![Screenshot 2019-06-25 at 13 20 25](https://user-images.githubusercontent.com/912473/60101298-6be8a800-9753-11e9-9b26-cb84379d0111.png)

### After
<img width="471" alt="Screenshot 2019-06-25 at 14 12 17" src="https://user-images.githubusercontent.com/912473/60101307-7145f280-9753-11e9-871f-bf9fd589ea35.png">
