### PR TITLE
[109] Filter defects by scheme name

### DIFF
--- a/app/controllers/staff/defects_controller.rb
+++ b/app/controllers/staff/defects_controller.rb
@@ -1,6 +1,10 @@
 class Staff::DefectsController < Staff::BaseController
   def index
-    @defect_filter = DefectFilter.new(statuses: statuses, types: types)
+    @defect_filter = DefectFilter.new(
+      statuses: statuses,
+      types: types,
+      schemes: scheme_ids,
+    )
     @defects = DefectFinder.new(order: :target_completion_date, filter: @defect_filter)
                            .call
                            .map { |defect| DefectPresenter.new(defect) }
@@ -40,5 +44,15 @@ class Staff::DefectsController < Staff::BaseController
   def type_communal?
     return false if types.blank?
     types.include?(:communal)
+  end
+
+  def scheme_ids
+    params.fetch(:scheme_ids, [])
+  end
+
+  helper_method :selected_scheme?
+  def selected_scheme?(scheme_id)
+    return false if scheme_id.blank?
+    scheme_ids.include?(scheme_id)
   end
 end

--- a/app/models/defect.rb
+++ b/app/models/defect.rb
@@ -43,6 +43,11 @@ class Defect < ApplicationRecord
   scope :for_properties_or_communal_areas, lambda { |property_ids, communal_area_ids|
     for_properties(property_ids).or(for_communal_areas(communal_area_ids))
   }
+  scope :for_scheme, (lambda { |scheme_ids|
+    property_ids = Property.joins(:scheme).where(schemes: { id: scheme_ids }).pluck(:id)
+    communal_area_ids = CommunalArea.joins(:scheme).where(schemes: { id: scheme_ids }).pluck(:id)
+    for_properties_or_communal_areas(property_ids, communal_area_ids)
+  })
 
   belongs_to :property, optional: true
   belongs_to :communal_area, optional: true

--- a/app/models/defect.rb
+++ b/app/models/defect.rb
@@ -38,6 +38,12 @@ class Defect < ApplicationRecord
   scope :property, (-> { where(communal: false) })
   scope :communal, (-> { where(communal: true) })
 
+  scope :for_properties, (->(property_ids) { where(property_id: property_ids) })
+  scope :for_communal_areas, (->(communal_area_ids) { where(communal_area_id: communal_area_ids) })
+  scope :for_properties_or_communal_areas, lambda { |property_ids, communal_area_ids|
+    for_properties(property_ids).or(for_communal_areas(communal_area_ids))
+  }
+
   belongs_to :property, optional: true
   belongs_to :communal_area, optional: true
   belongs_to :priority

--- a/app/models/defect.rb
+++ b/app/models/defect.rb
@@ -87,7 +87,7 @@ class Defect < ApplicationRecord
   ].freeze
 
   def self.send_chain(methods)
-    methods.inject(self, :send)
+    methods.inject(self) { |s, method| s.send(*method) }
   end
 
   def set_completion_date

--- a/app/services/defect_filter.rb
+++ b/app/services/defect_filter.rb
@@ -8,7 +8,9 @@ class DefectFilter
   end
 
   def scopes
-    [status_scope, type_scope].compact
+    scopes = [status_scope, type_scope].compact
+    return [:all] if scopes.empty?
+    scopes
   end
 
   private

--- a/app/services/defect_filter.rb
+++ b/app/services/defect_filter.rb
@@ -1,14 +1,16 @@
 class DefectFilter
   attr_accessor :statuses,
-                :types
+                :types,
+                :schemes
 
-  def initialize(statuses: [], types: [])
+  def initialize(statuses: [], types: [], schemes: [])
     self.statuses = statuses
     self.types = types
+    self.schemes = schemes
   end
 
   def scopes
-    scopes = [status_scope, type_scope].compact
+    scopes = [status_scope, type_scope, scheme_scope].compact
     return [:all] if scopes.empty?
     scopes
   end
@@ -25,6 +27,11 @@ class DefectFilter
     return :property_and_communal if property? && communal?
     return :property if property?
     return :communal if communal?
+  end
+
+  def scheme_scope
+    return nil if schemes.empty?
+    [:for_scheme, schemes]
   end
 
   def none?

--- a/app/views/staff/dashboard/index.html.haml
+++ b/app/views/staff/dashboard/index.html.haml
@@ -26,6 +26,8 @@
       = hidden_field_tag 'statuses[]', 'Open'
       = hidden_field_tag 'types[]', 'Property'
       = hidden_field_tag 'types[]', 'Communal'
+      - Scheme.all.each do |scheme|
+        = hidden_field_tag 'scheme_ids[]', scheme.id
       = submit_tag 'View all defects', class: 'govuk-button mb0'
 
     %hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible

--- a/app/views/staff/defects/index.html.haml
+++ b/app/views/staff/defects/index.html.haml
@@ -31,7 +31,13 @@
             .govuk-checkboxes__item
               = check_box_tag 'types[]', 'Communal', type_communal?, id: 'types_communal', class: 'govuk-checkboxes__input'
               = label_tag 'types[]', 'Communal', for: 'types_communal', class: 'govuk-label govuk-checkboxes__label'
-
+        %fieldset.govuk-fieldset.lbh-fieldset
+          = label_tag 'schemes', 'Scheme', class: 'govuk-label'
+          .govuk-checkboxes.checkbox-group
+            - Scheme.all.each do |scheme|
+              .govuk-checkboxes__item
+                = check_box_tag 'scheme_ids[]', scheme.id, selected_scheme?(scheme.id), id: scheme.id, class: 'govuk-checkboxes__input'
+                = label_tag 'scheme_ids[]', scheme.name, for: scheme.id, class: 'govuk-label govuk-checkboxes__label'
       = submit_tag I18n.t('generic.button.filter'), class: 'govuk-button mb0'
 
 .govuk-grid-row

--- a/spec/features/anyone_can_view_all_defects_spec.rb
+++ b/spec/features/anyone_can_view_all_defects_spec.rb
@@ -107,10 +107,7 @@ RSpec.feature 'Anyone can view all defects' do
     click_on('View all defects')
 
     within('.filter-defects') do
-      uncheck 'Open', name: 'statuses[]'
-      uncheck 'Closed', name: 'statuses[]'
-      uncheck 'Property', name: 'types[]'
-      uncheck 'Communal', name: 'types[]'
+      uncheck_all_filters
       click_on(I18n.t('generic.button.filter'))
     end
 
@@ -119,6 +116,12 @@ RSpec.feature 'Anyone can view all defects' do
       expect(page).to have_content(closed_property_defect.reference_number)
       expect(page).to have_content(open_communal_defect.reference_number)
       expect(page).to have_content(closed_communal_defect.reference_number)
+    end
+  end
+
+  def uncheck_all_filters
+    all('input[type=checkbox]').each do |checkbox|
+      checkbox.click if checkbox.checked?
     end
   end
 end

--- a/spec/models/defect_spec.rb
+++ b/spec/models/defect_spec.rb
@@ -186,5 +186,15 @@ RSpec.describe Defect, type: :model do
       expect(described_class).to receive(:all)
       described_class.send_chain([:all])
     end
+
+    context 'when there is an nested array of parameters' do
+      it 'sends the symbol as a method, with the parameters' do
+        class TestDefect < Defect
+          scope :any_scope, (->(args) { where(id: args) })
+        end
+        expect(TestDefect).to receive(:any_scope).with(%w[foo bar])
+        TestDefect.send_chain([:all, [:any_scope, %w[foo bar]]])
+      end
+    end
   end
 end

--- a/spec/models/defect_spec.rb
+++ b/spec/models/defect_spec.rb
@@ -180,4 +180,11 @@ RSpec.describe Defect, type: :model do
       )
     end
   end
+
+  describe '.send_chain' do
+    it 'sends each symbol as a method to Defect' do
+      expect(described_class).to receive(:all)
+      described_class.send_chain([:all])
+    end
+  end
 end

--- a/spec/models/defect_spec.rb
+++ b/spec/models/defect_spec.rb
@@ -55,6 +55,58 @@ RSpec.describe Defect, type: :model do
     end
   end
 
+  describe '.for_properties' do
+    it 'returns a list of defects for a given property ID' do
+      interested_property = create(:property)
+      interested_property_defect = create(:property_defect, property: interested_property)
+      distracting_property = create(:property)
+      distracting_property_defect = create(:property_defect, property: distracting_property)
+
+      result = described_class.for_properties([interested_property.id])
+
+      expect(result).to include(interested_property_defect)
+      expect(result).not_to include(distracting_property_defect)
+    end
+  end
+
+  describe '.for_communal_areas' do
+    it 'returns a list of defects for a given communal area ID' do
+      interested_communal_area = create(:communal_area)
+      interested_communal_defect = create(:communal_defect, communal_area: interested_communal_area)
+      distracting_communal_area = create(:communal_area)
+      distracting_communal_defect = create(:communal_defect, communal_area: distracting_communal_area)
+
+      result = described_class.for_communal_areas([interested_communal_area.id])
+
+      expect(result).to include(interested_communal_defect)
+      expect(result).not_to include(distracting_communal_defect)
+    end
+  end
+
+  describe '.for_properties_or_communal_areas' do
+    it 'returns a list of defects that match either a list of property_ids or communal_area_ids' do
+      interested_property = create(:property)
+      interested_property_defect = create(:property_defect, property: interested_property)
+      distracting_property = create(:property)
+      distracting_property_defect = create(:property_defect, property: distracting_property)
+
+      interested_communal_area = create(:communal_area)
+      interested_communal_defect = create(:communal_defect, communal_area: interested_communal_area)
+      distracting_communal_area = create(:communal_area)
+      distracting_communal_defect = create(:communal_defect, communal_area: distracting_communal_area)
+
+      result = described_class.for_properties_or_communal_areas(
+        [interested_property.id],
+        [interested_communal_area.id]
+      )
+
+      expect(result).to include(interested_property_defect)
+      expect(result).to include(interested_communal_defect)
+      expect(result).not_to include(distracting_property_defect)
+      expect(result).not_to include(distracting_communal_defect)
+    end
+  end
+
   describe '#status' do
     it 'returns the capitalized status' do
       defect = build(:defect, status: 'outstanding')

