### PR TITLE
[109] Agents can see all defects

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,8 +7,15 @@ Metrics/AbcSize:
   Exclude:
     - 'spec/**/*'
 
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*'
+    - 'config/routes.rb'
+    - 'config/environments/*'
+    - 'config/initializers/devise.rb'
+
 Metrics/MethodLength:
   Max: 25
-  
+
 Style/ClassAndModuleChildren:
   Enabled: false

--- a/app/controllers/staff/communal_defects_controller.rb
+++ b/app/controllers/staff/communal_defects_controller.rb
@@ -20,7 +20,7 @@ class Staff::CommunalDefectsController < Staff::BaseController
   end
 
   def show
-    @defect = Defect.find(id)
+    @defect = DefectPresenter.new(Defect.find(id))
   end
 
   def edit

--- a/app/controllers/staff/communal_defects_controller.rb
+++ b/app/controllers/staff/communal_defects_controller.rb
@@ -24,7 +24,7 @@ class Staff::CommunalDefectsController < Staff::BaseController
   end
 
   def edit
-    @defect = Defect.find(id)
+    @defect = DefectPresenter.new(Defect.find(id))
   end
 
   def update

--- a/app/controllers/staff/defects_controller.rb
+++ b/app/controllers/staff/defects_controller.rb
@@ -1,0 +1,7 @@
+class Staff::DefectsController < Staff::BaseController
+  def index
+    @defects = Defect.all
+                     .includes(:property, :communal_area, :priority)
+                     .map { |defect| DefectPresenter.new(defect) }
+  end
+end

--- a/app/controllers/staff/defects_controller.rb
+++ b/app/controllers/staff/defects_controller.rb
@@ -1,7 +1,5 @@
 class Staff::DefectsController < Staff::BaseController
   def index
-    @defects = Defect.all
-                     .includes(:property, :communal_area, :priority)
-                     .map { |defect| DefectPresenter.new(defect) }
+    @defects = DefectFinder.new.call
   end
 end

--- a/app/controllers/staff/property_defects_controller.rb
+++ b/app/controllers/staff/property_defects_controller.rb
@@ -20,7 +20,7 @@ class Staff::PropertyDefectsController < Staff::BaseController
   end
 
   def show
-    @defect = Defect.find(id)
+    @defect = DefectPresenter.new(Defect.find(id))
   end
 
   def edit

--- a/app/controllers/staff/property_defects_controller.rb
+++ b/app/controllers/staff/property_defects_controller.rb
@@ -24,7 +24,7 @@ class Staff::PropertyDefectsController < Staff::BaseController
   end
 
   def edit
-    @defect = Defect.find(id)
+    @defect = DefectPresenter.new(Defect.find(id))
   end
 
   def update

--- a/app/helpers/datetime_helper.rb
+++ b/app/helpers/datetime_helper.rb
@@ -1,12 +1,6 @@
 module DatetimeHelper
   class FormatDateError < RuntimeError; end
 
-  def format_date(date, format = :default)
-    return 'No date given' if date.nil?
-
-    date.to_s(format).lstrip
-  end
-
   def format_time_in_sentence(time)
     time.in_time_zone.strftime('on %-d %B %Y at %H:%M')
   end

--- a/app/mailers/defect_mailer.rb
+++ b/app/mailers/defect_mailer.rb
@@ -1,7 +1,7 @@
 class DefectMailer < ApplicationMailer
   def forward(recipient_type, recipient_email_address, defect_id)
     @defect = Defect.find(defect_id)
-    @presenter = DefectMailPresenter.new(@defect)
+    @presenter = DefectPresenter.new(@defect)
 
     view_mail(
       NOTIFY_FORWARD_DEFECT_TEMPLATE,

--- a/app/models/defect.rb
+++ b/app/models/defect.rb
@@ -100,13 +100,6 @@ class Defect < ApplicationRecord
     )
   end
 
-  def accepted_on
-    acceptance_event = activities.find_by(key: 'defect.accepted')
-    return I18n.t('page_content.defect.show.not_accepted_yet') unless acceptance_event
-
-    acceptance_event.created_at.to_s
-  end
-
   def self.to_csv
     all_defects = all.includes(:priority, :property, :communal_area)
 

--- a/app/models/defect.rb
+++ b/app/models/defect.rb
@@ -30,6 +30,8 @@ class Defect < ApplicationRecord
     rejected
   ]
 
