### PR TITLE
[109] Basic filtering of the Defect overview

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -7,6 +7,7 @@ $govuk-image-url-function: 'image-url';
 @import 'components/lbh-header';
 @import 'components/lbh-buttons';
 @import 'components/flashes';
+@import 'components/filters';
 
 p {
   @include govuk-font(19);

--- a/app/assets/stylesheets/components/filters.scss
+++ b/app/assets/stylesheets/components/filters.scss
@@ -1,0 +1,10 @@
+.filter-defects {
+  border: 4px solid $lbh-panel-light;
+  padding: 0.75rem;
+
+  .lbh-checkboxes {
+    border-top: 1px solid $lbh-panel-light;
+    padding-top: 1px;
+    background-color: #fff;
+  }
+}

--- a/app/controllers/staff/dashboard_controller.rb
+++ b/app/controllers/staff/dashboard_controller.rb
@@ -2,5 +2,6 @@ class Staff::DashboardController < Staff::BaseController
   def index
     @estates = Estate.all
     @search = Search.new
+    @defect_filter = DefectFilter.new
   end
 end

--- a/app/controllers/staff/defects_controller.rb
+++ b/app/controllers/staff/defects_controller.rb
@@ -1,5 +1,25 @@
 class Staff::DefectsController < Staff::BaseController
   def index
-    @defects = DefectFinder.new.call
+    @defect_filter = DefectFilter.new(statuses: statuses)
+    @defects = DefectFinder.new(filter: @defect_filter).call
+  end
+
+  private
+
+  def statuses
+    params.fetch(:statuses, [])
+          .map { |status| status.parameterize.underscore.to_sym }
+  end
+
+  helper_method :open_status?
+  def open_status?
+    return false if statuses.blank?
+    statuses.include?(:open)
+  end
+
+  helper_method :closed_status?
+  def closed_status?
+    return false if statuses.blank?
+    statuses.include?(:closed)
   end
 end

--- a/app/models/defect.rb
+++ b/app/models/defect.rb
@@ -31,6 +31,7 @@ class Defect < ApplicationRecord
   ]
 
   scope :open, (-> { where(status: %i[outstanding follow_on end_of_year dispute referral]) })
+  scope :closed, (-> { where(status: %i[completed closed raised_in_error rejected]) })
 
   belongs_to :property, optional: true
   belongs_to :communal_area, optional: true

--- a/app/services/defect_filter.rb
+++ b/app/services/defect_filter.rb
@@ -1,0 +1,26 @@
+class DefectFilter
+  attr_accessor :statuses
+
+  def initialize(statuses: [])
+    self.statuses = statuses
+  end
+
+  def scope
+    return :all if open? && closed?
+    return :open if open?
+    return :closed if closed?
+    :none
+  end
+
+  def none?
+    statuses.empty?
+  end
+
+  def open?
+    statuses.include?(:open)
+  end
+
+  def closed?
+    statuses.include?(:closed)
+  end
+end

--- a/app/services/defect_finder.rb
+++ b/app/services/defect_finder.rb
@@ -1,7 +1,11 @@
 class DefectFinder
   def call
     Defect.all
-          .includes(:property, :communal_area, :priority)
+          .includes(:property,
+                    :communal_area,
+                    :priority,
+                    property: :scheme,
+                    communal_area: :scheme)
           .order(:target_completion_date)
           .map { |defect| DefectPresenter.new(defect) }
   end

--- a/app/services/defect_finder.rb
+++ b/app/services/defect_finder.rb
@@ -1,12 +1,21 @@
 class DefectFinder
+  attr_accessor :filter
+
+  def initialize(filter: {})
+    self.filter = filter
+  end
+
   def call
-    Defect.all
-          .includes(:property,
-                    :communal_area,
-                    :priority,
-                    property: :scheme,
-                    communal_area: :scheme)
-          .order(:target_completion_date)
-          .map { |defect| DefectPresenter.new(defect) }
+    defects.includes(:property,
+                     :communal_area,
+                     :priority,
+                     property: :scheme,
+                     communal_area: :scheme)
+           .order(:target_completion_date)
+           .map { |defect| DefectPresenter.new(defect) }
+  end
+
+  def defects
+    Defect.send(filter.scope)
   end
 end

--- a/app/services/defect_finder.rb
+++ b/app/services/defect_finder.rb
@@ -1,6 +1,6 @@
 class DefectFinder
   def call
