### PR TITLE
Times formats restructured

### DIFF
--- a/app/helpers/datetime_helper.rb
+++ b/app/helpers/datetime_helper.rb
@@ -7,11 +7,7 @@ module DatetimeHelper
     date.to_s(format).lstrip
   end
 
-  def format_time(time)
-    time.in_time_zone.strftime('%H:%M%P %-d %B %Y')
-  end
-
   def format_time_in_sentence(time)
-    time.in_time_zone.strftime('at %H:%M%P on %-d %B %Y')
+    time.in_time_zone.strftime('on %-d %B %Y at %H:%M')
   end
 end

--- a/app/models/defect.rb
+++ b/app/models/defect.rb
@@ -2,7 +2,6 @@ require 'csv'
 
 # rubocop:disable Metrics/ClassLength
 class Defect < ApplicationRecord
-  include DatetimeHelper
   before_validation :set_completion_date
   validates :title,
             :description,
@@ -106,7 +105,7 @@ class Defect < ApplicationRecord
     acceptance_event = activities.find_by(key: 'defect.accepted')
     return I18n.t('page_content.defect.show.not_accepted_yet') unless acceptance_event
 
-    format_time(acceptance_event.created_at)
+    acceptance_event.created_at.to_s
   end
 
   def self.to_csv
