### PR TITLE
[146] Switching between making different types of defect

### DIFF
--- a/app/views/staff/comments/new.html.haml
+++ b/app/views/staff/comments/new.html.haml
@@ -15,4 +15,4 @@
                   as: :text,
                   input_html: { rows: 10 },
                   required: true
-      = f.button :submit, I18n.t('generic.button.create', resource: 'Comment')
+      = f.button :submit, I18n.t('button.create.comment')

--- a/app/views/staff/communal_areas/edit.html.haml
+++ b/app/views/staff/communal_areas/edit.html.haml
@@ -18,4 +18,4 @@
         = f.input :location,
                   hint: I18n.t('form.communal_area.location.hint'),
                   placeholder: I18n.t('form.communal_area.location.placeholder')
-      = f.button :submit, I18n.t('generic.button.update', resource: 'Communal Area')
+      = f.button :submit, I18n.t('button.update.communal_area')

--- a/app/views/staff/communal_areas/new.html.haml
+++ b/app/views/staff/communal_areas/new.html.haml
@@ -18,4 +18,4 @@
         = f.input :location,
                   hint: I18n.t('form.communal_area.location.hint'),
                   placeholder: I18n.t('form.communal_area.location.placeholder')
-      = f.button :submit, I18n.t('generic.button.create', resource: 'Communal Area')
+      = f.button :submit, I18n.t('button.create.communal_area')

--- a/app/views/staff/communal_areas/show.html.haml
+++ b/app/views/staff/communal_areas/show.html.haml
@@ -28,6 +28,7 @@
 
     .govuk-grid-column-full
       = link_to(I18n.t('button.create.communal_defect'), new_communal_area_defect_path(@communal_area), class: 'govuk-button mb0')
+      = link_to(I18n.t('button.create.property_defect'), estate_scheme_path(@communal_area.scheme.estate, @communal_area.scheme, anchor: 'properties'), class: 'govuk-button govuk-button--secondary mb0')
 
     .govuk-grid-column-full
       = render partial: '/shared/defects/table', locals: { scheme: @communal_area.scheme, defects: @communal_area.defects, parent: @communal_area }

--- a/app/views/staff/communal_areas/show.html.haml
+++ b/app/views/staff/communal_areas/show.html.haml
@@ -27,7 +27,7 @@
         = I18n.t('page_content.communal_area.table.header')
 
     .govuk-grid-column-full
-      = link_to(I18n.t('generic.button.create', resource: 'communal defect'), new_communal_area_defect_path(@communal_area), class: 'govuk-button mb0')
+      = link_to(I18n.t('button.create.communal_defect'), new_communal_area_defect_path(@communal_area), class: 'govuk-button mb0')
 
     .govuk-grid-column-full
       = render partial: '/shared/defects/table', locals: { scheme: @communal_area.scheme, defects: @communal_area.defects, parent: @communal_area }

--- a/app/views/staff/communal_defects/edit.html.haml
+++ b/app/views/staff/communal_defects/edit.html.haml
@@ -61,4 +61,4 @@
                 selected: @defect.priority,
                 label_method: ->(obj){ priority_form_label(priority: obj) }
 
-      = f.button :submit, I18n.t('generic.button.update', resource: 'Defect')
+      = f.button :submit, I18n.t('button.update.defect')

--- a/app/views/staff/communal_defects/new.html.haml
+++ b/app/views/staff/communal_defects/new.html.haml
@@ -41,4 +41,4 @@
                   required: true,
                   selected: @defect.priority,
                   label_method: ->(obj){ priority_form_label(priority: obj) }
-      = f.button :submit, I18n.t('generic.button.create', resource: 'communal defect')
+      = f.button :submit, I18n.t('button.create.communal_defect')

--- a/app/views/staff/communal_defects/show.html.haml
+++ b/app/views/staff/communal_defects/show.html.haml
@@ -9,7 +9,7 @@
 .govuk-grid-row
   .govuk-grid-column-one-half
     %h2.govuk-heading-m= @defect.title
-    = link_to(I18n.t('generic.button.edit', resource: 'Defect'), edit_communal_area_defect_path(@defect.communal_area, @defect), class: 'govuk-button govuk-button--secondary mb0')
+    = link_to(I18n.t('button.edit.defect'), edit_communal_area_defect_path(@defect.communal_area, @defect), class: 'govuk-button govuk-button--secondary mb0')
 
 .govuk-grid-row
   .govuk-grid-column-one-half.summary

--- a/app/views/staff/communal_defects/show.html.haml
+++ b/app/views/staff/communal_defects/show.html.haml
@@ -31,7 +31,7 @@
   .govuk-grid-column-one-half.comments
     %h2.govuk-heading-m
       Comments
-    = link_to(I18n.t('generic.button.create', resource: 'Comment'), new_defect_comment_path(@defect), class: 'govuk-button mb0')
+    = link_to(I18n.t('button.create.comment'), new_defect_comment_path(@defect), class: 'govuk-button mb0')
     = render partial: '/shared/comments/list', locals: { comments: @defect.comments }
 
   .govuk-grid-column-one-half.events

