### PR TITLE
(fix) Remove duplicate trades and order alphabetically

### DIFF
--- a/app/models/defect.rb
+++ b/app/models/defect.rb
@@ -80,6 +80,7 @@ class Defect < ApplicationRecord
     'Boiler work',
     'Brickwork',
     'Carpentry',
+    'Carpentry/Doors',
     'Connectivity',
     'Cosmetic',
     'Damp',
@@ -87,6 +88,7 @@ class Defect < ApplicationRecord
     'Door work',
     'Drainage',
     'Electrical',
+    'Electrical/Mechanical',
     'Fan/Ventilation',
     'Filters',
     'Fire Safety',
@@ -104,10 +106,6 @@ class Defect < ApplicationRecord
     'Tile work',
     'Water Temperature/Supply',
     'Window Work',
-    'Cosmetic',
-    'Carpentry/Doors',
-    'Plumbing',
-    'Electrical/Mechanical',
   ].freeze
 
   def self.send_chain(methods)


### PR DESCRIPTION
## Changes in this PR:

- scheme reports included duplicate rows for cosmetic and plumbing since they were added twice to the Trade list by mistake