### PR TITLE
[116] Scheme reports show how many defects have been completed on…

### DIFF
--- a/app/views/staff/report/_priorities.html.haml
+++ b/app/views/staff/report/_priorities.html.haml
@@ -25,4 +25,4 @@
         %td.govuk-table__cell= presenter.due_defects_by_priority(priority: priority).count
         %td.govuk-table__cell= presenter.overdue_defects_by_priority(priority: priority).count
         %td.govuk-table__cell= presenter.defects_by_priority(priority: priority).count
-        %td.govuk-table__cell= '-'
+        %td.govuk-table__cell= presenter.defects_completed_on_time(priority: priority).count

--- a/spec/features/anyone_can_view_a_scheme_report_spec.rb
+++ b/spec/features/anyone_can_view_a_scheme_report_spec.rb
@@ -119,4 +119,36 @@ RSpec.feature 'Anyone can view a report for a scheme' do
 
     travel_back
   end
+
+  scenario 'defects completed on or before their target date' do
+    travel_to Time.zone.parse('2019-05-23')
+
+    completed_early_defect = create(:property_defect,
+                                    property: property,
+                                    priority: priority,
+                                    target_completion_date: Date.new(2019, 5, 22))
+    completed_on_time_defect = create(:property_defect,
+                                      property: property,
+                                      priority: priority,
+                                      target_completion_date: Date.new(2019, 5, 23))
+    completed_later_defect = create(:property_defect,
+                                    property: property,
+                                    priority: priority,
+                                    target_completion_date: Date.new(2019, 5, 24))
+
+    # Update the records status so that PublicActivity creates the required defect.update events
+    [
+      completed_early_defect,
+      completed_on_time_defect,
+      completed_later_defect,
+    ].each(&:completed!)
+
+    visit report_scheme_path(scheme)
+
+    within('.priorities') do
+      expect(page).to have_content('2')
+    end
+
+    travel_back
+  end
 end


### PR DESCRIPTION
… time

## Changes in this PR:
* We are thinking of "On time"  as on or before the target completion date of the defect
* Defect statuses _can_ go back from a completed status to an open one. This we have learnt is a rare case since most defects that aren't completed are re-raised as new defects. As this situation can happen (statuses can be changed back) we are first ensuring we are only checking currently `completed` defects, and then only using the events to check the dates
* I spent 40 or so minutes trying to query the Activity table directly in order to find the content 'status: '[anything, 'completed']' without success. As it's a text format, not a json or jsonb type any query would have to match on serialised data which I can't see how to do clearly.

## Screenshots of UI changes:

### Before
![Screenshot 2019-07-15 at 11 01 51](https://user-images.githubusercontent.com/912473/61224160-fcdcee80-a715-11e9-8455-3585ffae7c72.png)

### After
![Screenshot 2019-07-15 at 15 26 12](https://user-images.githubusercontent.com/912473/61224150-f5b5e080-a715-11e9-847b-d36b48818a64.png)