--- a/app/views/staff/dashboard/partials/_manage-estates.haml
+++ b/app/views/staff/dashboard/partials/_manage-estates.haml
@@ -1,7 +1,7 @@
 %p.govuk-body-s
   In this section you can view and create Estate records and add schemes, contractors, priorities and property addresses.
 
-= link_to(I18n.t('generic.button.create', resource: 'Estate'), new_estate_path, class: 'govuk-button govuk-button--secondary mb0')
+= link_to(I18n.t('button.create.estate'), new_estate_path, class: 'govuk-button govuk-button--secondary mb0')
 %table.govuk-table.estates
   %thead.govuk-table__head
     %tr.govuk-table__row

--- a/app/views/staff/estates/new.html.haml
+++ b/app/views/staff/estates/new.html.haml
@@ -11,4 +11,4 @@
     = simple_form_for @estate do |f|
       .form-group
         = f.input :name
-      = f.button :submit, I18n.t('generic.button.create', resource: 'Estate')
+      = f.button :submit, I18n.t('button.create.estate')

--- a/app/views/staff/estates/show.html.haml
+++ b/app/views/staff/estates/show.html.haml
@@ -8,7 +8,7 @@
 .govuk-grid-row
   .govuk-grid-column-two-thirds
     %h1.govuk-heading-l= I18n.t('page_title.staff.estates.show', name: @estate.name)
-    = link_to(I18n.t('generic.button.create', resource: 'Scheme'), new_estate_scheme_path(@estate), class: 'govuk-button mb0')
+    = link_to(I18n.t('button.create.scheme'), new_estate_scheme_path(@estate), class: 'govuk-button mb0')
 
 
     %h2.govuk-heading-m.section-heading

--- a/app/views/staff/priorities/new.html.haml
+++ b/app/views/staff/priorities/new.html.haml
@@ -23,4 +23,4 @@
                   label_html: { class: 'govuk-label'},
                   input_html: { class: 'govuk-input--width-3' }
 
-      = f.button :submit, I18n.t('generic.button.create', resource: 'Priority')
+      = f.button :submit, I18n.t('button.create.priority')

--- a/app/views/staff/properties/edit.html.haml
+++ b/app/views/staff/properties/edit.html.haml
@@ -13,4 +13,4 @@
         = f.input :address
         = f.input :postcode
         = f.input :uprn, label: 'Universal Property Reference Number (UPRN)'
-      = f.button :submit, I18n.t('generic.button.update', resource: 'Property')
+      = f.button :submit, I18n.t('button.update.property')

--- a/app/views/staff/properties/new.html.haml
+++ b/app/views/staff/properties/new.html.haml
@@ -13,4 +13,4 @@
         = f.input :address
         = f.input :postcode
         = f.input :uprn, label: 'Universal Property Reference Number (UPRN)'
-      = f.button :submit, I18n.t('generic.button.create', resource: 'Property')
+      = f.button :submit, I18n.t('button.create.property')

--- a/app/views/staff/properties/show.html.haml
+++ b/app/views/staff/properties/show.html.haml
@@ -27,7 +27,7 @@
       = I18n.t('page_content.property.table.header')
 
   .govuk-grid-column-full
-    = link_to(I18n.t('generic.button.create', resource: 'property defect'), new_property_defect_path(@property), class: 'govuk-button mb0')
+    = link_to(I18n.t('button.create.property_defect'), new_property_defect_path(@property), class: 'govuk-button mb0')
 
   .govuk-grid-column-full
     = render partial: '/shared/defects/table', locals: { scheme: @property.scheme, defects: @property.defects, parent: @property }

--- a/app/views/staff/properties/show.html.haml
+++ b/app/views/staff/properties/show.html.haml
@@ -28,6 +28,7 @@
 
   .govuk-grid-column-full
     = link_to(I18n.t('button.create.property_defect'), new_property_defect_path(@property), class: 'govuk-button mb0')
+    = link_to(I18n.t('button.create.communal_defect'), estate_scheme_path(@property.scheme.estate, @property.scheme, anchor: 'communal-areas'), class: 'govuk-button govuk-button--secondary mb0')
 
   .govuk-grid-column-full
     = render partial: '/shared/defects/table', locals: { scheme: @property.scheme, defects: @property.defects, parent: @property }

--- a/app/views/staff/property_defects/edit.html.haml
+++ b/app/views/staff/property_defects/edit.html.haml
@@ -56,4 +56,4 @@
                 selected: @defect.priority,
                 label_method: ->(obj){ priority_form_label(priority: obj) }
 
-      = f.button :submit, I18n.t('generic.button.update', resource: 'Defect')
+      = f.button :submit, I18n.t('button.update.defect')

--- a/app/views/staff/property_defects/new.html.haml
+++ b/app/views/staff/property_defects/new.html.haml
@@ -36,4 +36,4 @@
                   required: true,
                   selected: @defect.priority,
                   label_method: ->(obj){ priority_form_label(priority: obj) }
-      = f.button :submit, I18n.t('generic.button.create', resource: 'property defect')
+      = f.button :submit, I18n.t('button.create.property_defect')