+  scope :open, (-> { where(status: %i[outstanding follow_on end_of_year dispute referral]) })
+
   belongs_to :property, optional: true
   belongs_to :communal_area, optional: true
   belongs_to :priority

--- a/app/presenters/defect_presenter.rb
+++ b/app/presenters/defect_presenter.rb
@@ -1,4 +1,4 @@
-class DefectMailPresenter < SimpleDelegator
+class DefectPresenter < SimpleDelegator
   delegate :contractor_name, to: :scheme
   delegate :contractor_email_address, to: :scheme
   delegate :name, to: :priority, prefix: :priority
@@ -17,5 +17,12 @@ class DefectMailPresenter < SimpleDelegator
 
   def created_time
     created_at.to_s
+  end
+
+  def accepted_on
+    acceptance_event = activities.find_by(key: 'defect.accepted')
+    return I18n.t('page_content.defect.show.not_accepted_yet') unless acceptance_event
+
+    acceptance_event.created_at.to_s
   end
 end

--- a/app/presenters/defect_presenter.rb
+++ b/app/presenters/defect_presenter.rb
@@ -25,4 +25,8 @@ class DefectPresenter < SimpleDelegator
 
     acceptance_event.created_at.to_s
   end
+
+  def target_completion_date
+    super.to_s
+  end
 end

--- a/app/services/defect_finder.rb
+++ b/app/services/defect_finder.rb
@@ -1,0 +1,7 @@
+class DefectFinder
+  def call
+    Defect.all
+          .includes(:property, :communal_area, :priority)
+          .map { |defect| DefectPresenter.new(defect) }
+  end
+end

--- a/app/services/defect_finder.rb
+++ b/app/services/defect_finder.rb
@@ -1,6 +1,6 @@
 class DefectFinder
   def call
-    Defect.all
+    Defect.open
           .includes(:property, :communal_area, :priority)
           .map { |defect| DefectPresenter.new(defect) }
   end

--- a/app/services/defect_finder.rb
+++ b/app/services/defect_finder.rb
@@ -2,6 +2,7 @@ class DefectFinder
   def call
     Defect.open
           .includes(:property, :communal_area, :priority)
+          .order(:target_completion_date)
           .map { |defect| DefectPresenter.new(defect) }
   end
 end

--- a/app/views/shared/defects/_summary_information.html.haml
+++ b/app/views/shared/defects/_summary_information.html.haml
@@ -9,7 +9,7 @@
     %dd.govuk-summary-list__value= defect.status
   %div.govuk-summary-list__row
     %dt.govuk-summary-list__key Target date
-    %dd.govuk-summary-list__value= format_date(defect.target_completion_date)
+    %dd.govuk-summary-list__value= defect.target_completion_date
   %div.govuk-summary-list__row
     %dt.govuk-summary-list__key Accepted time
     %dd.govuk-summary-list__value= defect.accepted_on

--- a/app/views/shared/defects/_table.html.haml
+++ b/app/views/shared/defects/_table.html.haml
@@ -22,6 +22,6 @@
         %td.govuk-table__cell= defect.title
         %td.govuk-table__cell= defect.status
         %td.govuk-table__cell= defect.priority.name
-        %td.govuk-table__cell= format_date(defect.target_completion_date)
+        %td.govuk-table__cell= defect.target_completion_date
         %td.govuk-table__cell= defect.trade
         %td.govuk-table__cell= link_to(I18n.t('generic.link.show'), view_path_for(parent: parent, defect: defect), class: 'govuk-link')

--- a/app/views/staff/communal_defects/edit.html.haml
+++ b/app/views/staff/communal_defects/edit.html.haml
@@ -48,7 +48,7 @@
         %label.govuk-label
           %span Target date for completion
           %p.govuk-inset-text
-            = format_date(@defect.target_completion_date) if @defect.target_completion_date?
+            = @defect.target_completion_date
 
       = f.input :priority,
                 as: :radio_buttons,

--- a/app/views/staff/dashboard/index.html.haml
+++ b/app/views/staff/dashboard/index.html.haml
@@ -5,9 +5,10 @@
     %h1.govuk-heading-xl= I18n.t('page_title.staff.dashboard')
 
     %h3.govuk-heading-m
-      Find a defect
+      = I18n.t('page_content.dashboard.header.find_defect')
     %p.govuk-body-s
-      Search for an individual property or communal area to create or update defects.
+      = I18n.t('page_content.dashboard.description.find_defect')
+
     = form_tag search_path, method: :get, class: 'search' do |f|
       .govuk-form-group
         = label_tag 'query', 'Address or communal area name', class: 'govuk-label'
