### PR TITLE
[119] Scheme reports include counts for overdue and due by priority

### DIFF
--- a/app/presenters/scheme_report_presenter.rb
+++ b/app/presenters/scheme_report_presenter.rb
@@ -41,6 +41,16 @@ class SchemeReportPresenter
     )
   end
 
+  def due_defects_by_priority(priority:)
+    defects = defects_by_priority(priority: priority)
+    defects.where('target_completion_date >= ?', Date.current)
+  end
+
+  def overdue_defects_by_priority(priority:)
+    defects = defects_by_priority(priority: priority)
+    defects.where('target_completion_date < ?', Date.current)
+  end
+
   private
 
   def percentage_for(number:, total:)

--- a/app/views/staff/report/_priorities.html.haml
+++ b/app/views/staff/report/_priorities.html.haml
@@ -9,11 +9,11 @@
       %th.govuk-table__header
         Percentage
       %th.govuk-table__header
-        Total
-      %th.govuk-table__header
         Due
       %th.govuk-table__header
         Overdue
+      %th.govuk-table__header
+        Total
       %th.govuk-table__header
         Completed on time
   %tbody.govuk-table__body
@@ -22,7 +22,7 @@
         %td.govuk-table__cell= priority.name
         %td.govuk-table__cell= priority.days
         %td.govuk-table__cell= presenter.priority_percentage(priority: priority)
+        %td.govuk-table__cell= presenter.due_defects_by_priority(priority: priority).count
+        %td.govuk-table__cell= presenter.overdue_defects_by_priority(priority: priority).count
         %td.govuk-table__cell= presenter.defects_by_priority(priority: priority).count
-        %td.govuk-table__cell= '-'
-        %td.govuk-table__cell= '-'
         %td.govuk-table__cell= '-'

--- a/spec/features/anyone_can_view_a_scheme_report_spec.rb
+++ b/spec/features/anyone_can_view_a_scheme_report_spec.rb
@@ -87,7 +87,17 @@ RSpec.feature 'Anyone can view a report for a scheme' do
   end
 
   scenario 'defect information by scheme priority' do
-    create(:property_defect, property: property, priority: priority)
+    travel_to Time.zone.parse('2019-05-23')
+
+    _due_priority = create(:property_defect,
+                           property: property,
+                           priority: priority,
+                           target_completion_date: Date.new(2019, 5, 24))
+    _overdue_priorities = create_list(:property_defect,
+                                      2,
+                                      property: property,
+                                      priority: priority,
+                                      target_completion_date: Date.new(2019, 5, 22))
 
     visit report_scheme_path(scheme)
 
@@ -103,6 +113,10 @@ RSpec.feature 'Anyone can view a report for a scheme' do
 
       expect(page).to have_content('100.0%')
       expect(page).to have_content('1')
+      expect(page).to have_content('2')
+      expect(page).to have_content('3')
     end
+
+    travel_back
   end
 end

--- a/spec/presenters/scheme_report_presenter_spec.rb
+++ b/spec/presenters/scheme_report_presenter_spec.rb
@@ -110,4 +110,58 @@ RSpec.describe SchemeReportPresenter do
       end
     end
   end
+
+  describe '#due_defects_by_priority' do
+    it 'returns all defects with a target_completion_date before todays date' do
+      travel_to Time.zone.parse('2019-05-23')
+
+      due_tomorrow_priority_defect = create(:property_defect,
+                                            property: property,
+                                            priority: priority,
+                                            target_completion_date: Date.new(2019, 5, 24))
+      due_today_priority_defect = create(:property_defect,
+                                         property: property,
+                                         priority: priority,
+                                         target_completion_date: Date.new(2019, 5, 23))
+      overdue_priority_defect = create(:property_defect,
+                                       property: property,
+                                       priority: priority,
+                                       target_completion_date: Date.new(2019, 5, 22))
+
+      result = described_class.new(scheme: scheme).due_defects_by_priority(priority: priority)
+
+      expect(result).to include(due_tomorrow_priority_defect)
+      expect(result).to include(due_today_priority_defect)
+      expect(result).not_to include(overdue_priority_defect)
+
+      travel_back
+    end
+  end
+
+  describe '#overdue_defects_by_priority' do
+    it 'returns all defects with a target_completion_date before todays date' do
+      travel_to Time.zone.parse('2019-05-23')
+
+      due_tomorrow_priority_defect = create(:property_defect,
+                                            property: property,
+                                            priority: priority,
+                                            target_completion_date: Date.new(2019, 5, 24))
+      due_today_priority_defect = create(:property_defect,
+                                         property: property,
+                                         priority: priority,
+                                         target_completion_date: Date.new(2019, 5, 23))
+      overdue_priority_defect = create(:property_defect,
+                                       property: property,
+                                       priority: priority,
+                                       target_completion_date: Date.new(2019, 5, 22))
+
+      result = described_class.new(scheme: scheme).overdue_defects_by_priority(priority: priority)
+
+      expect(result).not_to include(due_tomorrow_priority_defect)
+      expect(result).not_to include(due_today_priority_defect)
+      expect(result).to include(overdue_priority_defect)
+
+      travel_back
+    end
+  end
 end


### PR DESCRIPTION
## Changes in this PR:
- the priority table in a scheme report includes the counts of defects of that priority which are due and overdue

## Screenshots of UI changes:

### Before

![Screenshot 2019-07-15 at 11 02 08](https://user-images.githubusercontent.com/912473/61208764-0d7a6e00-a6f0-11e9-80a5-47ce7e353d81.png)


### After

![Screenshot 2019-07-15 at 11 01 51](https://user-images.githubusercontent.com/912473/61208781-0fdcc800-a6f0-11e9-985c-5f6bca01968a.png)