--- a/app/views/staff/property_defects/show.html.haml
+++ b/app/views/staff/property_defects/show.html.haml
@@ -31,7 +31,7 @@
   .govuk-grid-column-one-half.comments
     %h2.govuk-heading-m
       Comments
-    = link_to(I18n.t('generic.button.create', resource: 'Comment'), new_defect_comment_path(@defect), class: 'govuk-button mb0')
+    = link_to(I18n.t('button.create.comment'), new_defect_comment_path(@defect), class: 'govuk-button mb0')
     = render partial: '/shared/comments/list', locals: { comments: @defect.comments }
 
   .govuk-grid-column-one-half.events

--- a/app/views/staff/property_defects/show.html.haml
+++ b/app/views/staff/property_defects/show.html.haml
@@ -9,7 +9,7 @@
 .govuk-grid-row
   .govuk-grid-column-one-half
     %h2.govuk-heading-m= @defect.title
-    = link_to(I18n.t('generic.button.edit', resource: 'Defect'), edit_property_defect_path(@defect.property, @defect), class: 'govuk-button govuk-button--secondary mb0')
+    = link_to(I18n.t('button.edit.defect'), edit_property_defect_path(@defect.property, @defect), class: 'govuk-button govuk-button--secondary mb0')
 
 .govuk-grid-row
   .govuk-grid-column-one-half.summary

--- a/app/views/staff/schemes/edit.html.haml
+++ b/app/views/staff/schemes/edit.html.haml
@@ -13,4 +13,4 @@
         = f.input :contractor_email_address
         = f.input :employer_agent_name
         = f.input :employer_agent_email_address
-      = f.button :submit, I18n.t('generic.button.update', resource: 'Scheme')
+      = f.button :submit, I18n.t('button.update.scheme')

--- a/app/views/staff/schemes/new.html.haml
+++ b/app/views/staff/schemes/new.html.haml
@@ -17,4 +17,4 @@
         = f.input :contractor_email_address
         = f.input :employer_agent_name
         = f.input :employer_agent_email_address
-      = f.button :submit, I18n.t('generic.button.create', resource: 'Scheme')
+      = f.button :submit, I18n.t('button.create.scheme')

--- a/app/views/staff/schemes/show.html.haml
+++ b/app/views/staff/schemes/show.html.haml
@@ -22,7 +22,7 @@
       = render partial: '/shared/schemes/information', locals: { scheme: @scheme }
     .govuk-grid-row
       .govuk-grid-column-full
-        = link_to(I18n.t('generic.button.edit', resource: 'Scheme'), edit_estate_scheme_path(@scheme.estate, @scheme), class: 'govuk-button govuk-button--secondary mb0')
+        = link_to(I18n.t('button.edit.scheme'), edit_estate_scheme_path(@scheme.estate, @scheme), class: 'govuk-button govuk-button--secondary mb0')
 
   .govuk-grid-column-full.govuk-grid-column-one-third-from-desktop.scheme-priorities
     %h3.govuk-heading-s

--- a/app/views/staff/schemes/show.html.haml
+++ b/app/views/staff/schemes/show.html.haml
@@ -34,18 +34,18 @@
       %p.govuk-body
         = I18n.t('page_content.scheme.show.priorities.no_priorities')
 
-    = link_to(I18n.t('generic.button.create', resource: 'Priority'), new_estate_scheme_priority_path(@scheme.estate, @scheme), class: 'govuk-button govuk-button--secondary mb0')
+    = link_to(I18n.t('button.create.priority'), new_estate_scheme_priority_path(@scheme.estate, @scheme), class: 'govuk-button govuk-button--secondary mb0')
 
 .govuk-grid-row
   .govuk-grid-column-full
-    %h2.govuk-heading-m.section-heading
+    %h2.govuk-heading-m.section-heading#communal-areas
       Communal Areas
-    = link_to(I18n.t('generic.button.create', resource: 'Communal Area'), new_estate_scheme_communal_area_path(@scheme.estate, @scheme), class: 'govuk-button mb0')
+    = link_to(I18n.t('button.create.communal_area'), new_estate_scheme_communal_area_path(@scheme.estate, @scheme), class: 'govuk-button mb0')
     = render partial: '/shared/communal_areas/table', locals: { communal_areas: @scheme.communal_areas }
 
 .govuk-grid-row
   .govuk-grid-column-full
     %h2.govuk-heading-m.section-heading
       Properties
-    = link_to(I18n.t('generic.button.create', resource: 'Property'), new_estate_scheme_property_path(@scheme.estate, @scheme), class: 'govuk-button mb0')
+    = link_to(I18n.t('button.create.property'), new_estate_scheme_property_path(@scheme.estate, @scheme), class: 'govuk-button mb0')
     = render partial: '/shared/properties/table', locals: { properties: @scheme.properties }

--- a/app/views/staff/schemes/show.html.haml
+++ b/app/views/staff/schemes/show.html.haml
@@ -45,7 +45,7 @@
 
 .govuk-grid-row
   .govuk-grid-column-full
