### PR TITLE
Download a basic CSV of all defects

### DIFF
--- a/app/controllers/staff/report_controller.rb
+++ b/app/controllers/staff/report_controller.rb
@@ -1,0 +1,11 @@
+require 'csv'
+
+class Staff::ReportController < Staff::BaseController
+  def index
+    @defects = Defect.all
+    respond_to do |format|
+      format.html
+      format.csv { send_data @defects.to_csv }
+    end
+  end
+end

--- a/app/helpers/datetime_helper.rb
+++ b/app/helpers/datetime_helper.rb
@@ -8,7 +8,7 @@ module DatetimeHelper
   end
 
   def format_time(time)
-    time.in_time_zone.strftime('%H:%M%P, %-d %B %Y')
+    time.in_time_zone.strftime('%H:%M%P %-d %B %Y')
   end
 
   def format_time_in_sentence(time)

--- a/app/models/defect.rb
+++ b/app/models/defect.rb
@@ -108,5 +108,53 @@ class Defect < ApplicationRecord
 
     format_time(acceptance_event.created_at)
   end
+
+  def self.to_csv
+    all_defects = all.includes(:priority, :property, :communal_area)
+
+    CSV.generate(headers: true) do |csv|
+      csv << csv_headers
+
+      all_defects.order(:created_at).each do |defect|
+        csv << defect.to_row
+      end
+    end
+  end
+
+  def self.csv_headers
+    %w[
+      reference_number
+      title
+      type
+      status
+      trade
+      priority_name
+      priority_duration
+      target_completion_date
+      property_address
+      communal_area_name
+      communal_area_location
+      description
+      access_information
+    ]
+  end
+
+  def to_row
+    [
+      reference_number,
+      title,
+      communal? ? 'Communal' : 'Property',
+      status,
+      trade,
+      priority.name,
+      priority.days,
+      target_completion_date,
+      property&.address,
+      communal_area&.name,
+      communal_area&.location,
+      description,
+      access_information,
+    ]
+  end
 end
 # rubocop:enable Metrics/ClassLength

--- a/app/models/defect.rb
+++ b/app/models/defect.rb
@@ -1,3 +1,6 @@
+require 'csv'
+
+# rubocop:disable Metrics/ClassLength
 class Defect < ApplicationRecord
   include DatetimeHelper
   before_validation :set_completion_date