@@ -17,10 +18,10 @@
       %hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
 
       %h3.govuk-heading-m
-        Reporting
+        = I18n.t('page_content.dashboard.header.reporting')
       = link_to(I18n.t('button.report.download_all'), report_path(format: :csv), class: 'govuk-button govuk-button--secondary mb0')
 
   .govuk-grid-column-one-third
     %h2.govuk-heading-m
-      Manage Estates
+      = I18n.t('page_content.dashboard.header.manage')
     = render partial: 'staff/dashboard/partials/manage-estates', locals: { estates: @estates }

--- a/app/views/staff/dashboard/index.html.haml
+++ b/app/views/staff/dashboard/index.html.haml
@@ -18,6 +18,15 @@
       %hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
 
       %h3.govuk-heading-m
+        = I18n.t('page_content.dashboard.header.defect_overview')
+      %p.govuk-body-s
+        = I18n.t('page_content.dashboard.description.defect_overview')
+
+      = link_to('View all defects', defects_path, class: 'govuk-button mb0')
+
+      %hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
+
+      %h3.govuk-heading-m
         = I18n.t('page_content.dashboard.header.reporting')
       = link_to(I18n.t('button.report.download_all'), report_path(format: :csv), class: 'govuk-button govuk-button--secondary mb0')
 

--- a/app/views/staff/defects/index.html.haml
+++ b/app/views/staff/defects/index.html.haml
@@ -1,0 +1,43 @@
+- content_for :page_title_prefix, I18n.t('page_title.staff.defects.index')
+= link_to 'Back', root_path, class: 'govuk-back-link'
+
+.govuk-grid-row
+  .govuk-grid-column-full
+    %h1.govuk-heading-l
+      = I18n.t('page_title.staff.defects.index')
+
+.govuk-grid-row
+  .govuk-grid-column-full
+    %table.govuk-table.defects
+      %thead.govuk-table__head
+        %tr.govuk-table__row
+          %th.govuk-table__header
+            Reference number
+          %th.govuk-table__header
+            Title
+          %th.govuk-table__header
+            Type
+          %th.govuk-table__header
+            Status
+          %th.govuk-table__header
+            Address
+          %th.govuk-table__header
+            Priority
+          %th.govuk-table__header
+            Trade
+          %th.govuk-table__header
+            Target completion
+          %th.govuk-table__header
+            Actions
+      %tbody.govuk-table__body
+        - @defects.each do |defect|
+          %tr.govuk-table__row
+            %td.govuk-table__cell= defect.reference_number
+            %td.govuk-table__cell= defect.title
+            %td.govuk-table__cell= defect.defect_type
+            %td.govuk-table__cell= defect.status
+            %td.govuk-table__cell= defect.address
+            %td.govuk-table__cell= defect.priority.name
+            %td.govuk-table__cell= defect.trade
+            %td.govuk-table__cell= defect.target_completion_date
+            %td.govuk-table__cell= link_to I18n.t('generic.link.show'), defect_path_for(defect: defect), class: 'govuk-link'

--- a/app/views/staff/defects/index.html.haml
+++ b/app/views/staff/defects/index.html.haml
@@ -16,11 +16,13 @@
           %th.govuk-table__header
             Title
           %th.govuk-table__header
+            Scheme
+          %th.govuk-table__header
             Type
           %th.govuk-table__header
-            Status
-          %th.govuk-table__header
             Address
+          %th.govuk-table__header
+            Status
           %th.govuk-table__header
             Priority
           %th.govuk-table__header
@@ -34,6 +36,7 @@
           %tr.govuk-table__row
             %td.govuk-table__cell= defect.reference_number
             %td.govuk-table__cell= defect.title
+            %td.govuk-table__cell= defect.scheme.name
             %td.govuk-table__cell= defect.defect_type
             %td.govuk-table__cell= defect.status
             %td.govuk-table__cell= defect.address

--- a/app/views/staff/property_defects/edit.html.haml
+++ b/app/views/staff/property_defects/edit.html.haml
@@ -43,7 +43,7 @@
         %label.govuk-label
           %span Target date for completion
           %p.govuk-inset-text
-            = format_date(@defect.target_completion_date) if @defect.target_completion_date?
+            = @defect.target_completion_date
 
       = f.input :priority,
                 as: :radio_buttons,

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -48,5 +48,15 @@ Rails.application.configure do
     Bullet.enable = true
     Bullet.bullet_logger = true
     Bullet.raise = true # raise an error if n+1 query occurs