-    %h2.govuk-heading-m.section-heading
+    %h2.govuk-heading-m.section-heading#properties
       Properties
     = link_to(I18n.t('button.create.property'), new_estate_scheme_property_path(@scheme.estate, @scheme), class: 'govuk-button mb0')
     = render partial: '/shared/properties/table', locals: { properties: @scheme.properties }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -66,7 +66,6 @@ en:
       show: 'View'
       edit: 'Edit'
     button:
-      edit: 'Edit %{resource}'
       find: 'Search'
     notice:
       create:
@@ -90,6 +89,9 @@ en:
       communal_area: 'Update communal area'
       property: 'Update property'
       defect: 'Update defect'
+    edit:
+      scheme: Edit scheme
+      defect: Edit defect
   form:
     communal_area:
       explanation: 'A communal area can be used to report and manage defects that are in a shared location rather than within an individual property.'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -66,7 +66,6 @@ en:
       show: 'View'
       edit: 'Edit'
     button:
-      update: 'Update %{resource}'
       edit: 'Edit %{resource}'
       find: 'Search'
     notice:
@@ -86,6 +85,11 @@ en:
       property_defect: 'Create property defect'
       communal_defect: 'Create communal defect'
       comment: 'Create comment'
+    update:
+      scheme: 'Update scheme'
+      communal_area: 'Update communal area'
+      property: 'Update property'
+      defect: 'Update defect'
   form:
     communal_area:
       explanation: 'A communal area can be used to report and manage defects that are in a shared location rather than within an individual property.'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -66,7 +66,6 @@ en:
       show: 'View'
       edit: 'Edit'
     button:
-      create: 'Create %{resource}'
       update: 'Update %{resource}'
       edit: 'Edit %{resource}'
       find: 'Search'
@@ -77,6 +76,16 @@ en:
       update:
         success:
           'The %{resource} has successfully been updated.'
+  button:
+    create:
+      estate: 'Create estate'
+      scheme: 'Create scheme'
+      communal_area: 'Create communal area'
+      property: 'Create property'
+      priority: 'Create priority'
+      property_defect: 'Create property defect'
+      communal_defect: 'Create communal defect'
+      comment: 'Create comment'
   form:
     communal_area:
       explanation: 'A communal area can be used to report and manage defects that are in a shared location rather than within an individual property.'

--- a/spec/features/anyone_can_create_a_comment_spec.rb
+++ b/spec/features/anyone_can_create_a_comment_spec.rb
@@ -33,13 +33,13 @@ RSpec.feature 'Anyone can create a comment' do
         click_on(I18n.t('generic.link.show'))
       end
 
-      expect(page).to have_content(I18n.t('page_title.staff.comments.create'))
+      expect(page).to have_content(I18n.t('button.create.comment'))
 
-      click_on(I18n.t('generic.button.create', resource: 'Comment'))
+      click_on(I18n.t('button.create.comment'))
 
       within('form.new_comment') do
         fill_in 'comment[message]', with: 'None of the electrics work'
-        click_on(I18n.t('generic.button.create', resource: 'Comment'))
+        click_on(I18n.t('button.create.comment'))
       end
 
       expect(page).to have_content(I18n.t('generic.notice.create.success', resource: 'comment'))
@@ -85,13 +85,11 @@ RSpec.feature 'Anyone can create a comment' do
         click_on(I18n.t('generic.link.show'))
       end
 
-      expect(page).to have_content(I18n.t('page_title.staff.comments.create'))
-
-      click_on(I18n.t('generic.button.create', resource: 'Comment'))
+      click_on(I18n.t('button.create.comment'))
 
       within('form.new_comment') do
         fill_in 'comment[message]', with: 'None of the electrics work'
-        click_on(I18n.t('generic.button.create', resource: 'Comment'))
+        click_on(I18n.t('button.create.comment'))
       end
 
       expect(page).to have_content(I18n.t('generic.notice.create.success', resource: 'comment'))
@@ -122,7 +120,7 @@ RSpec.feature 'Anyone can create a comment' do
     expect(page).to have_content(I18n.t('page_title.staff.comments.create'))
     within('form.new_comment') do
       # Deliberately forget to fill out the required name field
-      click_on(I18n.t('generic.button.create', resource: 'Comment'))
+      click_on(I18n.t('button.create.comment'))
     end
 
     within('.comment_message') do

--- a/spec/features/anyone_can_create_a_communal_area_spec.rb
+++ b/spec/features/anyone_can_create_a_communal_area_spec.rb
@@ -8,14 +8,14 @@ RSpec.feature 'Anyone can create a communal_area' do
 
     expect(page).to have_content(I18n.t('page_title.staff.schemes.show', name: scheme.name))
 
-    click_on(I18n.t('generic.button.create', resource: 'Communal Area'))
+    click_on(I18n.t('button.create.communal_area'))
 
     expect(page).to have_content(I18n.t('page_title.staff.communal_areas.create'))
     expect(page).to have_content(I18n.t('form.communal_area.explanation'))
     within('form.new_communal_area') do
       fill_in 'communal_area[name]', with: 'Chipping'
       fill_in 'communal_area[location]', with: '22-25 Chipping Road'
