### PR TITLE
Retain shellwords correctly when invoking rspec

### DIFF
--- a/bin/dspec
+++ b/bin/dspec
@@ -7,5 +7,5 @@ then
   docker exec -it report-a-defect_test_web_1 rake default $@
 else
   echo "Testing: $@"
-  docker exec -it report-a-defect_test_web_1 rspec $@
+  docker exec -it report-a-defect_test_web_1 rspec "$@"
 fi


### PR DESCRIPTION
This is a fix for the script that runs the full build or rspec via docker; it was mangling shell arguments when I tried to run a specific rspec test.

A full description is in the commit message -- do let me know if this could be clearer or amended at all :)