### PR TITLE
RSpec test script will output the seed order

### DIFF
--- a/bin/dspec
+++ b/bin/dspec
@@ -7,5 +7,5 @@ then
   docker exec -it report-a-defect_test_web_1 rake default $@
 else
   echo "Testing: $@"
-  docker exec -it report-a-defect_test_web_1 rspec "$@"
+  docker exec -it report-a-defect_test_web_1 rspec --order random "$@"
 fi


### PR DESCRIPTION
## Changes in this PR:

* Without this change, no seed numbers are ever output into the terminal which makes rerunning intermittently breaking tests a pain to deal with. What we want is to take note of the failing seed number and rerun it with confidence it contains the failing scenario for us to fix
* You can use a seed number to run a seed as normal `$ bin/dspec spec --seed=98909`