-      click_on(I18n.t('generic.button.create', resource: 'Communal Area'))
+      click_on(I18n.t('button.create.communal_area'))
     end
 
     expect(page).to have_content(I18n.t('generic.notice.create.success', resource: 'Communal Area'))
@@ -30,12 +30,12 @@ RSpec.feature 'Anyone can create a communal_area' do
 
     expect(page).to have_content(I18n.t('page_title.staff.schemes.show', name: scheme.name))
 
-    click_on(I18n.t('generic.button.create', resource: 'Communal Area'))
+    click_on(I18n.t('button.create.communal_area'))
 
     expect(page).to have_content(I18n.t('page_title.staff.communal_areas.create'))
     within('form.new_communal_area') do
       # Deliberately forget to fill out the required name field
-      click_on(I18n.t('generic.button.create', resource: 'Communal Area'))
+      click_on(I18n.t('button.create.communal_area'))
     end
 
     within('.communal_area_name') do

--- a/spec/features/anyone_can_create_a_communal_defect_spec.rb
+++ b/spec/features/anyone_can_create_a_communal_defect_spec.rb
@@ -84,4 +84,19 @@ RSpec.feature 'Anyone can create a defect for a communal_area' do
       expect(page).to have_content("can't be blank")
     end
   end
+
+  scenario 'a property defect can be created after finishing the creation of a communal defect' do
+    communal_defect = create(:communal_defect)
+
+    # Skip a manual defect creation when it's not the part under test
+    visit communal_area_path(communal_defect.communal_area)
+
+    expect(page).to have_link(
+      I18n.t('button.create.property_defect'),
+      href: estate_scheme_path(communal_defect.scheme.estate, communal_defect.scheme, anchor: 'properties')
+    )
+    click_on(I18n.t('button.create.property_defect'))
+
+    expect(page).to have_content(I18n.t('page_title.staff.schemes.show', name: communal_defect.scheme.name))
+  end
 end

--- a/spec/features/anyone_can_create_a_communal_defect_spec.rb
+++ b/spec/features/anyone_can_create_a_communal_defect_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature 'Anyone can create a defect for a communal_area' do
 
     expect(page).to have_content(I18n.t('page_title.staff.communal_areas.show', name: communal_area.name))
 
-    click_on(I18n.t('generic.button.create', resource: 'communal defect'))
+    click_on(I18n.t('button.create.communal_defect'))
 
     expect(page).to have_content(I18n.t('page_title.staff.defects.create.communal_area'))
 
@@ -36,7 +36,7 @@ RSpec.feature 'Anyone can create a defect for a communal_area' do
       fill_in 'defect[contact_phone_number]', with: '07123456789'
       select 'Electrical', from: 'defect[trade]'
       choose priority.name
-      click_on(I18n.t('generic.button.create', resource: 'communal defect'))
+      click_on(I18n.t('button.create.communal_defect'))
     end
 
     expect(page).to have_content(I18n.t('generic.notice.create.success', resource: 'defect'))
@@ -64,12 +64,12 @@ RSpec.feature 'Anyone can create a defect for a communal_area' do
 
     visit communal_area_path(communal_area)
 
-    click_on(I18n.t('generic.button.create', resource: 'communal defect'))
+    click_on(I18n.t('button.create.communal_defect'))
 
     expect(page).to have_content(I18n.t('page_title.staff.defects.create.communal_area'))
     within('form.new_defect') do
       # Deliberately forget to fill out the required name field
-      click_on(I18n.t('generic.button.create', resource: 'communal defect'))
+      click_on(I18n.t('button.create.communal_defect'))
     end
 
     within('.defect_description') do

--- a/spec/features/anyone_can_create_a_priority_spec.rb
+++ b/spec/features/anyone_can_create_a_priority_spec.rb
@@ -21,13 +21,13 @@ RSpec.feature 'Anyone can create a priority for a scheme' do
 
     expect(page).to have_content(I18n.t('page_title.staff.schemes.show', name: scheme.name))
 
-    click_on(I18n.t('generic.button.create', resource: 'Priority'))
+    click_on(I18n.t('button.create.priority'))
     expect(page).to have_content(I18n.t('page_title.staff.priorities.create'))
 
     within('form.new_priority') do
       fill_in 'priority[name]', with: 'P1'
       fill_in 'priority[days]', with: 1
-      click_on(I18n.t('generic.button.create', resource: 'Priority'))
+      click_on(I18n.t('button.create.priority'))
     end
 
     expect(page).to have_content(I18n.t('generic.notice.create.success', resource: 'priority'))
@@ -45,7 +45,7 @@ RSpec.feature 'Anyone can create a priority for a scheme' do
 
     within('form.new_priority') do
       # Deliberately forget to fill out the required name fields
-      click_on(I18n.t('generic.button.create', resource: 'Priority'))
+      click_on(I18n.t('button.create.priority'))
     end
 
     within('.priority_name') do