+
+    Bullet.add_whitelist type: :unused_eager_loading,
+                         class_name: 'Defect',
+                         association: :property
+    Bullet.add_whitelist type: :unused_eager_loading,
+                         class_name: 'Defect',
+                         association: :communal_area
+    Bullet.add_whitelist type: :unused_eager_loading,
+                         class_name: 'Defect',
+                         association: :priority
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -46,6 +46,14 @@ en:
       comments:
         create: 'Create Comment'
   page_content:
+    dashboard:
+      header:
+        find_defect: 'Find a defect'
+        reporting: 'Reporting'
+        manage: 'Manage estates'
+      description:
+        find_defect: 'Search for an individual property or communal area to create or update defects.'
+        defect_overview: 'View and manage all defects across all schemes.'
     scheme:
       show:
         priorities:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,6 +38,7 @@ en:
         edit: 'Update property'
         show: '%{name}'
       defects:
+        index: 'Defect overview'
         create:
           property: 'Create property defect'
           communal_area: 'Create communal defect'
@@ -49,6 +50,7 @@ en:
     dashboard:
       header:
         find_defect: 'Find a defect'
+        defect_overview: 'Defect overview'
         reporting: 'Reporting'
         manage: 'Manage estates'
       description:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,8 @@ Rails.application.routes.draw do
   get 'search' => 'staff/searches#index'
   get 'report' => 'staff/report#index'
 
+  resources :defects, controller: 'staff/defects'
+
   resources :properties, controller: 'staff/properties', only: %i[show] do
     resources :defects, controller: 'staff/property_defects', only: %i[new create show edit update]
   end

--- a/spec/features/anyone_can_view_all_defects_spec.rb
+++ b/spec/features/anyone_can_view_all_defects_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.feature 'Anyone can view all defects' do
+  scenario 'all defects are shown by default' do
+    property_defect = DefectPresenter.new(create(:property_defect))
+    communal_defect = DefectPresenter.new(create(:communal_defect))
+
+    visit root_path
+
+    click_on('View all defects')
+
+    within('.defects') do
+      expect(page).to have_content(property_defect.reference_number)
+      expect(page).to have_content(property_defect.title)
+      expect(page).to have_content(property_defect.defect_type)
+      expect(page).to have_content(property_defect.status)
+      expect(page).to have_content(property_defect.address)
+      expect(page).to have_content(property_defect.priority.name)
+      expect(page).to have_content(property_defect.trade)
+      expect(page).to have_content(property_defect.target_completion_date)
+      expect(page).to have_link(
+        I18n.t('generic.link.show'),
+        href: property_defect_path(property_defect.property, property_defect)
+      )
+      expect(page).to have_content(communal_defect.reference_number)
+      expect(page).to have_content(communal_defect.title)
+      expect(page).to have_content(communal_defect.defect_type)
+      expect(page).to have_content(communal_defect.status)
+      expect(page).to have_content(communal_defect.address)
+      expect(page).to have_content(communal_defect.priority.name)
+      expect(page).to have_content(communal_defect.trade)
+      expect(page).to have_content(communal_defect.target_completion_date)
+      expect(page).to have_link(
+        I18n.t('generic.link.show'),
+        href: communal_area_defect_path(communal_defect.communal_area, communal_defect)
+      )
+    end
+  end
+end

--- a/spec/features/anyone_can_view_all_defects_spec.rb
+++ b/spec/features/anyone_can_view_all_defects_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
 RSpec.feature 'Anyone can view all defects' do
-  scenario 'all defects are shown by default' do
-    property_defect = DefectPresenter.new(create(:property_defect))
-    communal_defect = DefectPresenter.new(create(:communal_defect))
+  scenario 'open defects are shown by default' do
+    property_defect = DefectPresenter.new(create(:property_defect, status: :outstanding))
+    communal_defect = DefectPresenter.new(create(:communal_defect, status: :outstanding))
 
     visit root_path
 

--- a/spec/features/anyone_can_view_all_defects_spec.rb
+++ b/spec/features/anyone_can_view_all_defects_spec.rb
@@ -12,6 +12,7 @@ RSpec.feature 'Anyone can view all defects' do
     within('.defects') do
       expect(page).to have_content(property_defect.reference_number)
       expect(page).to have_content(property_defect.title)
+      expect(page).to have_content(property_defect.scheme.name)
       expect(page).to have_content(property_defect.defect_type)
       expect(page).to have_content(property_defect.status)
       expect(page).to have_content(property_defect.address)
