### PR TITLE
Fix the delay to changing assets in development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -40,7 +40,7 @@ Rails.application.configure do
   # Debug mode disables concatenation and preprocessing of assets.
   # This option may cause significant delays in view rendering with a large
   # number of complex assets.
-  config.assets.debug = true
+  config.assets.debug = false
 
   # Suppress logger output for asset requests.
   config.assets.quiet = true


### PR DESCRIPTION
## Changes in this PR:
* This delay was becoming more and more noticeable when changing styles, the local server would take time to precompile all assets each time there was a small change. In development, we don't get any advantages in using precompile assets.