--- a/spec/features/anyone_can_create_a_property_defect_spec.rb
+++ b/spec/features/anyone_can_create_a_property_defect_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature 'Anyone can create a defect for a property' do
 
     expect(page).to have_content(I18n.t('page_title.staff.properties.show', name: property.address))
 
-    click_on(I18n.t('generic.button.create', resource: 'property defect'))
+    click_on(I18n.t('button.create.property_defect'))
 
     expect(page).to have_content(I18n.t('page_title.staff.defects.create.property'))
 
@@ -36,7 +36,7 @@ RSpec.feature 'Anyone can create a defect for a property' do
       fill_in 'defect[contact_phone_number]', with: '07123456789'
       select 'Electrical', from: 'defect[trade]'
       choose priority.name
-      click_on(I18n.t('generic.button.create', resource: 'property defect'))
+      click_on(I18n.t('button.create.property_defect'))
     end
 
     expect(page).to have_content(I18n.t('generic.notice.create.success', resource: 'defect'))
@@ -64,12 +64,12 @@ RSpec.feature 'Anyone can create a defect for a property' do
 
     visit property_path(property)
 
-    click_on(I18n.t('generic.button.create', resource: 'property defect'))
+    click_on(I18n.t('button.create.property_defect'))
 
     expect(page).to have_content(I18n.t('page_title.staff.defects.create.property'))
     within('form.new_defect') do
       # Deliberately forget to fill out the required name field
-      click_on(I18n.t('generic.button.create', resource: 'property defect'))
+      click_on(I18n.t('button.create.property_defect'))
     end
 
     within('.defect_description') do

--- a/spec/features/anyone_can_create_a_property_defect_spec.rb
+++ b/spec/features/anyone_can_create_a_property_defect_spec.rb
@@ -84,4 +84,19 @@ RSpec.feature 'Anyone can create a defect for a property' do
       expect(page).to have_content("can't be blank")
     end
   end
+
+  scenario 'a communal defect can be created after finishing the creation of a property defect' do
+    property_defect = create(:property_defect)
+
+    # Skip a manual defect creation when it's not the part under test
+    visit property_path(property_defect.property)
+
+    expect(page).to have_link(
+      I18n.t('button.create.communal_defect'),
+      href: estate_scheme_path(property_defect.scheme.estate, property_defect.scheme, anchor: 'communal-areas')
+    )
+    click_on(I18n.t('button.create.communal_defect'))
+
+    expect(page).to have_content(I18n.t('page_title.staff.schemes.show', name: property_defect.scheme.name))
+  end
 end

--- a/spec/features/anyone_can_create_a_property_spec.rb
+++ b/spec/features/anyone_can_create_a_property_spec.rb
@@ -8,14 +8,14 @@ RSpec.feature 'Anyone can create a property' do
 
     expect(page).to have_content(I18n.t('page_title.staff.schemes.show', name: scheme.name))
 
-    click_on(I18n.t('generic.button.create', resource: 'Property'))
+    click_on(I18n.t('button.create.property'))
 
     expect(page).to have_content(I18n.t('page_title.staff.properties.create'))
     within('form.new_property') do
       fill_in 'property[address]', with: 'Flat 1, Hackney Street'
       fill_in 'property[postcode]', with: 'N16NU'
       fill_in 'property[uprn]', with: '100081272892'
-      click_on(I18n.t('generic.button.create', resource: 'Property'))
+      click_on(I18n.t('button.create.property'))
     end
 
     expect(page).to have_content(I18n.t('generic.notice.create.success', resource: 'property'))
@@ -31,12 +31,12 @@ RSpec.feature 'Anyone can create a property' do
 
     expect(page).to have_content(I18n.t('page_title.staff.schemes.show', name: scheme.name))
 
-    click_on(I18n.t('generic.button.create', resource: 'Property'))
+    click_on(I18n.t('button.create.property'))
 
     expect(page).to have_content(I18n.t('page_title.staff.properties.create'))
     within('form.new_property') do
       # Deliberately forget to fill out the required name field
-      click_on(I18n.t('generic.button.create', resource: 'Property'))
+      click_on(I18n.t('button.create.property'))
     end
 
     within('.property_address') do

--- a/spec/features/anyone_can_create_a_scheme_spec.rb
+++ b/spec/features/anyone_can_create_a_scheme_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature 'Anyone can create a scheme' do
 
     expect(page).to have_content(I18n.t('page_title.staff.estates.show', name: estate.name))
 
-    click_on(I18n.t('generic.button.create', resource: 'Scheme'))
+    click_on(I18n.t('button.create.scheme'))
 
     expect(page).to have_content(I18n.t('page_title.staff.schemes.create'))
     within('form.new_scheme') do
@@ -17,7 +17,7 @@ RSpec.feature 'Anyone can create a scheme' do
       fill_in 'scheme[contractor_email_address]', with: 'email@example.com'
       fill_in 'scheme[employer_agent_name]', with: 'Alex'
       fill_in 'scheme[employer_agent_email_address]', with: 'alex@example.com'
