### PR TITLE
Feature/140 record status change events

### DIFF
--- a/app/helpers/defect_helper.rb
+++ b/app/helpers/defect_helper.rb
@@ -25,30 +25,6 @@ module DefectHelper
   end
 
   def event_description_for(event:)
-    case event.key
-    when 'defect.create' then
-      if event.owner
-        I18n.t('events.defect.created', name: event.owner.name)
-      else
-        event.key
-      end
-    when 'defect.forwarded_to_contractor' then
-      I18n.t(
-        'events.defect.forwarded_to_contractor',
-        email: event.trackable.scheme.contractor_email_address
-      )
-    when 'defect.forwarded_to_employer_agent' then
-      I18n.t(
-        'events.defect.forwarded_to_employer_agent',
-        email: event.trackable.scheme.employer_agent_email_address
-      )
-    when 'defect.accepted' then
-      I18n.t(
-        'events.defect.accepted',
-        email: event.trackable.scheme.contractor_email_address
-      )
-    else
-      event.key
-    end
+    DefectEventPresenter.new(event).description
   end
 end

--- a/app/models/defect.rb
+++ b/app/models/defect.rb
@@ -60,7 +60,17 @@ class Defect < ApplicationRecord
   end
 
   include PublicActivity::Model
-  tracked owner: ->(controller, _) { controller.current_user if controller }
+  tracked \
+    owner: ->(controller, _) { controller.current_user if controller },
+    params: { changes: ->(_, model) { model.tracked_changes } }
+
+  before_save :remember_changes_for_activity
+  attr_reader :tracked_changes
+
+  def remember_changes_for_activity
+    selected_changes = changes.slice(:status)
+    @tracked_changes = selected_changes unless selected_changes.empty?
+  end
 
   TRADES = [
     'Blinds',

--- a/app/models/defect.rb
+++ b/app/models/defect.rb
@@ -117,8 +117,12 @@ class Defect < ApplicationRecord
     self.target_completion_date = Date.current + priority.days.days
   end
 
+  def self.format_status(status)
+    status.tr('_', ' ').capitalize
+  end
+
   def status
-    super.tr('_', ' ').capitalize
+    Defect.format_status(super)
   end
 
   def contact_phone_number=(value)

--- a/app/presenters/defect_event_presenter.rb
+++ b/app/presenters/defect_event_presenter.rb
@@ -7,6 +7,8 @@ class DefectEventPresenter
     case @event.key
     when 'defect.create' then
       description_for_create
+    when 'defect.update' then
+      description_for_update
     when 'defect.forwarded_to_contractor' then
       descrition_for_forwarded_to_contractor
     when 'defect.forwarded_to_employer_agent' then
@@ -25,6 +27,15 @@ class DefectEventPresenter
       I18n.t('events.defect.created', name: @event.owner.name)
     else
       @event.key
+    end
+  end
+
+  def description_for_update
+    if params[:changes]&.key?(:status)
+      old, new = params[:changes][:status].map { |status| Defect.format_status(status) }
+      I18n.t('events.defect.status_changed', name: @event.owner.name, old: old, new: new)
+    else
+      I18n.t('events.defect.updated', name: @event.owner.name)
     end
   end
 

--- a/app/presenters/defect_event_presenter.rb
+++ b/app/presenters/defect_event_presenter.rb
@@ -1,0 +1,55 @@
+class DefectEventPresenter
+  def initialize(event)
+    @event = event
+  end
+
+  def description
+    case @event.key
+    when 'defect.create' then
+      description_for_create
+    when 'defect.forwarded_to_contractor' then
+      descrition_for_forwarded_to_contractor
+    when 'defect.forwarded_to_employer_agent' then
+      description_for_forwarded_to_employer_agent
+    when 'defect.accepted' then
+      description_for_accepted
+    else
+      @event.key
+    end
+  end
+
+  private
+
+  def description_for_create
+    if @event.owner
+      I18n.t('events.defect.created', name: @event.owner.name)
+    else
+      @event.key
+    end
+  end
+
+  def descrition_for_forwarded_to_contractor
+    I18n.t(
+      'events.defect.forwarded_to_contractor',
+      email: @event.trackable.scheme.contractor_email_address
+    )
+  end
+
+  def description_for_forwarded_to_employer_agent
+    I18n.t(
+      'events.defect.forwarded_to_employer_agent',
+      email: @event.trackable.scheme.employer_agent_email_address
+    )
+  end
+
+  def description_for_accepted
+    I18n.t(
+      'events.defect.accepted',
+      email: @event.trackable.scheme.contractor_email_address
+    )
+  end
+
+  def params
+    @event.parameters
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -158,6 +158,8 @@ en:
   events:
     defect:
       created: 'Defect was created by %{name}'
+      updated: 'Defect was updated by %{name}'
+      status_changed: 'Status was changed from %{old} to %{new} by %{name}'
       forwarded_to_contractor: 'An email was sent to the contractor (%{email})'
       forwarded_to_employer_agent: 'An email was sent to the employer agent (%{email})'
       accepted: 'Defect was accepted by %{email}'

--- a/spec/features/anyone_can_update_a_property_defect_spec.rb
+++ b/spec/features/anyone_can_update_a_property_defect_spec.rb
@@ -61,6 +61,25 @@ RSpec.feature 'Anyone can update a defect' do
     expect(page).to have_content('Completed')
   end
 
+  scenario 'a detect status change is listed as an event' do
+    travel_to Time.zone.parse('2019-05-23')
+
+    defect = create(:property_defect, property: property, status: :outstanding)
+
+    visit edit_property_defect_path(defect.property, defect)
+
+    within('form.edit_defect') do
+      select 'Completed', from: 'defect[status]'
+      click_on(I18n.t('button.update.defect'))
+    end
+
+    within('.events') do
+      expect(page).to have_content(
+        I18n.t('events.defect.status_changed', name: 'Generic team user', old: 'Outstanding', new: 'Completed')
+      )
+    end
+  end
+
   scenario 'any defect status can be chosen' do
     defect = create(:property_defect, property: property)
 

--- a/spec/helpers/defect_helper_spec.rb
+++ b/spec/helpers/defect_helper_spec.rb
@@ -83,6 +83,31 @@ RSpec.describe DefectHelper, type: :helper do
       end
     end
 
+    context 'when the key is defect.update' do
+      it 'returns the event description' do
+        event = PublicActivity::Activity.new(trackable: defect, owner: user, key: 'defect.update')
+        result = helper.event_description_for(event: event)
+        expect(result).to eql(I18n.t('events.defect.updated',
+                                     name: event.owner.name))
+      end
+    end
+
+    context 'when the event describes a status change' do
+      it 'returns the event description' do
+        event = PublicActivity::Activity.new(
+          trackable: defect,
+          owner: user,
+          key: 'defect.update',
+          parameters: { changes: { status: %w[outstanding follow_on] } }
+        )
+        result = helper.event_description_for(event: event)
+        expect(result).to eql(I18n.t('events.defect.status_changed',
+                                     name: event.owner.name,
+                                     old: 'Outstanding',
+                                     new: 'Follow on'))
+      end
+    end
+
     context 'when the key is defect.forwarded_to_contractor' do
       it 'returns the event description' do
         event = PublicActivity::Activity.new(trackable: defect, owner: user, key: 'defect.forwarded_to_contractor')

--- a/spec/models/defect_spec.rb
+++ b/spec/models/defect_spec.rb
@@ -134,6 +134,14 @@ RSpec.describe Defect, type: :model do
       defect = build(:defect, status: 'follow_on')
       expect(defect.status).to eq('Follow on')
     end
+
+    it 'records changes in the activity log' do
+      defect = build(:defect, status: 'outstanding')
+      defect.follow_on!
+
+      event = defect.activities.last
+      expect(event.parameters[:changes]).to eq('status' => %w[outstanding follow_on])
+    end
   end
 
   describe '#set_completion_date' do


### PR DESCRIPTION
## Changes in this PR:

This records all changes to the status of a defect, and presents them in the event log when viewing the defect. We show the previous and new value of the status, and show the person that changed the status.

## Screenshots of UI changes:

<img width="613" alt="Screenshot 2019-07-10 at 13 56 58" src="https://user-images.githubusercontent.com/9265/60970843-b7d24a00-a31a-11e9-92af-978a6361d87b.png">