### PR TITLE
Feature/121 assign reference numbers

### DIFF
--- a/app/models/defect.rb
+++ b/app/models/defect.rb
@@ -6,7 +6,6 @@ class Defect < ApplicationRecord
             :description,
             :trade,
             :priority,
-            :reference_number,
             :status,
             :target_completion_date,
             presence: true
@@ -159,6 +158,13 @@ class Defect < ApplicationRecord
 
   def self.send_chain(methods)
     methods.inject(self) { |s, method| s.send(*method) }
+  end
+
+  def reference_number
+    return nil if new_record?
+
+    reload if sequence_number.blank?
+    format('NB-%06d', sequence_number).gsub(/-(\d{3})/, '-\1-')
   end
 
   def set_completion_date

--- a/app/models/defect.rb
+++ b/app/models/defect.rb
@@ -15,7 +15,6 @@ class Defect < ApplicationRecord
   validates :contact_phone_number, numericality: true,
                                    length: { minimum: 10, maximum: 15 },
                                    allow_blank: true
-  attribute :reference_number, :string, default: -> { SecureRandom.hex(3).upcase }
 
   enum status: %i[
     outstanding

--- a/db/migrate/20190710143416_add_defects_sequence_number.rb
+++ b/db/migrate/20190710143416_add_defects_sequence_number.rb
@@ -1,0 +1,8 @@
+class AddDefectsSequenceNumber < ActiveRecord::Migration[5.2]
+  def change
+    change_table :defects do |t|
+      t.serial :sequence_number, null: false
+      t.index :sequence_number, unique: true
+    end
+  end
+end

--- a/db/migrate/20190711110803_allow_null_defects_reference_number.rb
+++ b/db/migrate/20190711110803_allow_null_defects_reference_number.rb
@@ -1,0 +1,5 @@
+class AllowNullDefectsReferenceNumber < ActiveRecord::Migration[5.2]
+  def change
+    change_column :defects, :reference_number, :string, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_26_160126) do
+ActiveRecord::Schema.define(version: 2019_07_10_143416) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -71,9 +71,11 @@ ActiveRecord::Schema.define(version: 2019_06_26_160126) do
     t.string "access_information"
     t.boolean "communal", default: false
     t.uuid "communal_area_id"
+    t.serial "sequence_number", null: false
     t.index ["communal_area_id"], name: "index_defects_on_communal_area_id"
     t.index ["priority_id"], name: "index_defects_on_priority_id"
     t.index ["property_id"], name: "index_defects_on_property_id"
+    t.index ["sequence_number"], name: "index_defects_on_sequence_number", unique: true
   end
 
   create_table "estates", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_10_143416) do
+ActiveRecord::Schema.define(version: 2019_07_11_110803) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -62,7 +62,7 @@ ActiveRecord::Schema.define(version: 2019_07_10_143416) do
     t.string "trade"
     t.date "target_completion_date"
     t.integer "status", default: 0
-    t.string "reference_number", null: false
+    t.string "reference_number"
     t.uuid "property_id"
     t.uuid "priority_id"
     t.datetime "created_at", null: false

--- a/spec/factories/defects.rb
+++ b/spec/factories/defects.rb
@@ -9,7 +9,6 @@ FactoryBot.define do
     trade { Defect::TRADES.sample }
     target_completion_date { Faker::Date.between(1.day.from_now, 5.days.from_now) }
     status { Defect.statuses.keys.sample }
-    reference_number { SecureRandom.hex(3).upcase }
 
     association :priority, factory: :priority
 

--- a/spec/fixtures/download_defects.csv
+++ b/spec/fixtures/download_defects.csv
@@ -1,3 +1,3 @@
 reference_number,created_at,title,type,status,trade,category,priority_name,priority_duration,target_completion_date,estate,scheme,property_address,communal_area_name,communal_area_location,description,access_information
-456ABC,"1st October 2017, 13:13",a shorter title,Communal,Outstanding,Electrical,Electrical/Mechanical,P1,1, 1 October 2019,estate,scheme,,Pine Creek,1-100 Hackney Street,a longer description,The communal door will be unlocked
-123ABC,"1st October 2018, 13:13",a short title,Property,Outstanding,Electrical,Electrical/Mechanical,P1,1, 1 October 2020,estate,scheme,1 Hackney Street,,,a long description,The key is under the garden pot
+NB-000-002,"1st October 2017, 13:13",a shorter title,Communal,Outstanding,Electrical,Electrical/Mechanical,P1,1, 1 October 2019,estate,scheme,,Pine Creek,1-100 Hackney Street,a longer description,The communal door will be unlocked
+NB-000-001,"1st October 2018, 13:13",a short title,Property,Outstanding,Electrical,Electrical/Mechanical,P1,1, 1 October 2020,estate,scheme,1 Hackney Street,,,a long description,The key is under the garden pot

--- a/spec/models/defect_spec.rb
+++ b/spec/models/defect_spec.rb
@@ -124,6 +124,20 @@ RSpec.describe Defect, type: :model do
     end
   end
 
+  describe '#reference_number' do
+    it 'returns a formatted identifier code' do
+      defect = create(:defect, sequence_number: 42)
+      expect(defect.reference_number).to eq('NB-000-042')
+    end
+
+    it 'uses sequential identifiers' do
+      defects = create_list(:defect, 5)
+      ids = defects.map { |d| d.reference_number.scan(/\d/).join('').to_i }
+      first = ids.first
+      expect(ids).to eq((0..4).map { |i| first + i })
+    end
+  end
+
   describe '#status' do
     it 'returns the capitalized status' do
       defect = build(:defect, status: 'outstanding')
@@ -200,7 +214,7 @@ RSpec.describe Defect, type: :model do
       create(:property_defect,
              property: property,
              priority: priority,
-             reference_number: '123ABC',
+             sequence_number: 1,
              title: 'a short title',
              status: :outstanding,
              trade: 'Electrical',
@@ -215,7 +229,7 @@ RSpec.describe Defect, type: :model do
       create(:communal_defect,
              communal_area: communal_area,
              priority: priority,
-             reference_number: '456ABC',
+             sequence_number: 2,
              title: 'a shorter title',
              status: :outstanding,
              trade: 'Electrical',


### PR DESCRIPTION
## Changes in this PR:

- Introduce a column `defects.sequence_number`, which is a `SERIAL` column that generates a sequential number
- Make the `defects.reference_number` nullable and stop writing data to it
- Make `Defect#reference_number` return a formatted version of the sequence number; the format is visible in the screenshots below

By making `reference_number` nullable, this PR is compatible with the current production release that is still writing to this column, and with the code in this PR which no longer does so. I will add a migration to remove this unused column in a later release.

## Screenshots of UI changes:

### Before

<img width="1235" alt="Screenshot 2019-07-11 at 14 28 12" src="https://user-images.githubusercontent.com/9265/61054941-61334180-a3e8-11e9-8c58-4adbf5f49307.png">

<img width="602" alt="Screenshot 2019-07-11 at 14 28 28" src="https://user-images.githubusercontent.com/9265/61054963-6c866d00-a3e8-11e9-97d5-b75463fe756a.png">

### After

<img width="1233" alt="Screenshot 2019-07-11 at 14 29 20" src="https://user-images.githubusercontent.com/9265/61054974-714b2100-a3e8-11e9-93af-42971ddaf154.png">

<img width="603" alt="Screenshot 2019-07-11 at 14 29 06" src="https://user-images.githubusercontent.com/9265/61054984-760fd500-a3e8-11e9-8300-00fffd2e843d.png">