-    Defect.open
+    Defect.all
           .includes(:property, :communal_area, :priority)
           .order(:target_completion_date)
           .map { |defect| DefectPresenter.new(defect) }

--- a/app/views/staff/dashboard/index.html.haml
+++ b/app/views/staff/dashboard/index.html.haml
@@ -15,20 +15,22 @@
         = search_field_tag :query, @search.query, class: 'govuk-input form-control form-control-communal_area govuk-!-width-three-quarters', placeholder: '1 Hackney Street or Clift House'
       = submit_tag I18n.t('generic.button.find'), class: 'govuk-button mb0'
 
-      %hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
+    %hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
 
-      %h3.govuk-heading-m
-        = I18n.t('page_content.dashboard.header.defect_overview')
-      %p.govuk-body-s
-        = I18n.t('page_content.dashboard.description.defect_overview')
+    %h3.govuk-heading-m
+      = I18n.t('page_content.dashboard.header.defect_overview')
+    %p.govuk-body-s
+      = I18n.t('page_content.dashboard.description.defect_overview')
 
-      = link_to('View all defects', defects_path, class: 'govuk-button mb0')
+    = form_tag defects_path, method: :get do
+      = hidden_field_tag 'statuses[]', 'Open'
+      = submit_tag 'View all defects', class: 'govuk-button mb0'
 
-      %hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
+    %hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
 
-      %h3.govuk-heading-m
-        = I18n.t('page_content.dashboard.header.reporting')
-      = link_to(I18n.t('button.report.download_all'), report_path(format: :csv), class: 'govuk-button govuk-button--secondary mb0')
+    %h3.govuk-heading-m
+      = I18n.t('page_content.dashboard.header.reporting')
+    = link_to(I18n.t('button.report.download_all'), report_path(format: :csv), class: 'govuk-button govuk-button--secondary mb0')
 
   .govuk-grid-column-one-third
     %h2.govuk-heading-m

--- a/app/views/staff/defects/index.html.haml
+++ b/app/views/staff/defects/index.html.haml
@@ -5,6 +5,24 @@
   .govuk-grid-column-full
     %h1.govuk-heading-l
       = I18n.t('page_title.staff.defects.index')
+      %span.govuk-caption-l= "Showing #{@defects.count} of #{Defect.count} defects"
+
+.govuk-grid-row
+  .govuk-grid-column-full
+    %h2.govuk-heading-m Filters
+
+    = form_tag defects_path, class: 'filter-defects', method: :get do
+      .govuk-form-group
+        %fieldset.govuk-fieldset
+          = label_tag 'statuses', 'Status', class: 'govuk-label'
+          .govuk-checkboxes.checkbox-group
+            .govuk-checkboxes__item
+              = check_box_tag 'statuses[]', 'Open', open_status?, id: 'statuses_open', class: 'govuk-checkboxes__input'
+              = label_tag 'statuses[]', 'Open', for: 'statuses_open', class: 'govuk-label govuk-checkboxes__label'
+            .govuk-checkboxes__item
+              = check_box_tag 'statuses[]', 'Closed', closed_status?, id: 'statuses_closed', class: 'govuk-checkboxes__input'
+              = label_tag 'statuses[]', 'Closed', for: 'statuses_closed', class: 'govuk-label govuk-checkboxes__label'
+      = submit_tag I18n.t('generic.button.filter'), class: 'govuk-button mb0'
 
 .govuk-grid-row
   .govuk-grid-column-full
@@ -20,9 +38,9 @@
           %th.govuk-table__header
             Type
           %th.govuk-table__header
-            Address
-          %th.govuk-table__header
             Status
+          %th.govuk-table__header
+            Address
           %th.govuk-table__header
             Priority
           %th.govuk-table__header

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -58,5 +58,11 @@ Rails.application.configure do
     Bullet.add_whitelist type: :unused_eager_loading,
                          class_name: 'Defect',
                          association: :priority
+    Bullet.add_whitelist type: :unused_eager_loading,
+                         class_name: 'Property',
+                         association: :scheme
+    Bullet.add_whitelist type: :unused_eager_loading,
+                         class_name: 'CommunalArea',
+                         association: :scheme
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -78,6 +78,7 @@ en:
     button:
       find: 'Search'
       download: 'Download'
+      filter: 'Filter'
     notice:
       create:
         success:

--- a/spec/features/anyone_can_view_all_defects_spec.rb
+++ b/spec/features/anyone_can_view_all_defects_spec.rb
@@ -38,4 +38,23 @@ RSpec.feature 'Anyone can view all defects' do
       )
     end
   end
+
+  scenario 'closed defects can shown using a filter' do
+    _open_defect = DefectPresenter.new(create(:property_defect, status: :outstanding))
+    closed_defect = DefectPresenter.new(create(:property_defect, status: :completed))
+
+    visit root_path
+
+    click_on('View all defects')
+
+    within('.filter-defects') do
+      check 'Closed', name: 'statuses[]'
+      click_on(I18n.t('generic.button.filter'))
+    end
+
+    within '.defects' do
+      expect(page).to have_content(closed_defect.reference_number)
+      expect(page).to have_content(closed_defect.status)
+    end
+  end
 end

--- a/spec/services/defect_filter_spec.rb
+++ b/spec/services/defect_filter_spec.rb
@@ -1,0 +1,88 @@
+require 'rails_helper'
+
+RSpec.describe DefectFilter do
+  describe '#scope' do
+    context 'when the status are both open and closed' do
+      it 'returns :all' do
+        result = described_class.new(statuses: %i[open closed])
+        expect(result.scope).to eq(:all)
+      end
+    end
+
+    context 'when the status is only open' do
+      it 'returns :open' do
+        result = described_class.new(statuses: %i[open])
+        expect(result.scope).to eq(:open)
+      end
+    end
+
+    context 'when the status is only closed' do
+      it 'returns :closed' do
+        result = described_class.new(statuses: %i[closed])
+        expect(result.scope).to eq(:closed)
+      end
+    end
+
+    context 'when the status is neither' do
+      it 'returns :none' do
+        result = described_class.new(statuses: %i[foo])
+        expect(result.scope).to eq(:none)
+      end
+    end
+
+    context 'when there are no statuses' do
+      it 'returns :none' do
+        result = described_class.new(statuses: %i[])
+        expect(result.scope).to eq(:none)
+      end
+    end
+  end
+
+  describe '#none?' do
+    context 'when there are no statuses' do
+      it 'returns true' do
+        result = described_class.new(statuses: [])
+        expect(result.none?).to eq(true)
+      end
+    end
+
+    context 'when there is at least one status' do
+      it 'returns false' do
+        result = described_class.new(statuses: [:foo])
+        expect(result.none?).to eq(false)
+      end
+    end
+  end
+
+  describe '#open?' do
+    context 'when there is an open status' do
+      it 'returns true' do
+        result = described_class.new(statuses: [:open])
+        expect(result.open?).to eq(true)
+      end
+    end
+
+    context 'when open is not an included status' do
+      it 'returns false' do
+        result = described_class.new(statuses: [:foo])
+        expect(result.open?).to eq(false)
+      end
+    end
+  end
+
+  describe '#closed' do
+    context 'when there is an closed status' do
+      it 'returns true' do
+        result = described_class.new(statuses: [:closed])
+        expect(result.closed?).to eq(true)
+      end
+    end
+
+    context 'when closed is not an included status' do
+      it 'returns false' do
+        result = described_class.new(statuses: [:foo])
+        expect(result.closed?).to eq(false)
+      end
+    end
+  end
+end

--- a/spec/services/defect_finder_spec.rb
+++ b/spec/services/defect_finder_spec.rb
@@ -56,5 +56,16 @@ RSpec.describe DefectFinder do
       expect(result[3]).to eq(defect_two)
       expect(result[4]).to eq(defect_one)
     end
+    it 'eager loads associated records' do
+      create(:property_defect)
+
+      result = described_class.new(filter: filter).call
+
+      defect = result.first
+
+      expect(defect.association(:property).loaded?).to eq(true)
+      expect(defect.association(:communal_area).loaded?).to eq(true)
+      expect(defect.association(:priority).loaded?).to eq(true)
+    end
   end
 end

--- a/spec/services/defect_finder_spec.rb
+++ b/spec/services/defect_finder_spec.rb
@@ -2,43 +2,17 @@ require 'rails_helper'
 
 RSpec.describe DefectFinder do
   describe '#call' do
-    let(:service) do
-      described_class.new
+    let(:filter) do
+      double('DefectFilter', scope: :all)
     end
 
     it 'returns an array of DefectPresenters for open Defects' do
       defect_one = create(:property_defect, status: :outstanding)
 
