### PR TITLE
[116] Scheme level reporting

### DIFF
--- a/app/controllers/staff/report_controller.rb
+++ b/app/controllers/staff/report_controller.rb
@@ -10,4 +10,15 @@ class Staff::ReportController < Staff::BaseController
       format.csv { send_data Defect.to_csv(defects: @defects) }
     end
   end
+
+  def show
+    @scheme = Scheme.find(scheme_id)
+    @presenter = SchemeReportPresenter.new(scheme: @scheme)
+  end
+
+  private
+
+  def scheme_id
+    params[:id]
+  end
 end

--- a/app/helpers/defect_helper.rb
+++ b/app/helpers/defect_helper.rb
@@ -3,8 +3,12 @@ module DefectHelper
     "#{priority.name} - #{pluralize(priority.days, 'day')} from now"
   end
 
+  def format_status(text)
+    text.capitalize.tr('_', ' ')
+  end
+
   def status_form_label(option_array:)
-    option_array.first.capitalize.tr('_', ' ')
+    format_status(option_array.first)
   end
 
   def view_path_for(parent:, defect:)

--- a/app/models/defect.rb
+++ b/app/models/defect.rb
@@ -38,6 +38,7 @@ class Defect < ApplicationRecord
   scope :property, (-> { where(communal: false) })
   scope :communal, (-> { where(communal: true) })
 
+  scope :for_priorities, (->(priority_ids) { where(priority_id: priority_ids) })
   scope :for_properties, (->(property_ids) { where(property_id: property_ids) })
   scope :for_communal_areas, (->(communal_area_ids) { where(communal_area_id: communal_area_ids) })
   scope :for_properties_or_communal_areas, lambda { |property_ids, communal_area_ids|

--- a/app/models/defect.rb
+++ b/app/models/defect.rb
@@ -49,6 +49,8 @@ class Defect < ApplicationRecord
     for_properties_or_communal_areas(property_ids, communal_area_ids)
   })
 
+  scope :for_trade, (->(trade) { where(trade: trade) })
+
   belongs_to :property, optional: true
   belongs_to :communal_area, optional: true
   belongs_to :priority

--- a/app/presenters/scheme_report_presenter.rb
+++ b/app/presenters/scheme_report_presenter.rb
@@ -1,0 +1,13 @@
+class SchemeReportPresenter
+  delegate :name, to: :scheme
+
+  attr_accessor :scheme
+
+  def initialize(scheme:)
+    self.scheme = scheme
+  end
+
+  def defects
+    @defects ||= Defect.for_scheme([scheme.id])
+  end
+end

--- a/app/presenters/scheme_report_presenter.rb
+++ b/app/presenters/scheme_report_presenter.rb
@@ -10,4 +10,8 @@ class SchemeReportPresenter
   def defects
     @defects ||= Defect.for_scheme([scheme.id])
   end
+
+  def date_range
+    "From #{scheme.created_at} to #{Time.current}"
+  end
 end

--- a/app/presenters/scheme_report_presenter.rb
+++ b/app/presenters/scheme_report_presenter.rb
@@ -18,4 +18,18 @@ class SchemeReportPresenter
   def defects_by_status(text:)
     defects.send(text)
   end
+
+  def defects_by_trade(text:)
+    defects.for_trade(text)
+  end
+
+  def trade_percentage(text:)
+    total = Float(defects.count)
+    trade_total = Float(defects_by_trade(text: text).count)
+
+    return '0.0%' if total.zero? || trade_total.zero?
+
+    percentage = (trade_total / total) * 100
+    "#{percentage}%"
+  end
 end

--- a/app/presenters/scheme_report_presenter.rb
+++ b/app/presenters/scheme_report_presenter.rb
@@ -14,4 +14,8 @@ class SchemeReportPresenter
   def date_range
     "From #{scheme.created_at} to #{Time.current}"
   end
+
+  def defects_by_status(text:)
+    defects.send(text)
+  end
 end

--- a/app/presenters/scheme_report_presenter.rb
+++ b/app/presenters/scheme_report_presenter.rb
@@ -30,6 +30,17 @@ class SchemeReportPresenter
     )
   end
 