@@ -24,6 +25,7 @@ RSpec.feature 'Anyone can view all defects' do
       )
       expect(page).to have_content(communal_defect.reference_number)
       expect(page).to have_content(communal_defect.title)
+      expect(page).to have_content(property_defect.scheme.name)
       expect(page).to have_content(communal_defect.defect_type)
       expect(page).to have_content(communal_defect.status)
       expect(page).to have_content(communal_defect.address)

--- a/spec/helpers/datetime_format_helper_spec.rb
+++ b/spec/helpers/datetime_format_helper_spec.rb
@@ -1,12 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe DatetimeHelper, type: :helper do
-  describe '#format_date' do
-    it 'returns the date in the default format' do
-      expect(helper.format_date(Date.new(2017, 10, 7))).to eq '7 October 2017'
-    end
-  end
-
   describe '#format_time_in_sentence' do
     it 'returns the time and date in the default format' do
       expect(helper.format_time_in_sentence(Time.zone.local(2017, 10, 7, 9, 45)))

--- a/spec/mailers/defect_spec.rb
+++ b/spec/mailers/defect_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe DefectMailer, type: :mailer do
   after(:each) { travel_back }
 
   let(:defect) { create(:property_defect, contact_name: 'Bilbo') }
-  let(:presenter) { DefectMailPresenter.new(defect) }
+  let(:presenter) { DefectPresenter.new(defect) }
 
   describe('#forward') do
     it 'sends an email to contractors' do

--- a/spec/models/defect_spec.rb
+++ b/spec/models/defect_spec.rb
@@ -114,31 +114,6 @@ RSpec.describe Defect, type: :model do
     end
   end
 
-  describe '#accepted_on' do
-    before(:each) do
-      travel_to Time.zone.parse('2019-05-23')
-    end
-
-    after(:each) do
-      travel_back
-    end
-
-    context 'when the defect has been accepted' do
-      it 'returns the time of acceptance' do
-        defect = create(:property_defect)
-        PublicActivity::Activity.create(trackable: defect, key: 'defect.accepted')
-        expect(defect.accepted_on).to eq('23rd May 2019, 00:00')
-      end
-    end
-
-    context 'when the defect has NOT been accepted' do
-      it 'returns an explanation' do
-        defect = create(:property_defect)
-        expect(defect.accepted_on).to eq(I18n.t('page_content.defect.show.not_accepted_yet'))
-      end
-    end
-  end
-
   describe '.to_csv' do
     let(:property) { create(:property, address: '1 Hackney Street') }
     let(:priority) { create(:priority, name: 'P1', days: 1) }

--- a/spec/presenters/defect_presenter_spec.rb
+++ b/spec/presenters/defect_presenter_spec.rb
@@ -104,13 +104,6 @@ RSpec.describe DefectPresenter do
     end
   end
 
-  describe '#target_completion_date' do
-    it 'returns the targetted completion date' do
-      result = described_class.new(property_defect).target_completion_date
-      expect(result).to eq(property_defect.target_completion_date)
-    end
-  end
-
   describe '#accepted_on' do
     before(:each) do
       travel_to Time.zone.parse('2019-05-23')
@@ -135,6 +128,15 @@ RSpec.describe DefectPresenter do
         expect(described_class.new(defect).accepted_on)
           .to eq(I18n.t('page_content.defect.show.not_accepted_yet'))
       end
+    end
+  end
+
+  describe '#target_completion_date' do
+    it 'returns a formatted date' do
+      defect = create(:property_defect)
+      expected_date = defect.target_completion_date.to_s
+      expect(described_class.new(defect).target_completion_date)
+        .to eq(expected_date)
     end
   end
 end

--- a/spec/presenters/defect_presenter_spec.rb
+++ b/spec/presenters/defect_presenter_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe DefectMailPresenter do
+RSpec.describe DefectPresenter do
   let(:property_defect) do
     create(:property_defect)
   end
@@ -108,6 +108,33 @@ RSpec.describe DefectMailPresenter do
     it 'returns the targetted completion date' do
       result = described_class.new(property_defect).target_completion_date
       expect(result).to eq(property_defect.target_completion_date)
