### PR TITLE
(fix) Deployments to Heroku use containers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,19 +23,25 @@ jobs:
           name: Run the tests
           command: |
             bin/dtest-server ci
-            docker ps
             bin/dspec
+      - run:
+          name: Make a cache
+          command: mkdir -p /cache
       - run:
           name: Save the tested Docker image for deployment
           command: |
-            mkdir -p docker-cache
             docker tag reportadefect_test:latest reportadefect:$CIRCLE_SHA1
-            docker image save -o docker-cache/built-image.tar reportadefect:$CIRCLE_SHA1
-            docker image load --input docker-cache/built-image.tar
+            docker image save -o /cache/built-image.tar reportadefect:$CIRCLE_SHA1
+            docker image load --input /cache/built-image.tar
+      - run:
+          name: Save the application for deployment
+          command: |
+            cp -rT . /cache/report-a-defect
       - save_cache:
           key: docker-images-{{ .Environment.CIRCLE_SHA1 }}
           paths:
-            - docker-cache/built-image.tar
+            - /cache/report-a-defect
+            - /cache/built-image.tar
 
   deploy_staging:
     working_directory: ~/report_a_defect
@@ -56,11 +62,20 @@ jobs:
           name: Login to Docker
           command: docker login --username=$HEROKU_LOGIN --password=$HEROKU_API_KEY registry.heroku.com
       - run:
+          name: Setup Heroku
+          command: |
+            cp -rT /cache/report-a-defect .
+            git init
+            git remote add heroku https://git.heroku.com/$HEROKU_APP_NAME_STAGING.git
+            chmod +x /cache/report_a_defect/.circlici/setup-heroku.sh
+            /cache/report_a_defect/.circlici/setup-heroku.sh
+      - run:
           name: Deploy the Docker image to Heroku Staging
           command: |
-            docker image load --input /root/report_a_defect/docker-cache/built-image.tar
+            docker image load --input /cache/built-image.tar
             docker tag reportadefect:$CIRCLE_SHA1 registry.heroku.com/$HEROKU_APP_NAME_STAGING/web
             docker push registry.heroku.com/$HEROKU_APP_NAME_STAGING/web
+            heroku container:release web --app $HEROKU_APP_NAME_STAGING
 
   deploy_production:
     working_directory: ~/report_a_defect
@@ -81,11 +96,20 @@ jobs:
           name: Login to Docker
           command: docker login --username=$HEROKU_LOGIN --password=$HEROKU_API_KEY registry.heroku.com
       - run:
+          name: Setup Heroku
+          command: |
+            cp -rT /cache/report-a-defect .
+            git init
+            git remote add heroku https://git.heroku.com/$HEROKU_APP_NAME_PRODUCTION.git
+            chmod +x /cache/report-a-defect/.circleci/setup-heroku.sh
+            /cache/report-a-defect/.circleci/setup-heroku.sh
+      - run:
           name: Deploy the Docker image to Heroku Production
           command: |
-            docker image load --input /root/report_a_defect/docker-cache/built-image.tar
+            docker image load --input /cache/built-image.tar
             docker tag reportadefect:$CIRCLE_SHA1 registry.heroku.com/$HEROKU_APP_NAME_PRODUCTION/web
             docker push registry.heroku.com/$HEROKU_APP_NAME_PRODUCTION/web
+            heroku container:release web --app $HEROKU_APP_NAME_PRODUCTION
 
 workflows:
   version: 2

--- a/.circleci/setup-heroku.sh
+++ b/.circleci/setup-heroku.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -eu
+curl https://cli-assets.heroku.com/install.sh | sh
+cat > ~/.netrc << EOF
+machine api.heroku.com
+login $HEROKU_LOGIN
+password $HEROKU_API_KEY
+machine git.heroku.com
+login $HEROKU_LOGIN
+password $HEROKU_API_KEY
+EOF
+chmod 600 ~/.netrc


### PR DESCRIPTION
## Changes in this PR:
* Heroku-cli is required to release new versions of containers, somehow staging has been using buildpacks as a result of GitHub webhooks letting us know a new commit was made. I thought this turning was disabled however since the recent production deploy I noticed it was off.
* We have to use setup-heroku.sh to create a ~/.netrc file which Heroku will check before asking for a browser based log in, which isn't possible from an automated CI machine. Inspiration comes from this post https://discuss.circleci.com/t/deployment-on-circleci-docker-heroku-does-not-work/26106/3
