### PR TITLE
Fix production deploys and turn on a Sidekiq process on Heroku

### DIFF
--- a/heroku.yml
+++ b/heroku.yml
@@ -7,3 +7,7 @@ release:
     - rake db:migrate
 run:
   web: bundle exec puma -C config/puma.rb
+  worker:
+    command:
+      - bundle exec sidekiq -C config/sidekiq.yml
+    image: web

--- a/heroku.yml
+++ b/heroku.yml
@@ -1,6 +1,3 @@
-setup:
-  addons:
-  - plan: heroku-postgresql
 build:
   docker:
     web: Dockerfile

--- a/heroku.yml
+++ b/heroku.yml
@@ -6,4 +6,4 @@ release:
   command:
     - rake db:migrate
 run:
-  web: rails s
+  web: bundle exec puma -C config/puma.rb


### PR DESCRIPTION
* As the title says, the presence of a worker process in Heroku was accidentally omitted during the work emails were still being sent and all the tests were fine. I imagine that even though `queue_adapter` was set to Sidekiq, since there was no explicit start command called, it was falling back to running inline.