@@ -106,3 +109,4 @@ class Defect < ApplicationRecord
     format_time(acceptance_event.created_at)
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/app/models/defect.rb
+++ b/app/models/defect.rb
@@ -124,6 +124,7 @@ class Defect < ApplicationRecord
   def self.csv_headers
     %w[
       reference_number
+      created_at
       title
       type
       status
@@ -142,6 +143,7 @@ class Defect < ApplicationRecord
   def to_row
     [
       reference_number,
+      format_time(created_at),
       title,
       communal? ? 'Communal' : 'Property',
       status,

--- a/app/views/staff/dashboard/index.html.haml
+++ b/app/views/staff/dashboard/index.html.haml
@@ -16,6 +16,10 @@
 
       %hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
 
+      %h3.govuk-heading-m
+        Reporting
+      = link_to(I18n.t('button.report.download_all'), report_path(format: :csv), class: 'govuk-button govuk-button--secondary mb0')
+
   .govuk-grid-column-one-third
     %h2.govuk-heading-m
       Manage Estates

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -67,6 +67,7 @@ en:
       edit: 'Edit'
     button:
       find: 'Search'
+      download: 'Download'
     notice:
       create:
         success:
@@ -75,6 +76,8 @@ en:
         success:
           'The %{resource} has successfully been updated.'
   button:
+    report:
+      download_all: Download CSV
     create:
       estate: 'Create estate'
       scheme: 'Create scheme'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,8 @@ Rails.application.routes.draw do
   end
 
   get 'search' => 'staff/searches#index'
+  get 'report' => 'staff/report#index'
+
   resources :properties, controller: 'staff/properties', only: %i[show] do
     resources :defects, controller: 'staff/property_defects', only: %i[new create show edit update]
   end

--- a/spec/features/anyone_can_download_defect_csv_spec.rb
+++ b/spec/features/anyone_can_download_defect_csv_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+RSpec.feature 'Anyone can download defect data' do
+  scenario 'download all defects' do
+    property_defect = create(:property_defect)
+    communal_defect = create(:communal_defect)
+
+    visit root_path
+
+    click_on(I18n.t('button.report.download_all'))
+
+    header = page.response_headers['Content-Disposition']
+    expect(header).to eql('attachment')
+
+    # Headers
+    expected_headers = %w[
+      reference_number
+      title
+      type
+      status
+      trade
+      priority_name
+      priority_duration
+      target_completion_date
+      property_address
+      communal_area_name
+      communal_area_location
+      description
+      access_information
+    ]
+
+    expected_headers.each do |expected_header|
+      expect(page).to have_content(expected_header)
+    end
+
+    # Property defect
+    expect(page).to have_content(property_defect.reference_number)
+    expect(page).to have_content(property_defect.title)
+    expect(page).to have_content('Property')
+    expect(page).to have_content(property_defect.status)
+    expect(page).to have_content(property_defect.trade)
+    expect(page).to have_content(property_defect.priority.name)
+    expect(page).to have_content(property_defect.priority.days)
+    expect(page).to have_content(property_defect.target_completion_date)
+    expect(page).to have_content(property_defect.property.address)
+    expect(page).to have_content(property_defect.description)
+    expect(page).to have_content(property_defect.access_information)
+
+    # Communal defect
+    expect(page).to have_content(communal_defect.reference_number)
+    expect(page).to have_content(communal_defect.title)
+    expect(page).to have_content('Communal')
+    expect(page).to have_content(communal_defect.status)
+    expect(page).to have_content(communal_defect.trade)
+    expect(page).to have_content(communal_defect.priority.name)
+    expect(page).to have_content(communal_defect.priority.days)
+    expect(page).to have_content(communal_defect.target_completion_date)
+    expect(page).to have_content(communal_defect.communal_area.name)
+    expect(page).to have_content(communal_defect.communal_area.location)
+    expect(page).to have_content(communal_defect.description)
+    expect(page).to have_content(communal_defect.access_information)
+  end
+end

--- a/spec/features/anyone_can_download_defect_csv_spec.rb
+++ b/spec/features/anyone_can_download_defect_csv_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.feature 'Anyone can download defect data' do
+  include DatetimeHelper
+
   scenario 'download all defects' do
     property_defect = create(:property_defect)
     communal_defect = create(:communal_defect)
@@ -15,6 +17,7 @@ RSpec.feature 'Anyone can download defect data' do
     # Headers
     expected_headers = %w[
       reference_number
+      created_at
       title
       type
       status
@@ -35,6 +38,7 @@ RSpec.feature 'Anyone can download defect data' do
 
     # Property defect
     expect(page).to have_content(property_defect.reference_number)
+    expect(page).to have_content(format_time(property_defect.created_at))
     expect(page).to have_content(property_defect.title)
     expect(page).to have_content('Property')
     expect(page).to have_content(property_defect.status)
@@ -48,6 +52,7 @@ RSpec.feature 'Anyone can download defect data' do
 
     # Communal defect
     expect(page).to have_content(communal_defect.reference_number)
+    expect(page).to have_content(format_time(property_defect.created_at))
     expect(page).to have_content(communal_defect.title)
     expect(page).to have_content('Communal')
     expect(page).to have_content(communal_defect.status)

--- a/spec/fixtures/download_defects.csv
+++ b/spec/fixtures/download_defects.csv
@@ -1,3 +1,3 @@
-reference_number,title,type,status,trade,priority_name,priority_duration,target_completion_date,property_address,communal_area_name,communal_area_location,description,access_information
-456ABC,a shorter title,Communal,Outstanding,Electrical,P1,1, 2 July 2019,,Pine Creek,1-100 Hackney Street,a longer description,The communal door will be unlocked
-123ABC,a short title,Property,Outstanding,Electrical,P1,1, 2 July 2019,1 Hackney Street,,,a long description,The key is under the garden pot
+reference_number,created_at,title,type,status,trade,priority_name,priority_duration,target_completion_date,property_address,communal_area_name,communal_area_location,description,access_information
+456ABC,13:13pm 1 October 2017,a shorter title,Communal,Outstanding,Electrical,P1,1, 2 July 2019,,Pine Creek,1-100 Hackney Street,a longer description,The communal door will be unlocked
+123ABC,13:13pm 1 October 2018,a short title,Property,Outstanding,Electrical,P1,1, 2 July 2019,1 Hackney Street,,,a long description,The key is under the garden pot

--- a/spec/fixtures/download_defects.csv
+++ b/spec/fixtures/download_defects.csv
@@ -1,0 +1,3 @@
+reference_number,title,type,status,trade,priority_name,priority_duration,target_completion_date,property_address,communal_area_name,communal_area_location,description,access_information
+456ABC,a shorter title,Communal,Outstanding,Electrical,P1,1, 2 July 2019,,Pine Creek,1-100 Hackney Street,a longer description,The communal door will be unlocked
+123ABC,a short title,Property,Outstanding,Electrical,P1,1, 2 July 2019,1 Hackney Street,,,a long description,The key is under the garden pot

--- a/spec/helpers/datetime_format_helper_spec.rb
+++ b/spec/helpers/datetime_format_helper_spec.rb
@@ -25,14 +25,14 @@ RSpec.describe DatetimeHelper, type: :helper do
   describe '#format_time' do
     it 'returns the time and date in the default format' do
       expect(helper.format_time(Time.zone.local(2017, 10, 7, 9, 45)))
-        .to eq '09:45am, 7 October 2017'
+        .to eq '09:45am 7 October 2017'
     end
 
     context 'when the time zone is BST' do
       it 'renders the time +1 hour on top of UTC' do
         time = Time.utc(2017, 10, 7, 9, 45)
         expect(helper.format_time(time))
-          .to eq '10:45am, 7 October 2017'
+          .to eq '10:45am 7 October 2017'
       end
     end
   end

--- a/spec/models/defect_spec.rb
+++ b/spec/models/defect_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Defect, type: :model do
+  include DatetimeHelper
+
   it { should belong_to(:property) }
   it { should have_many(:comments) }
 
@@ -127,7 +129,7 @@ RSpec.describe Defect, type: :model do
       it 'returns the time of acceptance' do
         defect = create(:property_defect)
         PublicActivity::Activity.create(trackable: defect, key: 'defect.accepted')
-        expect(defect.accepted_on).to eq('00:00am, 23 May 2019')
+        expect(defect.accepted_on).to eq('00:00am 23 May 2019')
       end
     end
 
@@ -153,7 +155,7 @@ RSpec.describe Defect, type: :model do
              target_completion_date: Date.new(2020, 10, 1),
              description: 'a long description',
              access_information: 'The key is under the garden pot',
-             created_at: 2.days.ago)
+             created_at: Time.utc(2018, 10, 1, 12, 13, 55))
     end
 
     let(:communal_area) { create(:communal_area, name: 'Pine Creek', location: '1-100 Hackney Street') }
@@ -168,7 +170,7 @@ RSpec.describe Defect, type: :model do
              target_completion_date: Date.new(2019, 10, 1),
              description: 'a longer description',
              access_information: 'The communal door will be unlocked',
-             created_at: 5.days.ago)
+             created_at: Time.utc(2017, 10, 1, 12, 13, 55))
     end
 
     it 'returns a CSV of all defects ordered by created_at' do
