### PR TITLE
Target completion date has more stable testing

### DIFF
--- a/app/controllers/staff/communal_defects_controller.rb
+++ b/app/controllers/staff/communal_defects_controller.rb
@@ -28,10 +28,12 @@ class Staff::CommunalDefectsController < Staff::BaseController
   end
 
   def update
-    @defect = Defect.find(id)
-    @defect.assign_attributes(defect_params)
-    @defect.priority = Priority.find(priority_id) if priority_id.present?
-    @defect.set_completion_date
+    defect = Defect.find(id)
+    @defect = EditDefect.new(
+      defect: defect,
+      defect_params: defect_params,
+      options: { priority_id: priority_id }
+    ).call
 
     if @defect.valid?
       @defect.save

--- a/app/controllers/staff/communal_defects_controller.rb
+++ b/app/controllers/staff/communal_defects_controller.rb
@@ -31,6 +31,7 @@ class Staff::CommunalDefectsController < Staff::BaseController
     @defect = Defect.find(id)
     @defect.assign_attributes(defect_params)
     @defect.priority = Priority.find(priority_id) if priority_id.present?
+    @defect.set_completion_date
 
     if @defect.valid?
       @defect.save

--- a/app/controllers/staff/property_defects_controller.rb
+++ b/app/controllers/staff/property_defects_controller.rb
@@ -28,10 +28,12 @@ class Staff::PropertyDefectsController < Staff::BaseController
   end
 
   def update
-    @defect = Defect.find(id)
-    @defect.assign_attributes(defect_params)
-    @defect.priority = Priority.find(priority_id) if priority_id.present?
-    @defect.set_completion_date
+    defect = Defect.find(id)
+    @defect = EditDefect.new(
+      defect: defect,
+      defect_params: defect_params,
+      options: { priority_id: priority_id }
+    ).call
 
     if @defect.valid?
       @defect.save

--- a/app/controllers/staff/property_defects_controller.rb
+++ b/app/controllers/staff/property_defects_controller.rb
@@ -31,6 +31,7 @@ class Staff::PropertyDefectsController < Staff::BaseController
     @defect = Defect.find(id)
     @defect.assign_attributes(defect_params)
     @defect.priority = Priority.find(priority_id) if priority_id.present?
+    @defect.set_completion_date
 
     if @defect.valid?
       @defect.save

--- a/app/models/defect.rb
+++ b/app/models/defect.rb
@@ -2,7 +2,6 @@ require 'csv'
 
 # rubocop:disable Metrics/ClassLength
 class Defect < ApplicationRecord
-  before_validation :set_completion_date
   validates :title,
             :description,
             :trade,

--- a/app/models/defect.rb
+++ b/app/models/defect.rb
@@ -82,7 +82,7 @@ class Defect < ApplicationRecord
   def set_completion_date
     return unless priority
 
-    self.target_completion_date = Time .zone.now + priority.days.days
+    self.target_completion_date = Date.current + priority.days.days
   end
 
   def status

--- a/app/services/build_defect.rb
+++ b/app/services/build_defect.rb
@@ -16,6 +16,7 @@ class BuildDefect
     defect.property = Property.find(property_id) if property_id.present?
     defect.communal_area = CommunalArea.find(communal_area_id) if communal_area_id.present?
     defect.priority = Priority.find(priority_id) if priority_id.present?
+    defect.set_completion_date
 
     defect
   end

--- a/app/services/edit_defect.rb
+++ b/app/services/edit_defect.rb
@@ -1,0 +1,22 @@
+class EditDefect
+  attr_accessor :defect,
+                :defect_params,
+                :priority_id
+
+  def initialize(defect:, defect_params:, options: {})
+    self.defect = defect
+    self.defect_params = defect_params
+    self.priority_id = options[:priority_id]
+  end
+
+  def call
+    defect.assign_attributes(defect_params)
+
+    if priority_id.present?
+      defect.priority = Priority.find(priority_id)
+      defect.set_completion_date
+    end
+
+    defect
+  end
+end

--- a/spec/factories/defects.rb
+++ b/spec/factories/defects.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     contact_email_address { Faker::Internet.email }
     contact_phone_number { Faker::Base.numerify('###########') }
     trade { Defect::TRADES.sample }
-    target_completion_date { (1..10).to_a.sample.days.from_now }
+    target_completion_date { Faker::Date.between(1.day.from_now, 5.days.from_now) }
     status { Defect.statuses.keys.sample }
     reference_number { SecureRandom.hex(3).upcase }
 

--- a/spec/features/anyone_can_update_a_communal_defect_spec.rb
+++ b/spec/features/anyone_can_update_a_communal_defect_spec.rb
@@ -43,7 +43,7 @@ RSpec.feature 'Anyone can update a communal_area defect' do
     expect(page).to have_content('Brickwork')
     expect(page).to have_content(new_priority.name)
 
-    expect(page).to have_content((Time.zone.now + new_priority.days.days).to_date)
+    expect(page).to have_content((Date.current + new_priority.days.days).to_date)
   end
 
   scenario 'any defect status can be chosen' do

