### PR TITLE
Acceptance links can be created on staging

### DIFF
--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -29,6 +29,10 @@ test:
 # Or, use `bin/rails secrets:setup` to configure encrypted secrets
 # and move the `production:` environment over there.
 
+staging:
+  domain_name: <%= ENV["DOMAIN_NAME"] %>
+  secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
+
 production:
   domain_name: <%= ENV["DOMAIN_NAME"] %>
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>


### PR DESCRIPTION
## Changes in this PR:
* Now that staging is using `RAILS_ENV=staging`, `Rails.application.secrets.secret_key_base` returns nil which stops the secrets being generated for the acceptance link.

```
irb(main):004:0>     MessageVerifier.verifier.generate(
irb(main):005:1*       id,
irb(main):006:1*       purpose: :accept_defect_ownership,
irb(main):007:1*       expires_in: 3.months
irb(main):008:1>     )
Traceback (most recent call last):
        3: from (irb):4
        2: from app/services/message_verifier.rb:3:in `verifier'
        1: from app/services/message_verifier.rb:3:in `new'
ArgumentError (Secret should not be nil.)
irb(main):009:0> Rails.application.secrets.secret_key_base
=> nil
```