+  def defects_by_priority(priority:)
+    defects.for_priorities([priority.id])
+  end
+
+  def priority_percentage(priority:)
+    percentage_for(
+      number: Float(defects_by_priority(priority: priority).count),
+      total: Float(defects.count)
+    )
+  end
+
   private
 
   def percentage_for(number:, total:)

--- a/app/presenters/scheme_report_presenter.rb
+++ b/app/presenters/scheme_report_presenter.rb
@@ -24,12 +24,17 @@ class SchemeReportPresenter
   end
 
   def trade_percentage(text:)
-    total = Float(defects.count)
-    trade_total = Float(defects_by_trade(text: text).count)
+    percentage_for(
+      number: Float(defects_by_trade(text: text).count),
+      total: Float(defects.count)
+    )
+  end
 
-    return '0.0%' if total.zero? || trade_total.zero?
+  private
 
-    percentage = (trade_total / total) * 100
+  def percentage_for(number:, total:)
+    return '0.0%' if number.zero? || total.zero?
+    percentage = (number / total) * 100
     "#{percentage}%"
   end
 end

--- a/app/views/staff/dashboard/index.html.haml
+++ b/app/views/staff/dashboard/index.html.haml
@@ -36,6 +36,19 @@
       = I18n.t('page_content.dashboard.header.reporting')
     = link_to(I18n.t('button.report.download_all'), report_path(format: :csv), class: 'govuk-button govuk-button--secondary mb0')
 
+    %table.govuk-table.scheme-reports
+      %thead.govuk-table__head
+        %tr.govuk-table__row
+          %th.govuk-table__header
+            Name
+          %th.govuk-table__header
+            Actions
+      %tbody.govuk-table__body
+        - Scheme.all.each do |scheme|
+          %tr.govuk-table__row
+            %td.govuk-table__cell= scheme.name
+            %td.govuk-table__cell= link_to(I18n.t('generic.link.show'), report_scheme_path(scheme), class: 'govuk-link')
+
   .govuk-grid-column-one-third
     %h2.govuk-heading-m
       = I18n.t('page_content.dashboard.header.manage')

--- a/app/views/staff/report/_priorities.html.haml
+++ b/app/views/staff/report/_priorities.html.haml
@@ -1,0 +1,28 @@
+%h1.govuk-heading-m.section-heading Priorities
+%table.govuk-table.priorities
+  %thead.govuk-table__head
+    %tr.govuk-table__row
+      %th.govuk-table__header
+        Code
+      %th.govuk-table__header
+        Days
+      %th.govuk-table__header
+        Percentage
+      %th.govuk-table__header
+        Total
+      %th.govuk-table__header
+        Due
+      %th.govuk-table__header
+        Overdue
+      %th.govuk-table__header
+        Completed on time
+  %tbody.govuk-table__body
+    - presenter.scheme.priorities.each do |priority|
+      %tr.govuk-table__row
+        %td.govuk-table__cell= priority.name
+        %td.govuk-table__cell= priority.days
+        %td.govuk-table__cell= presenter.priority_percentage(priority: priority)
+        %td.govuk-table__cell= presenter.defects_by_priority(priority: priority).count
+        %td.govuk-table__cell= '-'
+        %td.govuk-table__cell= '-'
+        %td.govuk-table__cell= '-'

--- a/app/views/staff/report/_statuses.html.haml
+++ b/app/views/staff/report/_statuses.html.haml
@@ -1,0 +1,19 @@
+%h1.govuk-heading-m.section-heading Status
+%table.govuk-table.scheme-reports
+  %thead.govuk-table__head
+    %tr.govuk-table__row
+      %th.govuk-table__header
+        Name
+      %th.govuk-table__header
+        Property
+      %th.govuk-table__header
+        Communal
+      %th.govuk-table__header
+        Total
+  %tbody.govuk-table__body
+    - Defect.statuses.each do |text, integer|
+      %tr.govuk-table__row
+        %td.govuk-table__cell= text.tr('_', ' ').capitalize
+        %td.govuk-table__cell= presenter.defects_by_status(text: text).property.count
+        %td.govuk-table__cell= presenter.defects_by_status(text: text).communal.count
+        %td.govuk-table__cell= presenter.defects_by_status(text: text).count