+    end
+  end
+
+  describe '#accepted_on' do
+    before(:each) do
+      travel_to Time.zone.parse('2019-05-23')
+    end
+
+    after(:each) do
+      travel_back
+    end
+
+    context 'when the defect has been accepted' do
+      it 'returns the time of acceptance' do
+        defect = create(:property_defect)
+        PublicActivity::Activity.create(trackable: defect, key: 'defect.accepted')
+        expect(described_class.new(defect).accepted_on)
+          .to eq('23rd May 2019, 00:00')
+      end
+    end
+
+    context 'when the defect has NOT been accepted' do
+      it 'returns an explanation' do
+        defect = create(:property_defect)
+        expect(described_class.new(defect).accepted_on)
+          .to eq(I18n.t('page_content.defect.show.not_accepted_yet'))
+      end
     end
   end
 end

--- a/spec/services/defect_finder_spec.rb
+++ b/spec/services/defect_finder_spec.rb
@@ -6,13 +6,39 @@ RSpec.describe DefectFinder do
       described_class.new
     end
 
-    it 'returns an array of DefectPresenters for all Defects' do
-      defect_one = create(:property_defect)
+    it 'returns an array of DefectPresenters for open Defects' do
+      defect_one = create(:property_defect, status: :outstanding)
 
       result = service.call
 
       expect(result).to be_a(Array)
       expect(result.first).to eq(defect_one)
+    end
+
+    it 'does not return closed or completed defects' do
+      outstanding_defect = create(:property_defect, status: :outstanding)
+      follow_on_defect = create(:property_defect, status: :follow_on)
+      end_of_year_defect = create(:property_defect, status: :end_of_year)
+      dispute_defect = create(:property_defect, status: :dispute)
+      referral_defect = create(:property_defect, status: :referral)
+
+      closed_defect = create(:property_defect, status: :closed)
+      completed_defect = create(:property_defect, status: :completed)
+      raised_in_error_defect = create(:property_defect, status: :raised_in_error)
+      rejected_defect = create(:property_defect, status: :rejected)
+
+      result = service.call
+
+      expect(result).to include(outstanding_defect)
+      expect(result).to include(follow_on_defect)
+      expect(result).to include(end_of_year_defect)
+      expect(result).to include(dispute_defect)
+      expect(result).to include(referral_defect)
+
+      expect(result).not_to include(closed_defect)
+      expect(result).not_to include(completed_defect)
+      expect(result).not_to include(raised_in_error_defect)
+      expect(result).not_to include(rejected_defect)
     end
     end
   end

--- a/spec/services/defect_finder_spec.rb
+++ b/spec/services/defect_finder_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe DefectFinder do
+  describe '#call' do
+    let(:service) do
+      described_class.new
+    end
+
+    it 'returns an array of DefectPresenters for all Defects' do
+      defect_one = create(:property_defect)
+
+      result = service.call
+
+      expect(result).to be_a(Array)
+      expect(result.first).to eq(defect_one)
+    end
+    end
+  end
+end

--- a/spec/services/defect_finder_spec.rb
+++ b/spec/services/defect_finder_spec.rb
@@ -40,6 +40,21 @@ RSpec.describe DefectFinder do
       expect(result).not_to include(raised_in_error_defect)
       expect(result).not_to include(rejected_defect)
     end
+
+    it 'sorts the list by target_completion_date' do
+      defect_two = create(:property_defect, status: :outstanding, target_completion_date: 1.day.from_now)
+      defect_one = create(:property_defect, status: :outstanding, target_completion_date: 2.days.from_now)
+      defect_five = create(:property_defect, status: :outstanding, target_completion_date: 2.days.ago)
+      defect_four = create(:property_defect, status: :outstanding, target_completion_date: 1.day.ago)
+      defect_three = create(:property_defect, status: :outstanding, target_completion_date: 0.days.from_now)
+
+      result = service.call
+
+      expect(result[0]).to eq(defect_five)
+      expect(result[1]).to eq(defect_four)
+      expect(result[2]).to eq(defect_three)
+      expect(result[3]).to eq(defect_two)
+      expect(result[4]).to eq(defect_one)
     end
   end
 end


### PR DESCRIPTION
## Changes in this PR:
- refactor and reuse the existing DefectPresenter to group the defect view logic for use
- a single view for all defects regardless of status or type 
- view links to easily access individual defects regardless of type
## Screenshots of UI changes:

![Screenshot 2019-07-02 at 12 42 08](https://user-images.githubusercontent.com/912473/60510225-d30fda80-9cc6-11e9-8ce8-8b6a82396992.png)

![Screenshot 2019-07-02 at 12 40 38](https://user-images.githubusercontent.com/912473/60510192-bf647400-9cc6-11e9-936a-ada788b5e5a6.png)