@@ -185,6 +187,7 @@ RSpec.describe Defect, type: :model do
       expect(described_class.csv_headers).to eq(
         %w[
           reference_number
+          created_at
           title
           type
           status
@@ -210,6 +213,7 @@ RSpec.describe Defect, type: :model do
         expect(result).to eq(
           [
             defect.reference_number,
+            format_time(defect.created_at),
             defect.title,
             'Property',
             defect.status,
@@ -234,6 +238,7 @@ RSpec.describe Defect, type: :model do
         expect(result).to eq(
           [
             defect.reference_number,
+            format_time(defect.created_at),
             defect.title,
             'Communal',
             defect.status,

--- a/spec/presenters/defect_mail_presenter_spec.rb
+++ b/spec/presenters/defect_mail_presenter_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe DefectMailPresenter do
 
         result = described_class.new(property_defect).created_time
 
-        expect(result).to eql('13:00pm, 30 October 2017')
+        expect(result).to eql('13:00pm 30 October 2017')
       end
     end
   end


### PR DESCRIPTION
## Changes in this PR:
- add a basic CSV download for all defect data, this will give the team a very minimum reporting mechanism and allow us to start testing with users 

## Screenshots of UI changes:

![Screenshot 2019-07-01 at 15 20 25](https://user-images.githubusercontent.com/912473/60443756-ca120100-9c13-11e9-889b-c82c20152c26.png)