--- a/app/views/staff/report/_statuses.html.haml
+++ b/app/views/staff/report/_statuses.html.haml
@@ -1,5 +1,5 @@
 %h1.govuk-heading-m.section-heading Status
-%table.govuk-table.scheme-reports
+%table.govuk-table.statuses
   %thead.govuk-table__head
     %tr.govuk-table__row
       %th.govuk-table__header

--- a/app/views/staff/report/_statuses.html.haml
+++ b/app/views/staff/report/_statuses.html.haml
@@ -13,7 +13,7 @@
   %tbody.govuk-table__body
     - Defect.statuses.each do |text, integer|
       %tr.govuk-table__row
-        %td.govuk-table__cell= text.tr('_', ' ').capitalize
+        %td.govuk-table__cell= format_status(text)
         %td.govuk-table__cell= presenter.defects_by_status(text: text).property.count
         %td.govuk-table__cell= presenter.defects_by_status(text: text).communal.count
         %td.govuk-table__cell= presenter.defects_by_status(text: text).count

--- a/app/views/staff/report/_summary.html.haml
+++ b/app/views/staff/report/_summary.html.haml
@@ -1,0 +1,18 @@
+%h1.govuk-heading-m.section-heading Summary
+%table.govuk-table.summary
+  %thead.govuk-table__head
+    %tr.govuk-table__row
+      %th.govuk-table__header
+        Title
+      %th.govuk-table__header
+        Property
+      %th.govuk-table__header
+        Communal
+      %th.govuk-table__header
+        Total
+  %tbody.govuk-table__body
+    %tr.govuk-table__row
+      %td.govuk-table__cell= 'Total defects'
+      %td.govuk-table__cell= presenter.defects.property.count
+      %td.govuk-table__cell= presenter.defects.communal.count
+      %td.govuk-table__cell= presenter.defects.count

--- a/app/views/staff/report/_trades.html.haml
+++ b/app/views/staff/report/_trades.html.haml
@@ -1,0 +1,16 @@
+%h1.govuk-heading-m.section-heading Trades
+%table.govuk-table.trades
+  %thead.govuk-table__head
+    %tr.govuk-table__row
+      %th.govuk-table__header
+        Name
+      %th.govuk-table__header
+        Percentage
+      %th.govuk-table__header
+        Total
+  %tbody.govuk-table__body
+    - Defect::TRADES.each do |trade|
+      %tr.govuk-table__row
+        %td.govuk-table__cell= trade
+        %td.govuk-table__cell= presenter.trade_percentage(text: trade)
+        %td.govuk-table__cell= presenter.defects_by_trade(text: trade).count

--- a/app/views/staff/report/show.html.haml
+++ b/app/views/staff/report/show.html.haml
@@ -14,4 +14,4 @@
     = render partial: 'summary', locals: { presenter: @presenter }
     = render partial: 'statuses', locals: { presenter: @presenter }
     = render partial: 'trades', locals: { presenter: @presenter }
-
+    = render partial: 'priorities', locals: { presenter: @presenter }

--- a/app/views/staff/report/show.html.haml
+++ b/app/views/staff/report/show.html.haml
@@ -9,5 +9,6 @@
     %h1.govuk-heading-l
       = I18n.t('page_title.staff.reports.scheme.show', name: @presenter.scheme.name)
       %span.govuk-caption-l= @presenter.scheme.contractor_name
+      %span.govuk-caption-l= @presenter.date_range
 
     = render partial: 'summary', locals: { presenter: @presenter }

--- a/app/views/staff/report/show.html.haml
+++ b/app/views/staff/report/show.html.haml
@@ -13,3 +13,5 @@
 
     = render partial: 'summary', locals: { presenter: @presenter }
     = render partial: 'statuses', locals: { presenter: @presenter }
+    = render partial: 'trades', locals: { presenter: @presenter }
+

