### PR TITLE
[147] Support new raised in error status

### DIFF
--- a/app/models/defect.rb
+++ b/app/models/defect.rb
@@ -21,6 +21,7 @@ class Defect < ApplicationRecord
     outstanding
     completed
     closed
+    raised_in_error
     follow_on
     end_of_year_defect
     dispute

--- a/app/models/defect.rb
+++ b/app/models/defect.rb
@@ -23,7 +23,7 @@ class Defect < ApplicationRecord
     closed
     raised_in_error
     follow_on
-    end_of_year_defect
+    end_of_year
     dispute
     referral
     rejected

--- a/app/views/staff/communal_defects/new.html.haml
+++ b/app/views/staff/communal_defects/new.html.haml
@@ -31,6 +31,14 @@
                   input_html: { class: 'trades' },
                   collection: Defect::TRADES,
                   required: true
+        = f.input :status,
+                  wrapper: 'select',
+                  input_html: { class: 'status' },
+                  collection: Defect.statuses,
+                  selected: @defect.status,
+                  required: true,
+                  label_method: ->(obj){ status_form_label(option_array: obj) },
+                  value_method: :first
         = f.input :priority,
                   as: :radio_buttons,
                   wrapper: :radio_buttons,

--- a/app/views/staff/property_defects/new.html.haml
+++ b/app/views/staff/property_defects/new.html.haml
@@ -26,6 +26,14 @@
                   input_html: { class: 'trades' },
                   collection: Defect::TRADES,
                   required: true
+        = f.input :status,
+                  wrapper: 'select',
+                  input_html: { class: 'status' },
+                  collection: Defect.statuses,
+                  selected: @defect.status,
+                  required: true,
+                  label_method: ->(obj){ status_form_label(option_array: obj) },
+                  value_method: :first
         = f.input :priority,
                   as: :radio_buttons,
                   wrapper: :radio_buttons,

--- a/spec/features/anyone_can_create_a_communal_defect_spec.rb
+++ b/spec/features/anyone_can_create_a_communal_defect_spec.rb
@@ -99,4 +99,23 @@ RSpec.feature 'Anyone can create a defect for a communal_area' do
 
     expect(page).to have_content(I18n.t('page_title.staff.schemes.show', name: communal_defect.scheme.name))
   end
+
+  scenario 'any status can be given' do
+    communal_area = create(:communal_area)
+
+    visit communal_area_path(communal_area)
+
+    click_on(I18n.t('button.create.communal_defect'))
+
+    expect(page).to have_content(I18n.t('page_title.staff.defects.create.communal_area'))
+
+    expected_statues = %w[outstanding completed closed follow_on end_of_year_defect referral rejected dispute]
+
+    within('form.new_defect') do
+      expected_statues.each do |status|
+        select status.capitalize.tr('_', ' '), from: 'defect[status]'
+      end
+      click_on(I18n.t('button.create.communal_defect'))
+    end
+  end
 end

--- a/spec/features/anyone_can_create_a_communal_defect_spec.rb
+++ b/spec/features/anyone_can_create_a_communal_defect_spec.rb
@@ -109,7 +109,7 @@ RSpec.feature 'Anyone can create a defect for a communal_area' do
 
     expect(page).to have_content(I18n.t('page_title.staff.defects.create.communal_area'))
 
-    expected_statues = %w[outstanding completed closed follow_on end_of_year_defect referral rejected dispute]
+    expected_statues = %w[outstanding completed closed raised_in_error follow_on end_of_year_defect referral rejected dispute]
 
     within('form.new_defect') do
       expected_statues.each do |status|

--- a/spec/features/anyone_can_create_a_communal_defect_spec.rb
+++ b/spec/features/anyone_can_create_a_communal_defect_spec.rb
@@ -109,7 +109,7 @@ RSpec.feature 'Anyone can create a defect for a communal_area' do
 
     expect(page).to have_content(I18n.t('page_title.staff.defects.create.communal_area'))
 