-      result = service.call
+      result = described_class.new(filter: filter).call
 
       expect(result).to be_a(Array)
       expect(result.first).to eq(defect_one)
-    end
-
-    it 'does not return closed or completed defects' do
-      outstanding_defect = create(:property_defect, status: :outstanding)
-      follow_on_defect = create(:property_defect, status: :follow_on)
-      end_of_year_defect = create(:property_defect, status: :end_of_year)
-      dispute_defect = create(:property_defect, status: :dispute)
-      referral_defect = create(:property_defect, status: :referral)
-
-      closed_defect = create(:property_defect, status: :closed)
-      completed_defect = create(:property_defect, status: :completed)
-      raised_in_error_defect = create(:property_defect, status: :raised_in_error)
-      rejected_defect = create(:property_defect, status: :rejected)
-
-      result = service.call
-
-      expect(result).to include(outstanding_defect)
-      expect(result).to include(follow_on_defect)
-      expect(result).to include(end_of_year_defect)
-      expect(result).to include(dispute_defect)
-      expect(result).to include(referral_defect)
-
-      expect(result).not_to include(closed_defect)
-      expect(result).not_to include(completed_defect)
-      expect(result).not_to include(raised_in_error_defect)
-      expect(result).not_to include(rejected_defect)
     end
 
     it 'sorts the list by target_completion_date' do
@@ -48,7 +22,7 @@ RSpec.describe DefectFinder do
       defect_four = create(:property_defect, status: :outstanding, target_completion_date: 1.day.ago)
       defect_three = create(:property_defect, status: :outstanding, target_completion_date: 0.days.from_now)
 
-      result = service.call
+      result = described_class.new(filter: filter).call
 
       expect(result[0]).to eq(defect_five)
       expect(result[1]).to eq(defect_four)
@@ -56,6 +30,7 @@ RSpec.describe DefectFinder do
       expect(result[3]).to eq(defect_two)
       expect(result[4]).to eq(defect_one)
     end
+
     it 'eager loads associated records' do
       create(:property_defect)
 
@@ -66,6 +41,37 @@ RSpec.describe DefectFinder do
       expect(defect.association(:property).loaded?).to eq(true)
       expect(defect.association(:communal_area).loaded?).to eq(true)
       expect(defect.association(:priority).loaded?).to eq(true)
+    end
+
+    context 'when the filters object returns a scope' do
+      it 'returns all open defects' do
+        outstanding_defect = create(:property_defect, status: :outstanding)
+        follow_on_defect = create(:property_defect, status: :follow_on)
+        end_of_year_defect = create(:property_defect, status: :end_of_year)
+        dispute_defect = create(:property_defect, status: :dispute)
+        referral_defect = create(:property_defect, status: :referral)
+
+        closed_defect = create(:property_defect, status: :closed)
+        completed_defect = create(:property_defect, status: :completed)
+        raised_in_error_defect = create(:property_defect, status: :raised_in_error)
+        rejected_defect = create(:property_defect, status: :rejected)
+
+        filter = double('DefectFilter', scope: :open)
+        expect(filter).to receive(:scope).and_return(:open)
+
+        result = described_class.new(filter: filter).call
+
+        expect(result).to include(outstanding_defect)
+        expect(result).to include(follow_on_defect)
+        expect(result).to include(end_of_year_defect)
+        expect(result).to include(dispute_defect)
+        expect(result).to include(referral_defect)
+
+        expect(result).not_to include(closed_defect)
+        expect(result).not_to include(completed_defect)
+        expect(result).not_to include(raised_in_error_defect)
+        expect(result).not_to include(rejected_defect)
+      end
     end
   end
 end


### PR DESCRIPTION
## Changes in this PR:
- defects can now be filtered by open or closed statuses (it will default to showing only open defects)
- designs for the page aren't complete but we feel are good enough to do some testing with users and get some feedback

## Screenshots of UI changes:
![Screenshot 2019-07-04 at 11 54 38](https://user-images.githubusercontent.com/912473/60661849-c91ae280-9e52-11e9-91a1-693b34d74d22.png)
![Screenshot 2019-07-04 at 11 54 41](https://user-images.githubusercontent.com/912473/60661850-c91ae280-9e52-11e9-8fd1-3ed3acaa9d6a.png)
![Screenshot 2019-07-04 at 11 54 43](https://user-images.githubusercontent.com/912473/60661851-c91ae280-9e52-11e9-9a8a-c98c1b53be80.png)