-      click_on(I18n.t('generic.button.create', resource: 'Scheme'))
+      click_on(I18n.t('button.create.scheme'))
     end
 
     expect(page).to have_content(I18n.t('generic.notice.create.success', resource: 'scheme'))
@@ -40,12 +40,12 @@ RSpec.feature 'Anyone can create a scheme' do
 
     expect(page).to have_content(I18n.t('page_title.staff.estates.show', name: estate.name))
 
-    click_on(I18n.t('generic.button.create', resource: 'Scheme'))
+    click_on(I18n.t('button.create.scheme'))
 
     expect(page).to have_content(I18n.t('page_title.staff.schemes.create'))
     within('form.new_scheme') do
       # Deliberately forget to fill out the required name field
-      click_on(I18n.t('generic.button.create', resource: 'Scheme'))
+      click_on(I18n.t('button.create.scheme'))
     end
 
     within('.scheme_name') do

--- a/spec/features/anyone_can_create_an_estate_spec.rb
+++ b/spec/features/anyone_can_create_an_estate_spec.rb
@@ -6,12 +6,12 @@ RSpec.feature 'Anyone can create a estate' do
 
     expect(page).to have_content(I18n.t('page_title.staff.dashboard'))
 
-    click_on(I18n.t('generic.button.create', resource: 'Estate'))
+    click_on(I18n.t('button.create.estate'))
 
     expect(page).to have_content(I18n.t('page_title.staff.estates.create'))
     within('form.new_estate') do
       fill_in 'estate[name]', with: 'Kings Cresent'
-      click_on(I18n.t('generic.button.create', resource: 'Estate'))
+      click_on(I18n.t('button.create.estate'))
     end
 
     expect(page).to have_content(I18n.t('generic.notice.create.success', resource: 'estate'))
@@ -23,12 +23,12 @@ RSpec.feature 'Anyone can create a estate' do
   scenario 'an invalid estate cannot be submitted' do
     visit root_path
 
-    click_on(I18n.t('generic.button.create', resource: 'Estate'))
+    click_on(I18n.t('button.create.estate'))
 
     expect(page).to have_content(I18n.t('page_title.staff.estates.create'))
     within('form.new_estate') do
       # Deliberately forget to fill out the required name field
-      click_on(I18n.t('generic.button.create', resource: 'Estate'))
+      click_on(I18n.t('button.create.estate'))
     end
 
     within('.estate_name') do

--- a/spec/features/anyone_can_update_a_communal_area_spec.rb
+++ b/spec/features/anyone_can_update_a_communal_area_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature 'Anyone can update a communal_area' do
     within('form.edit_communal_area') do
       fill_in 'communal_area[name]', with: 'Darling'
       fill_in 'communal_area[location]', with: 'Darling Estate'
-      click_on(I18n.t('generic.button.update', resource: 'Communal Area'))
+      click_on(I18n.t('button.update.communal_area'))
     end
   end
 
@@ -36,7 +36,7 @@ RSpec.feature 'Anyone can update a communal_area' do
       fill_in 'communal_area[name]', with: ''
       fill_in 'communal_area[location]', with: ''
 
-      click_on(I18n.t('generic.button.update', resource: 'Communal Area'))
+      click_on(I18n.t('button.update.communal_area'))
     end
 
     within('.communal_area_name') do

--- a/spec/features/anyone_can_update_a_communal_defect_spec.rb
+++ b/spec/features/anyone_can_update_a_communal_defect_spec.rb
@@ -30,7 +30,7 @@ RSpec.feature 'Anyone can update a communal_area defect' do
       expect(page).to have_content(defect.target_completion_date)
 
       choose "#{new_priority.name} - #{new_priority.days} days from now"
-      click_on(I18n.t('generic.button.update', resource: 'Defect'))
+      click_on(I18n.t('button.update.defect'))
     end
 
     expect(page).to have_content(I18n.t('generic.notice.update.success', resource: 'defect'))
@@ -53,7 +53,7 @@ RSpec.feature 'Anyone can update a communal_area defect' do
 
     within('form.edit_defect') do
       select 'Completed', from: 'defect[status]'
-      click_on(I18n.t('generic.button.update', resource: 'Defect'))
+      click_on(I18n.t('button.update.defect'))
     end
 
     expect(page).to have_content(I18n.t('generic.notice.update.success', resource: 'defect'))
@@ -73,7 +73,7 @@ RSpec.feature 'Anyone can update a communal_area defect' do
       fill_in 'defect[description]', with: ''
       select '', from: 'defect[trade]'
 
-      click_on(I18n.t('generic.button.update', resource: 'Defect'))
+      click_on(I18n.t('button.update.defect'))
     end
 
     within('.defect_description') do
@@ -99,7 +99,7 @@ RSpec.feature 'Anyone can update a communal_area defect' do
 
     within('form.edit_defect') do
       # Do not choose a new priority
-      click_on(I18n.t('generic.button.update', resource: 'Defect'))
+      click_on(I18n.t('button.update.defect'))
     end
 
     expect(page).to have_content(I18n.t('generic.notice.update.success', resource: 'defect'))