--- a/app/views/staff/report/show.html.haml
+++ b/app/views/staff/report/show.html.haml
@@ -12,3 +12,4 @@
       %span.govuk-caption-l= @presenter.date_range
 
     = render partial: 'summary', locals: { presenter: @presenter }
+    = render partial: 'statuses', locals: { presenter: @presenter }

--- a/app/views/staff/report/show.html.haml
+++ b/app/views/staff/report/show.html.haml
@@ -1,0 +1,13 @@
+- content_for :page_title_prefix, I18n.t('page_title.staff.reports.scheme.show', name: @presenter.scheme.name)
+
+.govuk-breadcrumbs
+  %ol.govuk-breadcrumbs__list
+    = breadcrumb_link_to('Home', root_path)
+
+.govuk-grid-row
+  .govuk-grid-column-full
+    %h1.govuk-heading-l
+      = I18n.t('page_title.staff.reports.scheme.show', name: @presenter.scheme.name)
+      %span.govuk-caption-l= @presenter.scheme.contractor_name
+
+    = render partial: 'summary', locals: { presenter: @presenter }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -14,6 +14,9 @@ en:
           body: 'This accept link appears to be invalid. This might be because it has already accepted it or it has expired.'
     staff:
       dashboard: 'Dashboard'
+      reports:
+        scheme:
+          show: 'Scheme report for %{name}'
       search:
         index:
           headers:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -87,7 +87,7 @@ en:
           'The %{resource} has successfully been updated.'
   button:
     report:
-      download_all: Download CSV
+      download_all: Download all defect data
     create:
       estate: 'Create estate'
       scheme: 'Create scheme'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
 
   get 'search' => 'staff/searches#index'
   get 'report' => 'staff/report#index'
+  get 'report/scheme/:id' => 'staff/report#show', as: :report_scheme
 
   resources :defects, controller: 'staff/defects'
 

--- a/spec/features/anyone_can_view_a_scheme_report_spec.rb
+++ b/spec/features/anyone_can_view_a_scheme_report_spec.rb
@@ -85,4 +85,24 @@ RSpec.feature 'Anyone can view a report for a scheme' do
       expect(page).to have_content(plumbing_property_defects.count + plumbing_communal_defects.count)
     end
   end
+
+  scenario 'defect information by scheme priority' do
+    create(:property_defect, property: property, priority: priority)
+
+    visit report_scheme_path(scheme)
+
+    within('.priorities') do
+      %w[Code Days Total Due Overdue Completed on time].each do |header|
+        expect(page).to have_content(header)
+      end
+
+      scheme.priorities.each do |priority|
+        expect(page).to have_content(priority.name)
+        expect(page).to have_content(priority.days)
+      end
+
+      expect(page).to have_content('100.0%')
+      expect(page).to have_content('1')
+    end
+  end
 end

--- a/spec/features/anyone_can_view_a_scheme_report_spec.rb
+++ b/spec/features/anyone_can_view_a_scheme_report_spec.rb
@@ -1,12 +1,12 @@
 require 'rails_helper'
 
 RSpec.feature 'Anyone can view a report for a scheme' do
-  scenario 'summary information for all defects belonging to the scheme' do
-    scheme = create(:scheme)
-    priority = create(:priority, scheme: scheme)
-    property = create(:property, scheme: scheme)
-    communal_area = create(:communal_area, scheme: scheme)
+  let(:scheme) { create(:scheme) }
+  let(:priority) { create(:priority, scheme: scheme) }
+  let(:property) { create(:property, scheme: scheme) }
+  let(:communal_area) { create(:communal_area, scheme: scheme) }
 
+  scenario 'summary information for all defects belonging to the scheme' do
     create_list(:property_defect, 1, property: property, priority: priority)
     create_list(:communal_defect, 2, communal_area: communal_area, priority: priority)
 
@@ -57,6 +57,32 @@ RSpec.feature 'Anyone can view a report for a scheme' do
       expect(page).to have_content(closed_property_defects.count)
       expect(page).to have_content(closed_communal_defects.count)
       expect(page).to have_content(closed_property_defects.count + closed_communal_defects.count)