-    expected_statues = %w[outstanding completed closed raised_in_error follow_on end_of_year_defect referral rejected dispute]
+    expected_statues = %w[outstanding completed closed raised_in_error follow_on end_of_year referral rejected dispute]
 
     within('form.new_defect') do
       expected_statues.each do |status|

--- a/spec/features/anyone_can_create_a_property_defect_spec.rb
+++ b/spec/features/anyone_can_create_a_property_defect_spec.rb
@@ -94,7 +94,7 @@ RSpec.feature 'Anyone can create a defect for a property' do
 
     expect(page).to have_content(I18n.t('page_title.staff.defects.create.property'))
 
-    expected_statues = %w[outstanding completed closed raised_in_error follow_on end_of_year_defect referral rejected dispute]
+    expected_statues = %w[outstanding completed closed raised_in_error follow_on end_of_year referral rejected dispute]
 
     within('form.new_defect') do
       expected_statues.each do |status|

--- a/spec/features/anyone_can_create_a_property_defect_spec.rb
+++ b/spec/features/anyone_can_create_a_property_defect_spec.rb
@@ -85,6 +85,25 @@ RSpec.feature 'Anyone can create a defect for a property' do
     end
   end
 
+  scenario 'any status can be given' do
+    property = create(:property)
+
+    visit property_path(property)
+
+    click_on(I18n.t('button.create.property_defect'))
+
+    expect(page).to have_content(I18n.t('page_title.staff.defects.create.property'))
+
+    expected_statues = %w[outstanding completed closed follow_on end_of_year_defect referral rejected dispute]
+
+    within('form.new_defect') do
+      expected_statues.each do |status|
+        select status.capitalize.tr('_', ' '), from: 'defect[status]'
+      end
+      click_on(I18n.t('button.create.property_defect'))
+    end
+  end
+
   scenario 'a communal defect can be created after finishing the creation of a property defect' do
     property_defect = create(:property_defect)
 

--- a/spec/features/anyone_can_create_a_property_defect_spec.rb
+++ b/spec/features/anyone_can_create_a_property_defect_spec.rb
@@ -94,7 +94,7 @@ RSpec.feature 'Anyone can create a defect for a property' do
 
     expect(page).to have_content(I18n.t('page_title.staff.defects.create.property'))
 
-    expected_statues = %w[outstanding completed closed follow_on end_of_year_defect referral rejected dispute]
+    expected_statues = %w[outstanding completed closed raised_in_error follow_on end_of_year_defect referral rejected dispute]
 
     within('form.new_defect') do
       expected_statues.each do |status|

--- a/spec/features/anyone_can_update_a_communal_defect_spec.rb
+++ b/spec/features/anyone_can_update_a_communal_defect_spec.rb
@@ -46,18 +46,22 @@ RSpec.feature 'Anyone can update a communal_area defect' do
     expect(page).to have_content((Time.zone.now + new_priority.days.days).to_date)
   end
 
-  scenario 'a defect status can be updated' do
+  scenario 'any defect status can be chosen' do
     defect = create(:communal_defect, communal_area: communal_area)
 
     visit edit_communal_area_defect_path(defect.communal_area, defect)
 
+    expected_statues = %w[outstanding completed closed follow_on end_of_year_defect referral rejected dispute]
+
     within('form.edit_defect') do
-      select 'Completed', from: 'defect[status]'
+      expected_statues.each do |status|
+        select status.capitalize.tr('_', ' '), from: 'defect[status]'
+      end
       click_on(I18n.t('button.update.defect'))
     end
 
     expect(page).to have_content(I18n.t('generic.notice.update.success', resource: 'defect'))
-    expect(page).to have_content('Completed')
+    expect(page).to have_content(expected_statues.last.capitalize)
   end
 
   scenario 'an invalid defect cannot be updated' do

--- a/spec/features/anyone_can_update_a_communal_defect_spec.rb
+++ b/spec/features/anyone_can_update_a_communal_defect_spec.rb
@@ -51,7 +51,7 @@ RSpec.feature 'Anyone can update a communal_area defect' do
 
     visit edit_communal_area_defect_path(defect.communal_area, defect)
 
