### PR TITLE
Fix percentage rounding for even defect counts

### DIFF
--- a/app/presenters/scheme_report_presenter.rb
+++ b/app/presenters/scheme_report_presenter.rb
@@ -46,6 +46,6 @@ class SchemeReportPresenter
   def percentage_for(number:, total:)
     return '0.0%' if number.zero? || total.zero?
     percentage = (number / total) * 100
-    "#{percentage}%"
+    "#{percentage.round(2)}%"
   end
 end

--- a/app/presenters/scheme_report_presenter.rb
+++ b/app/presenters/scheme_report_presenter.rb
@@ -16,7 +16,7 @@ class SchemeReportPresenter
   end
 
   def defects_by_status(text:)
-    defects.send(text)
+    defects.where(status: text)
   end
 
   def defects_by_trade(text:)

--- a/app/views/staff/report/_statuses.html.haml
+++ b/app/views/staff/report/_statuses.html.haml
@@ -12,8 +12,9 @@
         Total
   %tbody.govuk-table__body
     - Defect.statuses.each do |text, integer|
+      - defects_of_status = presenter.defects_by_status(text: text)
       %tr.govuk-table__row
         %td.govuk-table__cell= format_status(text)
-        %td.govuk-table__cell= presenter.defects_by_status(text: text).property.count
-        %td.govuk-table__cell= presenter.defects_by_status(text: text).communal.count
-        %td.govuk-table__cell= presenter.defects_by_status(text: text).count
+        %td.govuk-table__cell= defects_of_status.property.count
+        %td.govuk-table__cell= defects_of_status.communal.count
+        %td.govuk-table__cell= defects_of_status.count

--- a/spec/presenters/scheme_report_presenter_spec.rb
+++ b/spec/presenters/scheme_report_presenter_spec.rb
@@ -53,6 +53,16 @@ RSpec.describe SchemeReportPresenter do
       expect(result).to eql('50.0%')
     end
 
+    context 'when there the total defect count is odd' do
+      it 'returns a rounded percentage%' do
+        create(:property_defect, property: property, trade: 'Electrical')
+        create(:property_defect, property: property, trade: 'Plumbing')
+        create(:property_defect, property: property, trade: 'Plumbing')
+        result = described_class.new(scheme: scheme).trade_percentage(text: 'Electrical')
+        expect(result).to eql('33.33%')
+      end
+    end
+
     context 'when there are no defects with that trade' do
       it 'returns 0.0%' do
         result = described_class.new(scheme: scheme).trade_percentage(text: 'Electrical')

--- a/spec/presenters/scheme_report_presenter_spec.rb
+++ b/spec/presenters/scheme_report_presenter_spec.rb
@@ -31,6 +31,17 @@ RSpec.describe SchemeReportPresenter do
       expect(result).to include(outstanding_defect)
       expect(result).not_to include(closed_defect)
     end
+
+    context 'when the status is closed' do
+      it 'does not return an inflated number' do
+        create(:property_defect, property: property, priority: priority, status: :outstanding)
+        create(:property_defect, property: property, priority: priority, status: :completed)
+        create(:property_defect, property: property, priority: priority, status: :closed)
+        create(:property_defect, property: property, priority: priority, status: :closed)
+        result = described_class.new(scheme: scheme).defects_by_status(text: 'closed')
+        expect(result.count).to eql(2)
+      end
+    end
   end
 
   describe '#defects_by_trade' do


### PR DESCRIPTION
## Changes in this PR:

- add rounding to show report percentages correctly when the total count of defects is even
- fix inflated closed status counts

## Screenshots of UI changes:

### Before
![Screenshot 2019-07-12 at 17 50 15](https://user-images.githubusercontent.com/912473/61146468-0a099b80-a4d2-11e9-8270-2860ab7bff18.png)

### After
![Screenshot 2019-07-12 at 17 50 09](https://user-images.githubusercontent.com/912473/61146449-fd854300-a4d1-11e9-9308-b350bdb5054a.png)