--- a/spec/models/defect_spec.rb
+++ b/spec/models/defect_spec.rb
@@ -107,6 +107,23 @@ RSpec.describe Defect, type: :model do
     end
   end
 
+  describe '.for_scheme' do
+    it 'returns a list of defects that belong to provided schemes' do
+      interested_scheme = create(:scheme)
+      interested_property = create(:property, scheme: interested_scheme)
+      interested_defect = create(:property_defect, property: interested_property)
+
+      distracting_defect_with_different_scheme = create(:property_defect)
+
+      result = described_class.for_scheme(
+        [interested_scheme.id]
+      )
+
+      expect(result).to include(interested_defect)
+      expect(result).not_to include(distracting_defect_with_different_scheme)
+    end
+  end
+
   describe '#status' do
     it 'returns the capitalized status' do
       defect = build(:defect, status: 'outstanding')

--- a/spec/services/defect_filter_spec.rb
+++ b/spec/services/defect_filter_spec.rb
@@ -42,14 +42,14 @@ RSpec.describe DefectFilter do
       context 'when the status is neither' do
         it 'returns an empty array' do
           result = described_class.new(statuses: %i[foo])
-          expect(result.scopes).to eq([])
+          expect(result.scopes).to eq([:all])
         end
       end
 
       context 'when there are no statuses' do
         it 'returns an empty array' do
           result = described_class.new(statuses: %i[])
-          expect(result.scopes).to eq([])
+          expect(result.scopes).to eq([:all])
         end
       end
     end
@@ -79,14 +79,14 @@ RSpec.describe DefectFilter do
       context 'when the type is unknown' do
         it 'returns an empty array' do
           result = described_class.new(types: %i[foo])
-          expect(result.scopes).to eq([])
+          expect(result.scopes).to eq([:all])
         end
       end
 
       context 'when there are no types' do
         it 'returns an empty array' do
           result = described_class.new(types: %i[])
-          expect(result.scopes).to eq([])
+          expect(result.scopes).to eq([:all])
         end
       end
     end

--- a/spec/services/defect_filter_spec.rb
+++ b/spec/services/defect_filter_spec.rb
@@ -6,12 +6,14 @@ RSpec.describe DefectFilter do
       it 'returns an array of all required Defect scopes' do
         result = described_class.new(
           statuses: %i[open closed],
-          types: %i[property communal]
+          types: %i[property communal],
+          schemes: ['Blue Scheme']
         )
         expect(result.scopes).to eq(
-          %i[
-            open_and_closed
-            property_and_communal
+          [
+            :open_and_closed,
+            :property_and_communal,
+            [:for_scheme, ['Blue Scheme']],
           ]
         )
       end


### PR DESCRIPTION
## Changes in this PR:
- the filter form will present a check box for every Scheme by its name
- the default behaviour is that every scheme is shown
- filtering schemes will pass the scheme ID into the DefectFinder, this is different from the existing filters that pass strings for things like 'Open' and 'Property' where no resource exists
- when all defect filters are unchecked the default behaviour has changed from showing none, to showing all as there is no foreseeable need for us to ever hide all information
- the horizontal design of the filtering form on the overview page is a limitation that will grow ugly when 5+ Schemes exist, the decision for this form being horizontal is an intentional design decision we made when we added it after considering the impact of long lists of options impacting on the experience

## Screenshots of UI changes:

### Before
![Screenshot 2019-07-10 at 14 53 30](https://user-images.githubusercontent.com/912473/60974735-81003200-a322-11e9-86eb-bd7361340986.png)

### After
![Screenshot 2019-07-10 at 14 51 41](https://user-images.githubusercontent.com/912473/60974669-63cb6380-a322-11e9-8807-ec37e2d69425.png)
![Screenshot 2019-07-10 at 14 51 52](https://user-images.githubusercontent.com/912473/60974670-6463fa00-a322-11e9-9725-dacb4d3473d5.png)
![Screenshot 2019-07-10 at 14 51 56](https://user-images.githubusercontent.com/912473/60974671-6463fa00-a322-11e9-82a8-26489ea7099b.png)
