### PR TITLE
[142] Defects that are accepted show the date in the summary

### DIFF
--- a/app/models/defect.rb
+++ b/app/models/defect.rb
@@ -1,4 +1,5 @@
 class Defect < ApplicationRecord
+  include DatetimeHelper
   before_validation :set_completion_date
   validates :title,
             :description,
@@ -95,5 +96,12 @@ class Defect < ApplicationRecord
       purpose: :accept_defect_ownership,
       expires_in: 3.months
     )
+  end
+
+  def accepted_on
+    acceptance_event = activities.find_by(key: 'defect.accepted')
+    return I18n.t('page_content.defect.show.not_accepted_yet') unless acceptance_event
+
+    format_time(acceptance_event.created_at)
   end
 end

--- a/app/views/shared/defects/_summary_information.html.haml
+++ b/app/views/shared/defects/_summary_information.html.haml
@@ -11,8 +11,8 @@
     %dt.govuk-summary-list__key Target date
     %dd.govuk-summary-list__value= format_date(defect.target_completion_date)
   %div.govuk-summary-list__row
-    %dt.govuk-summary-list__key Accepted by #{defect.scheme.contractor_name} on
-    %dd.govuk-summary-list__value= '22 Nov 2018'
+    %dt.govuk-summary-list__key Accepted time
+    %dd.govuk-summary-list__value= defect.accepted_on
   %div.govuk-summary-list__row
     %dt.govuk-summary-list__key Trade
     %dd.govuk-summary-list__value= defect.trade

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -48,6 +48,9 @@ en:
       show:
         priorities:
           no_priorities: 'There are no priotities set yet. You need to create them.'
+    defect:
+      show:
+        not_accepted_yet: 'Waiting on the contractor to accept'
   error_pages:
     unprocessable_entity: 'Cannot process this request'
   generic:

--- a/spec/models/defect_spec.rb
+++ b/spec/models/defect_spec.rb
@@ -113,4 +113,29 @@ RSpec.describe Defect, type: :model do
       end
     end
   end
+
+  describe '#accepted_on' do
+    before(:each) do
+      travel_to Time.zone.parse('2019-05-23')
+    end
+
+    after(:each) do
+      travel_back
+    end
+
+    context 'when the defect has been accepted' do
+      it 'returns the time of acceptance' do
+        defect = create(:property_defect)
+        PublicActivity::Activity.create(trackable: defect, key: 'defect.accepted')
+        expect(defect.accepted_on).to eq('00:00am, 23 May 2019')
+      end
+    end
+
+    context 'when the defect has NOT been accepted' do
+      it 'returns an explanation' do
+        defect = create(:property_defect)
+        expect(defect.accepted_on).to eq(I18n.t('page_content.defect.show.not_accepted_yet'))
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Screenshots of UI changes:

### Before

It was hardcoded after the recent redesign of the defects page.

### After
<img width="461" alt="Screenshot 2019-06-25 at 14 36 56" src="https://user-images.githubusercontent.com/912473/60103043-c9322880-9756-11e9-8035-ec33fff2292c.png">
<img width="466" alt="Screenshot 2019-06-25 at 14 36 51" src="https://user-images.githubusercontent.com/912473/60103044-c9cabf00-9756-11e9-9b66-d2c3389e082e.png">