+    end
+  end
+
+  scenario 'defect information by trade belonging to the scheme' do
+    electrical_property_defects = create_list(:property_defect, 1, property: property, trade: 'Electrical')
+    electrical_communal_defects = create_list(:communal_defect, 2, communal_area: communal_area, trade: 'Electrical')
+
+    plumbing_property_defects = create_list(:property_defect, 3, property: property, trade: 'Plumbing')
+    plumbing_communal_defects = create_list(:communal_defect, 4, communal_area: communal_area, trade: 'Plumbing')
+
+    visit report_scheme_path(scheme)
+
+    within('.trades') do
+      %w[Name Percentage Total].each do |header|
+        expect(page).to have_content(header)
+      end
+
+      Defect::TRADES.each do |trade|
+        expect(page).to have_content(trade)
+      end
+
+      expect(page).to have_content('30.0%')
+      expect(page).to have_content(electrical_property_defects.count + electrical_communal_defects.count)
+
+      expect(page).to have_content('70.0%')
+      expect(page).to have_content(plumbing_property_defects.count + plumbing_communal_defects.count)
     end
   end
 end

--- a/spec/features/anyone_can_view_a_scheme_report_spec.rb
+++ b/spec/features/anyone_can_view_a_scheme_report_spec.rb
@@ -31,4 +31,32 @@ RSpec.feature 'Anyone can view a report for a scheme' do
       end
     end
   end
+
+  scenario 'defect information by status belonging to the scheme' do
+    outstanding_property_defects = create_list(:property_defect, 1, property: property, status: :outstanding)
+    outstanding_communal_defects = create_list(:communal_defect, 2, communal_area: communal_area, status: :outstanding)
+
+    closed_property_defects = create_list(:property_defect, 3, property: property, status: :closed)
+    closed_communal_defects = create_list(:communal_defect, 4, communal_area: communal_area, status: :closed)
+
+    visit report_scheme_path(scheme)
+
+    within('.statuses') do
+      %w[Name Property Communal Total].each do |header|
+        expect(page).to have_content(header)
+      end
+
+      Defect.statuses.each do |text, _integer|
+        expect(page).to have_content(format_status(text))
+      end
+
+      expect(page).to have_content(outstanding_property_defects.count)
+      expect(page).to have_content(outstanding_communal_defects.count)
+      expect(page).to have_content(outstanding_property_defects.count + outstanding_communal_defects.count)
+
+      expect(page).to have_content(closed_property_defects.count)
+      expect(page).to have_content(closed_communal_defects.count)
+      expect(page).to have_content(closed_property_defects.count + closed_communal_defects.count)
+    end
+  end
 end

--- a/spec/features/anyone_can_view_a_scheme_report_spec.rb
+++ b/spec/features/anyone_can_view_a_scheme_report_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.feature 'Anyone can view a report for a scheme' do
+  scenario 'summary information for all defects belonging to the scheme' do
+    scheme = create(:scheme)
+    priority = create(:priority, scheme: scheme)
+    property = create(:property, scheme: scheme)
+    communal_area = create(:communal_area, scheme: scheme)
+
+    create_list(:property_defect, 1, property: property, priority: priority)
+    create_list(:communal_defect, 2, communal_area: communal_area, priority: priority)
+
+    visit root_path
+
+    within('.scheme-reports') do
+      click_on(I18n.t('generic.link.show'))
+    end
+
+    expect(page).to have_content(I18n.t('page_title.staff.reports.scheme.show', name: scheme.name))
+
+    within('.summary') do
+      %w[Title Property Communal Total].each do |column_header|
+        expect(page).to have_content(column_header)
+      end
+      within('tbody tr') do
+        expect(page).to have_content('Total defects')
+        expect(page).to have_content('1')
+        expect(page).to have_content('2')
+        expect(page).to have_content('3')
+      end
+    end
+  end
+end