--- a/spec/features/anyone_can_update_a_property_defect_spec.rb
+++ b/spec/features/anyone_can_update_a_property_defect_spec.rb
@@ -44,7 +44,7 @@ RSpec.feature 'Anyone can update a defect' do
     expect(page).to have_content('Brickwork')
     expect(page).to have_content(new_priority.name)
 
-    expect(page).to have_content((Time.zone.now + priority.days.days).to_date)
+    expect(page).to have_content((Date.current + new_priority.days).to_date)
   end
 
   scenario 'a defect status can be updated' do

--- a/spec/features/anyone_can_update_a_property_defect_spec.rb
+++ b/spec/features/anyone_can_update_a_property_defect_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature 'Anyone can update a defect' do
 
   scenario 'a defect can be updated' do
     defect = create(:property_defect, property: property)
-    priority = defect.property.scheme.priorities.first
+    new_priority = create(:priority, scheme: property.scheme, days: 999)
 
     visit property_defect_path(defect.property, defect)
 
@@ -30,7 +30,7 @@ RSpec.feature 'Anyone can update a defect' do
 
       expect(page).to have_content(defect.target_completion_date)
 
-      choose "#{priority.name} - #{priority.days} days from now"
+      choose "#{new_priority.name} - #{new_priority.days} days from now"
       click_on(I18n.t('button.update.defect'))
     end
 
@@ -42,7 +42,7 @@ RSpec.feature 'Anyone can update a defect' do
     expect(page).to have_content('email@foo.com')
     expect(page).to have_content('0123456789')
     expect(page).to have_content('Brickwork')
-    expect(page).to have_content(priority.name)
+    expect(page).to have_content(new_priority.name)
 
     expect(page).to have_content((Time.zone.now + priority.days.days).to_date)
   end

--- a/spec/fixtures/download_defects.csv
+++ b/spec/fixtures/download_defects.csv
@@ -1,3 +1,3 @@
 reference_number,created_at,title,type,status,trade,priority_name,priority_duration,target_completion_date,property_address,communal_area_name,communal_area_location,description,access_information
-456ABC,"1st October 2017, 13:13",a shorter title,Communal,Outstanding,Electrical,P1,1, 2 July 2019,,Pine Creek,1-100 Hackney Street,a longer description,The communal door will be unlocked
-123ABC,"1st October 2018, 13:13",a short title,Property,Outstanding,Electrical,P1,1, 2 July 2019,1 Hackney Street,,,a long description,The key is under the garden pot
+456ABC,"1st October 2017, 13:13",a shorter title,Communal,Outstanding,Electrical,P1,1, 1 October 2019,,Pine Creek,1-100 Hackney Street,a longer description,The communal door will be unlocked
+123ABC,"1st October 2018, 13:13",a short title,Property,Outstanding,Electrical,P1,1, 1 October 2020,1 Hackney Street,,,a long description,The key is under the garden pot

--- a/spec/models/defect_spec.rb
+++ b/spec/models/defect_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe Defect, type: :model do
 
       defect.set_completion_date
 
-      expect(defect.reload.target_completion_date).to eq(Date.new(2019, 5, 25))
+      expect(defect.target_completion_date).to eq(Date.new(2019, 5, 26))
 
       travel_back
     end

--- a/spec/services/edit_defect_spec.rb
+++ b/spec/services/edit_defect_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe EditDefect do
+  let(:defect) { create(:property_defect) }
+  let(:defect_params) do
+    build(:property_defect).attributes
+  end
+
+  describe '#call' do
+    let(:service) do
+      described_class.new(defect: defect, defect_params: defect_params)
+    end
+
+    it 'returns a defect object' do
+      expect(service.call).to be_kind_of(Defect)
+    end
+
+    it 'passes the new params to assign_attributes' do
+      expect(defect).to receive(:assign_attributes).with(defect_params)
+      service.call
+    end
+
+    context 'when a new priority is present' do
+      let(:new_priority) { create(:priority) }
+      let(:service) do
+        described_class.new(
+          defect: defect,
+          defect_params: defect_params,
+          options: { priority_id: new_priority.id }
+        )
+      end
+
+      it 'creates an association to the new_priority' do
+        result = service.call
+        expect(result.priority).to eq(new_priority)
+      end
+
+      it 'updates the target_completion_date' do
+        result = service.call
+        expect(result.target_completion_date).to eq(Date.current + new_priority.days)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Changes in this PR:
- Time was used in once place instead of Date
- the Defect FactoryBot is now respecting default and custom target_completion_date
- removed a `reload` that was now shown to be returning a false positive test result
- this problem has been noticed through the current piece of work I'm doing to create a single defect overview which has moved presentational logic (like showing the target completion date) into a presenter rather than the defect model, those tests highlighted an issue
- as part of removing the activerecord hooks a new EditDefect service exists alongside BuildDefect to isolate this logic away from the PropertyDefect and CommunalDefect controllers to make this easier to understand and update in future