--- a/spec/features/anyone_can_update_a_property_defect_spec.rb
+++ b/spec/features/anyone_can_update_a_property_defect_spec.rb
@@ -31,7 +31,7 @@ RSpec.feature 'Anyone can update a defect' do
       expect(page).to have_content(defect.target_completion_date)
 
       choose "#{priority.name} - #{priority.days} days from now"
-      click_on(I18n.t('generic.button.update', resource: 'Defect'))
+      click_on(I18n.t('button.update.defect'))
     end
 
     expect(page).to have_content(I18n.t('generic.notice.update.success', resource: 'defect'))
@@ -54,7 +54,7 @@ RSpec.feature 'Anyone can update a defect' do
 
     within('form.edit_defect') do
       select 'Completed', from: 'defect[status]'
-      click_on(I18n.t('generic.button.update', resource: 'Defect'))
+      click_on(I18n.t('button.update.defect'))
     end
 
     expect(page).to have_content(I18n.t('generic.notice.update.success', resource: 'defect'))
@@ -74,7 +74,7 @@ RSpec.feature 'Anyone can update a defect' do
       fill_in 'defect[description]', with: ''
       select '', from: 'defect[trade]'
 
-      click_on(I18n.t('generic.button.update', resource: 'Defect'))
+      click_on(I18n.t('button.update.defect'))
     end
 
     within('.defect_description') do
@@ -100,7 +100,7 @@ RSpec.feature 'Anyone can update a defect' do
 
     within('form.edit_defect') do
       # Do not choose a new priority
-      click_on(I18n.t('generic.button.update', resource: 'Defect'))
+      click_on(I18n.t('button.update.defect'))
     end
 
     expect(page).to have_content(I18n.t('generic.notice.update.success', resource: 'defect'))

--- a/spec/features/anyone_can_update_a_property_spec.rb
+++ b/spec/features/anyone_can_update_a_property_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature 'Anyone can update a property' do
     within('form.edit_property') do
       fill_in 'property[address]', with: 'Flat 1, Hackney Street'
       fill_in 'property[postcode]', with: 'N16NU'
-      click_on(I18n.t('generic.button.update', resource: 'Property'))
+      click_on(I18n.t('button.update.property'))
     end
   end
 
@@ -36,7 +36,7 @@ RSpec.feature 'Anyone can update a property' do
       fill_in 'property[address]', with: ''
       fill_in 'property[postcode]', with: ''
 
-      click_on(I18n.t('generic.button.update', resource: 'Property'))
+      click_on(I18n.t('button.update.property'))
     end
 
     within('.property_address') do

--- a/spec/features/anyone_can_update_a_scheme_spec.rb
+++ b/spec/features/anyone_can_update_a_scheme_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature 'Anyone can update a scheme' do
       expect(page).to have_content(scheme.contractor_email_address)
     end
 
-    click_on(I18n.t('generic.button.edit', resource: 'Scheme'))
+    click_on(I18n.t('button.edit.scheme'))
 
     within('form.edit_scheme') do
       fill_in 'scheme[name]', with: '1'
@@ -30,7 +30,7 @@ RSpec.feature 'Anyone can update a scheme' do
 
     visit estate_scheme_path(scheme.estate, scheme)
 
-    click_on(I18n.t('generic.button.edit', resource: 'Scheme'))
+    click_on(I18n.t('button.edit.scheme'))
 
     within('form.edit_scheme') do
       fill_in 'scheme[name]', with: ''

--- a/spec/features/anyone_can_update_a_scheme_spec.rb
+++ b/spec/features/anyone_can_update_a_scheme_spec.rb
@@ -21,7 +21,7 @@ RSpec.feature 'Anyone can update a scheme' do
       fill_in 'scheme[contractor_email_address]', with: 'new@email.com'
       fill_in 'scheme[employer_agent_name]', with: 'Alex'
       fill_in 'scheme[employer_agent_email_address]', with: 'alex@example.com'
-      click_on(I18n.t('generic.button.update', resource: 'Scheme'))
+      click_on(I18n.t('button.update.scheme'))
     end
   end
 
@@ -37,7 +37,7 @@ RSpec.feature 'Anyone can update a scheme' do
       fill_in 'scheme[contractor_name]', with: ''
       fill_in 'scheme[contractor_email_address]', with: ''
 
-      click_on(I18n.t('generic.button.update', resource: 'Scheme'))
+      click_on(I18n.t('button.update.scheme'))
     end
 
     within('.scheme_name') do


### PR DESCRIPTION
- use the secondary button to provide a call to action for users to bounce between creating defects of different types
- refactor the way button content is shown for those that include the name of the resource eg. 'Create property' so that they are easier to work with and extend, during this work it became quite a lot of effort to update names and find out what the right casing was etc

![Screenshot 2019-06-27 at 15 27 10](https://user-images.githubusercontent.com/912473/60274810-aa679980-98f0-11e9-908d-7b3c2bbcc6eb.png)

![Screenshot 2019-06-27 at 15 30 39](https://user-images.githubusercontent.com/912473/60274756-899f4400-98f0-11e9-9796-64c76411424e.png)