--- a/spec/features/anyone_can_view_a_scheme_report_spec.rb
+++ b/spec/features/anyone_can_view_a_scheme_report_spec.rb
@@ -17,6 +17,7 @@ RSpec.feature 'Anyone can view a report for a scheme' do
     end
 
     expect(page).to have_content(I18n.t('page_title.staff.reports.scheme.show', name: scheme.name))
+    expect(page).to have_content("From #{scheme.created_at} to #{Time.current}")
 
     within('.summary') do
       %w[Title Property Communal Total].each do |column_header|

--- a/spec/features/anyone_can_view_a_scheme_spec.rb
+++ b/spec/features/anyone_can_view_a_scheme_spec.rb
@@ -10,7 +10,9 @@ RSpec.feature 'Anyone can view a scheme' do
     visit root_path
 
     expect(page).to have_content(I18n.t('page_title.staff.dashboard'))
-    click_on(I18n.t('generic.link.show'))
+    within('.estates') do
+      click_on(I18n.t('generic.link.show'))
+    end
 
     expect(page).to have_content(I18n.t('page_title.staff.estates.show', name: scheme.estate.name))
     click_on(I18n.t('generic.link.show'))

--- a/spec/helpers/defect_helper_spec.rb
+++ b/spec/helpers/defect_helper_spec.rb
@@ -135,4 +135,16 @@ RSpec.describe DefectHelper, type: :helper do
       end
     end
   end
+
+  describe '#format_status' do
+    it 'upcases the first word' do
+      result = helper.format_status('outstanding')
+      expect(result).to eql('Outstanding')
+    end
+
+    it 'replaces all underscores with empty spaces' do
+      result = helper.format_status('raised_in_error')
+      expect(result).to eql('Raised in error')
+    end
+  end
 end

--- a/spec/presenters/scheme_report_presenter_spec.rb
+++ b/spec/presenters/scheme_report_presenter_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe SchemeReportPresenter do
+  let(:scheme) { create(:scheme) }
+  let(:property) { create(:property, scheme: scheme) }
+  let(:priority) { create(:priority, scheme: scheme) }
+
+  describe '#defects' do
+    let(:defect) { create(:property_defect, property: property, priority: priority) }
+    it 'returns all defects for the given scheme' do
+      result = described_class.new(scheme: defect.scheme).defects
+      expect(result).to include(defect)
+    end
+  end
+end

--- a/spec/presenters/scheme_report_presenter_spec.rb
+++ b/spec/presenters/scheme_report_presenter_spec.rb
@@ -12,4 +12,13 @@ RSpec.describe SchemeReportPresenter do
       expect(result).to include(defect)
     end
   end
+
+  describe '#date_range' do
+    it 'returns a time range for all the data being viewed in a string format' do
+      start_time = Time.utc(2018, 1, 1, 13)
+      scheme = create(:scheme, created_at: start_time)
+      result = described_class.new(scheme: scheme).date_range
+      expect(result).to eq("From #{start_time} to #{Time.current}")
+    end
+  end
 end

--- a/spec/presenters/scheme_report_presenter_spec.rb
+++ b/spec/presenters/scheme_report_presenter_spec.rb
@@ -32,4 +32,33 @@ RSpec.describe SchemeReportPresenter do
       expect(result).not_to include(closed_defect)
     end
   end
+
+  describe '#defects_by_trade' do
+    it 'returns a count for all defects for the given trade' do
+      electrical_defect = create(:property_defect, property: property, trade: 'Electrical')
+      plumbing_defect = create(:property_defect, property: property, trade: 'Plumbing')
+
+      result = described_class.new(scheme: scheme).defects_by_trade(text: 'Plumbing')
+
+      expect(result).to include(plumbing_defect)
+      expect(result).not_to include(electrical_defect)
+    end
+  end
+
+
+  describe '#trade_percentage' do
+    it 'returns the percentage of defects with this trade ' do
+      create(:property_defect, property: property, trade: 'Plumbing')
+      create(:property_defect, property: property, trade: 'Electrical')
+      result = described_class.new(scheme: scheme).trade_percentage(text: 'Electrical')
+      expect(result).to eql('50.0%')
+    end
+
+    context 'when there are no defects with that trade' do
+      it 'returns 0.0%' do
+        result = described_class.new(scheme: scheme).trade_percentage(text: 'Electrical')
+        expect(result).to eql('0.0%')
+      end
+    end
+  end
 end