-    expected_statues = %w[outstanding completed closed raised_in_error follow_on end_of_year_defect referral rejected dispute]
+    expected_statues = %w[outstanding completed closed raised_in_error follow_on end_of_year referral rejected dispute]
 
     within('form.edit_defect') do
       expected_statues.each do |status|

--- a/spec/features/anyone_can_update_a_communal_defect_spec.rb
+++ b/spec/features/anyone_can_update_a_communal_defect_spec.rb
@@ -51,7 +51,7 @@ RSpec.feature 'Anyone can update a communal_area defect' do
 
     visit edit_communal_area_defect_path(defect.communal_area, defect)
 
-    expected_statues = %w[outstanding completed closed follow_on end_of_year_defect referral rejected dispute]
+    expected_statues = %w[outstanding completed closed raised_in_error follow_on end_of_year_defect referral rejected dispute]
 
     within('form.edit_defect') do
       expected_statues.each do |status|

--- a/spec/features/anyone_can_update_a_property_defect_spec.rb
+++ b/spec/features/anyone_can_update_a_property_defect_spec.rb
@@ -61,6 +61,24 @@ RSpec.feature 'Anyone can update a defect' do
     expect(page).to have_content('Completed')
   end
 
+  scenario 'any defect status can be chosen' do
+    defect = create(:property_defect, property: property)
+
+    visit edit_property_defect_path(defect.property, defect)
+
+    expected_statues = %w[outstanding completed closed follow_on end_of_year_defect referral rejected dispute]
+
+    within('form.edit_defect') do
+      expected_statues.each do |status|
+        select status.capitalize.tr('_', ' '), from: 'defect[status]'
+      end
+      click_on(I18n.t('button.update.defect'))
+    end
+
+    expect(page).to have_content(I18n.t('generic.notice.update.success', resource: 'defect'))
+    expect(page).to have_content(expected_statues.last.capitalize)
+  end
+
   scenario 'an invalid defect cannot be updated' do
     defect = create(:property_defect, property: property)
 

--- a/spec/features/anyone_can_update_a_property_defect_spec.rb
+++ b/spec/features/anyone_can_update_a_property_defect_spec.rb
@@ -66,7 +66,7 @@ RSpec.feature 'Anyone can update a defect' do
 
     visit edit_property_defect_path(defect.property, defect)
 
-    expected_statues = %w[outstanding completed closed follow_on end_of_year_defect referral rejected dispute]
+    expected_statues = %w[outstanding completed closed raised_in_error follow_on end_of_year_defect referral rejected dispute]
 
     within('form.edit_defect') do
       expected_statues.each do |status|

--- a/spec/features/anyone_can_update_a_property_defect_spec.rb
+++ b/spec/features/anyone_can_update_a_property_defect_spec.rb
@@ -66,7 +66,7 @@ RSpec.feature 'Anyone can update a defect' do
 
     visit edit_property_defect_path(defect.property, defect)
 
-    expected_statues = %w[outstanding completed closed raised_in_error follow_on end_of_year_defect referral rejected dispute]
+    expected_statues = %w[outstanding completed closed raised_in_error follow_on end_of_year referral rejected dispute]
 
     within('form.edit_defect') do
       expected_statues.each do |status|


### PR DESCRIPTION
## Changes in this PR:
- add more test coverage for statuses
- different statuses can be chosen when creating a defect, this wasn't actually shown
- rename the end_of_year_defect status to end_of_year

## Screenshots of UI changes:
![Screenshot 2019-06-27 at 16 45 08](https://user-images.githubusercontent.com/912473/60280569-16e79600-98fb-11e9-8ea4-2f217322c740.png)
![Screenshot 2019-06-27 at 16 44 53](https://user-images.githubusercontent.com/912473/60280568-16e79600-98fb-11e9-9378-6022a824fc8d.png)