@@ -143,7 +142,7 @@ class Defect < ApplicationRecord
   def to_row
     [
       reference_number,
-      format_time(created_at),
+      created_at.to_s,
       title,
       communal? ? 'Communal' : 'Property',
       status,

--- a/app/presenters/defect_mail_presenter.rb
+++ b/app/presenters/defect_mail_presenter.rb
@@ -1,6 +1,4 @@
 class DefectMailPresenter < SimpleDelegator
-  include DatetimeHelper
-
   delegate :contractor_name, to: :scheme
   delegate :contractor_email_address, to: :scheme
   delegate :name, to: :priority, prefix: :priority
@@ -18,6 +16,6 @@ class DefectMailPresenter < SimpleDelegator
   end
 
   def created_time
-    format_time(created_at)
+    created_at.to_s
   end
 end

--- a/config/initializers/time_formats.rb
+++ b/config/initializers/time_formats.rb
@@ -1,2 +1,2 @@
 Date::DATE_FORMATS[:default] = '%e %B %Y'
-Time::DATE_FORMATS[:date] = '%d/%m/%Y'
+Time::DATE_FORMATS[:default] = ->(time) { time.strftime("#{time.day.ordinalize} %B %Y, %H:%M") }

--- a/spec/features/anyone_can_create_a_comment_spec.rb
+++ b/spec/features/anyone_can_create_a_comment_spec.rb
@@ -46,7 +46,7 @@ RSpec.feature 'Anyone can create a comment' do
 
       within('.comments') do
         comment = Comment.first
-        expect(page).to have_content('Comment left by Generic team user posted at 00:00am on 23 May 2019')
+        expect(page).to have_content('Comment left by Generic team user posted on 23 May 2019 at 00:00')
         expect(page).to have_content(comment.message)
       end
     end
@@ -96,7 +96,7 @@ RSpec.feature 'Anyone can create a comment' do
 
       within('.comments') do
         comment = Comment.first
-        expect(page).to have_content('Comment left by Generic team user posted at 00:00am on 23 May 2019')
+        expect(page).to have_content('Comment left by Generic team user posted on 23 May 2019 at 00:00')
         expect(page).to have_content(comment.message)
       end
     end

--- a/spec/features/anyone_can_download_defect_csv_spec.rb
+++ b/spec/features/anyone_can_download_defect_csv_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 RSpec.feature 'Anyone can download defect data' do
-  include DatetimeHelper
-
   scenario 'download all defects' do
     property_defect = create(:property_defect)
     communal_defect = create(:communal_defect)
@@ -38,7 +36,7 @@ RSpec.feature 'Anyone can download defect data' do
 
     # Property defect
     expect(page).to have_content(property_defect.reference_number)
-    expect(page).to have_content(format_time(property_defect.created_at))
+    expect(page).to have_content(property_defect.created_at.to_s)
     expect(page).to have_content(property_defect.title)
     expect(page).to have_content('Property')
     expect(page).to have_content(property_defect.status)
@@ -52,7 +50,7 @@ RSpec.feature 'Anyone can download defect data' do
 
     # Communal defect
     expect(page).to have_content(communal_defect.reference_number)
-    expect(page).to have_content(format_time(property_defect.created_at))
+    expect(page).to have_content(property_defect.created_at.to_s)
     expect(page).to have_content(communal_defect.title)
     expect(page).to have_content('Communal')
     expect(page).to have_content(communal_defect.status)

--- a/spec/features/anyone_can_view_a_defect_spec.rb
+++ b/spec/features/anyone_can_view_a_defect_spec.rb
@@ -72,7 +72,7 @@ RSpec.feature 'Anyone can view a defect' do
     visit property_defect_path(defect.property, defect)
 
     within('.comments') do
-      expect(page).to have_content("Comment left by #{comment.user.name} posted at 00:00am on 23 May 2019")
+      expect(page).to have_content("Comment left by #{comment.user.name} posted on 23 May 2019 at 00:00")
       expect(page).to have_content(comment.message)
     end
 
@@ -87,7 +87,7 @@ RSpec.feature 'Anyone can view a defect' do
     visit property_defect_path(defect.property, defect)
 
     within('.events') do
-      expect(page).to have_content('defect.create at 00:00am on 23 May 2019')
+      expect(page).to have_content('defect.create on 23 May 2019 at 00:00')
     end
 
     travel_back

--- a/spec/fixtures/download_defects.csv
+++ b/spec/fixtures/download_defects.csv
@@ -1,3 +1,3 @@
 reference_number,created_at,title,type,status,trade,priority_name,priority_duration,target_completion_date,property_address,communal_area_name,communal_area_location,description,access_information
-456ABC,13:13pm 1 October 2017,a shorter title,Communal,Outstanding,Electrical,P1,1, 2 July 2019,,Pine Creek,1-100 Hackney Street,a longer description,The communal door will be unlocked
-123ABC,13:13pm 1 October 2018,a short title,Property,Outstanding,Electrical,P1,1, 2 July 2019,1 Hackney Street,,,a long description,The key is under the garden pot
+456ABC,"1st October 2017, 13:13",a shorter title,Communal,Outstanding,Electrical,P1,1, 2 July 2019,,Pine Creek,1-100 Hackney Street,a longer description,The communal door will be unlocked
+123ABC,"1st October 2018, 13:13",a short title,Property,Outstanding,Electrical,P1,1, 2 July 2019,1 Hackney Street,,,a long description,The key is under the garden pot

--- a/spec/helpers/datetime_format_helper_spec.rb
+++ b/spec/helpers/datetime_format_helper_spec.rb
@@ -10,29 +10,14 @@ RSpec.describe DatetimeHelper, type: :helper do
   describe '#format_time_in_sentence' do
     it 'returns the time and date in the default format' do
       expect(helper.format_time_in_sentence(Time.zone.local(2017, 10, 7, 9, 45)))
-        .to eq 'at 09:45am on 7 October 2017'
+        .to eq 'on 7 October 2017 at 09:45'
     end
 
     context 'when the time zone is BST' do
       it 'renders the time +1 hour on top of UTC' do
         time = Time.utc(2017, 10, 7, 9, 45)
         expect(helper.format_time_in_sentence(time))
-          .to eq 'at 10:45am on 7 October 2017'
-      end
-    end
-  end
-
-  describe '#format_time' do
-    it 'returns the time and date in the default format' do
-      expect(helper.format_time(Time.zone.local(2017, 10, 7, 9, 45)))
-        .to eq '09:45am 7 October 2017'
-    end
-
-    context 'when the time zone is BST' do
-      it 'renders the time +1 hour on top of UTC' do
-        time = Time.utc(2017, 10, 7, 9, 45)
-        expect(helper.format_time(time))
-          .to eq '10:45am 7 October 2017'
+          .to eq 'on 7 October 2017 at 10:45'
       end
     end
   end

--- a/spec/models/defect_spec.rb
+++ b/spec/models/defect_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Defect, type: :model do
-  include DatetimeHelper
-
   it { should belong_to(:property) }
   it { should have_many(:comments) }
 
@@ -129,7 +127,7 @@ RSpec.describe Defect, type: :model do
       it 'returns the time of acceptance' do
         defect = create(:property_defect)
         PublicActivity::Activity.create(trackable: defect, key: 'defect.accepted')
-        expect(defect.accepted_on).to eq('00:00am 23 May 2019')
+        expect(defect.accepted_on).to eq('23rd May 2019, 00:00')
       end
     end
 
@@ -213,7 +211,7 @@ RSpec.describe Defect, type: :model do
         expect(result).to eq(
           [
             defect.reference_number,
-            format_time(defect.created_at),
+            defect.created_at.to_s,
             defect.title,
             'Property',
             defect.status,
@@ -238,7 +236,7 @@ RSpec.describe Defect, type: :model do
         expect(result).to eq(
           [
             defect.reference_number,
-            format_time(defect.created_at),
+            defect.created_at.to_s,
             defect.title,
             'Communal',
             defect.status,

--- a/spec/presenters/defect_mail_presenter_spec.rb
+++ b/spec/presenters/defect_mail_presenter_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe DefectMailPresenter do
 
         result = described_class.new(property_defect).created_time
 
-        expect(result).to eql('13:00pm 30 October 2017')
+        expect(result).to eql('30th October 2017, 13:00')
       end
     end
   end


### PR DESCRIPTION
## Changes in this PR:
* Create a new :default Time format that will be applied everywhere when using <time>.to_s for reusability. This removes the the dependency on DatetimeHelper having to be required in views and tests everywhere
* Dates come before times as it makes sense to decrease in granularity the more you continue to read so you can stop reading when you've got what you need
* Don't show AM and PM when using the 24 hour time

## Screenshots of UI changes:

### Before
![Screenshot 2019-07-01 at 16 01 21](https://user-images.githubusercontent.com/912473/60447312-17de3780-9c1b-11e9-8a06-e5d455328b89.png)

![Screenshot 2019-07-01 at 15 20 25](https://user-images.githubusercontent.com/912473/60447204-d77eb980-9c1a-11e9-8f03-556a718d6621.png)


### After
![Screenshot 2019-07-01 at 16 05 21](https://user-images.githubusercontent.com/912473/60447317-1b71be80-9c1b-11e9-860a-f7d910f52d45.png)

![Screenshot 2019-07-01 at 16 04 55](https://user-images.githubusercontent.com/912473/60447178-c9309d80-9c1a-11e9-8416-da0967caf59d.png)