--- a/spec/presenters/scheme_report_presenter_spec.rb
+++ b/spec/presenters/scheme_report_presenter_spec.rb
@@ -45,7 +45,6 @@ RSpec.describe SchemeReportPresenter do
     end
   end
 
-
   describe '#trade_percentage' do
     it 'returns the percentage of defects with this trade ' do
       create(:property_defect, property: property, trade: 'Plumbing')
@@ -57,6 +56,35 @@ RSpec.describe SchemeReportPresenter do
     context 'when there are no defects with that trade' do
       it 'returns 0.0%' do
         result = described_class.new(scheme: scheme).trade_percentage(text: 'Electrical')
+        expect(result).to eql('0.0%')
+      end
+    end
+  end
+
+  describe '#defects_by_priority' do
+    let(:second_priority) { create(:priority, scheme: scheme) }
+
+    it 'returns a count for all defects for the given priority' do
+      first_priority_defect = create(:property_defect, property: property, priority: priority)
+      second_priority_defect = create(:property_defect, property: property, priority: second_priority)
+
+      result = described_class.new(scheme: scheme).defects_by_priority(priority: priority)
+
+      expect(result).to include(first_priority_defect)
+      expect(result).not_to include(second_priority_defect)
+    end
+  end
+
+  describe '#priority_percentage' do
+    it 'returns the percentage of defects with this priority ' do
+      create(:property_defect, property: property, priority: priority)
+      result = described_class.new(scheme: scheme).priority_percentage(priority: priority)
+      expect(result).to eql('100.0%')
+    end
+
+    context 'when there are no defects with that priority' do
+      it 'returns 0.0%' do
+        result = described_class.new(scheme: scheme).priority_percentage(priority: priority)
         expect(result).to eql('0.0%')
       end
     end

--- a/spec/presenters/scheme_report_presenter_spec.rb
+++ b/spec/presenters/scheme_report_presenter_spec.rb
@@ -21,4 +21,15 @@ RSpec.describe SchemeReportPresenter do
       expect(result).to eq("From #{start_time} to #{Time.current}")
     end
   end
+
+  describe '#defects_by_status' do
+    it 'returns all defects that belong to the given scheme with the given status' do
+      outstanding_defect = create(:property_defect, property: property, priority: priority, status: :outstanding)
+      closed_defect = create(:property_defect, property: property, priority: priority, status: :closed)
+
+      result = described_class.new(scheme: scheme).defects_by_status(text: 'outstanding')
+      expect(result).to include(outstanding_defect)
+      expect(result).not_to include(closed_defect)
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -60,6 +60,7 @@ RSpec.configure do |config|
   # config.filter_gems_from_backtrace("gem name")
 
   config.include AuthHelpers
+  config.include DefectHelper, type: :feature
 
   if Bullet.enable?
     config.before(:each) do


### PR DESCRIPTION
## Changes in this PR:

- display basic information for: an overall summary, statuses, trades and priorities
- we have a separate piece of work to condense trades into categories across this and the CSV
- we know that the priority information isn't complete but as explained in the commit that work can come next without blocking the delivery of what we do have here

## Screenshots of UI changes:

![Screenshot 2019-07-12 at 17 03 46](https://user-images.githubusercontent.com/912473/61142202-1c320c80-a4c7-11e9-9edc-45b37e395719.png)
![Screenshot 2019-07-12 at 17 03 51](https://user-images.githubusercontent.com/912473/61142201-1c320c80-a4c7-11e9-9064-97a3366568c8.png)
![Screenshot 2019-07-12 at 17 04 04](https://user-images.githubusercontent.com/912473/61142199-1b997600-a4c7-11e9-860d-45036637eb88.png)
![Screenshot 2019-07-12 at 17 04 10](https://user-images.githubusercontent.com/912473/61142200-1c320c80-a4c7-11e9-8739-1c77be640bc3.png)
