### PR TITLE
[163] Creating and editing properties provides guidance

### DIFF
--- a/app/views/staff/properties/_data_guidance.html.haml
+++ b/app/views/staff/properties/_data_guidance.html.haml
@@ -1,0 +1,6 @@
+%p.govuk-body
+  = I18n.t('form.property.guidance', link: link_to("Hackney's property lookup service", 'http://lbhgisnetp01/SinglePoint/SimpleSearch.aspx')).html_safe
+
+%ul.govuk-list.govuk-list--bullet
+  - I18n.t('form.property.steps').each do |step|
+    %li= step

--- a/app/views/staff/properties/edit.html.haml
+++ b/app/views/staff/properties/edit.html.haml
@@ -8,6 +8,8 @@
       = I18n.t('page_title.staff.properties.edit', name: @scheme.name)
       %span.govuk-caption-l= 'Step 1 of 1'
 
+    = render partial: 'data_guidance'
+
     = simple_form_for [@scheme.estate, @scheme, @property] do |f|
       .govuk-form-group
         = f.input :address

--- a/app/views/staff/properties/new.html.haml
+++ b/app/views/staff/properties/new.html.haml
@@ -8,6 +8,8 @@
       = I18n.t('page_title.staff.properties.create', name: @scheme.name)
       %span.govuk-caption-l= 'Step 1 of 1'
 
+    = render partial: 'data_guidance'
+
     = simple_form_for [@scheme.estate, @scheme, @property] do |f|
       .govuk-form-group
         = f.input :address

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -63,7 +63,6 @@ en:
     defect:
       show:
         not_accepted_yet: 'Waiting on the contractor to accept'
-    property:
       table:
         header: 'Property defects'
     communal_area:
@@ -107,6 +106,13 @@ en:
       scheme: Edit scheme
       defect: Edit defect
   form:
+    property:
+      guidance: 'Find address information (Address, Postcode, UPRN) from %{link}.'
+      steps:
+        - 'Go to advanced search'
+        - "Select 'provisional' for property type"
+        - 'Use a postcode to find a property'
+        - 'Copy and paste the relevant data into the fields below'
     communal_area:
       explanation: 'A communal area can be used to report and manage defects that are in a shared location rather than within an individual property.'
       name:

--- a/spec/features/anyone_can_create_a_property_spec.rb
+++ b/spec/features/anyone_can_create_a_property_spec.rb
@@ -11,6 +11,9 @@ RSpec.feature 'Anyone can create a property' do
     click_on(I18n.t('button.create.property'))
 
     expect(page).to have_content(I18n.t('page_title.staff.properties.create'))
+    expect(page).to have_content(I18n.t('form.property.guidance', link: "Hackney's property lookup service"))
+    expect(page).to have_link("Hackney's property lookup service", href: 'http://lbhgisnetp01/SinglePoint/SimpleSearch.aspx')
+
     within('form.new_property') do
       fill_in 'property[address]', with: 'Flat 1, Hackney Street'
       fill_in 'property[postcode]', with: 'N16NU'

--- a/spec/features/anyone_can_update_a_property_spec.rb
+++ b/spec/features/anyone_can_update_a_property_spec.rb
@@ -14,6 +14,9 @@ RSpec.feature 'Anyone can update a property' do
       click_on(I18n.t('generic.link.edit'))
     end
 
+    expect(page).to have_content(I18n.t('form.property.guidance', link: "Hackney's property lookup service"))
+    expect(page).to have_link("Hackney's property lookup service", href: 'http://lbhgisnetp01/SinglePoint/SimpleSearch.aspx')
+
     within('form.edit_property') do
       fill_in 'property[address]', with: 'Flat 1, Hackney Street'
       fill_in 'property[postcode]', with: 'N16NU'


### PR DESCRIPTION
## Changes in this PR:
* Until we are able to find and make time to integrate with a service which could automatically input all of the property information we need to do just enough in order to make sure the UPRNs are set correctly in the 2 weeks remaining.
* The minimum way we thought to do this was to link to this Hackney service which backs onto their single source of property data (AKA LLPG). This avoids having to have and maintain a separate spreadsheet.
* This link is only available from Hackney's VPN and so I'm unable to check if HTTPS is supported
* I'm not on the network to test if this link is URL driven in order to pre-check the checkbox for provisional properties so for now we have to set that as an explicit instruction to users.

## Screenshots of UI changes:
![Screenshot 2019-07-10 at 16 48 17](https://user-images.githubusercontent.com/912473/60983843-9b420c00-a332-11e9-9c68-a3c716b287e7.png)
![Screenshot 2019-07-10 at 16 48 31](https://user-images.githubusercontent.com/912473/60983844-9bdaa280-a332-11e9-8dba-2a67389ad797.png)

