### PR TITLE
[116] Reports can be filtered by date

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -7,7 +7,7 @@ $govuk-image-url-function: 'image-url';
 @import 'components/lbh-header';
 @import 'components/lbh-buttons';
 @import 'components/flashes';
-@import 'components/filters';
+@import 'components/forms';
 
 p {
   @include govuk-font(19);

--- a/app/assets/stylesheets/components/forms.scss
+++ b/app/assets/stylesheets/components/forms.scss
@@ -1,6 +1,10 @@
-.filter-defects {
+.lbh-filter-form {
   border: 4px solid $lbh-panel-light;
   padding: 0.75rem;
+}
+
+.filter-defects {
+  @extend .lbh-filter-form;
 
   .lbh-checkboxes {
     border-top: 1px solid $lbh-panel-light;
@@ -10,5 +14,13 @@
 
   .lbh-fieldset {
     display: inline;
+  }
+}
+
+.date-filter {
+  @extend .lbh-filter-form;
+  margin-bottom: 10px;
+  .date-form {
+    display: inline-block;
   }
 }

--- a/app/controllers/staff/report_controller.rb
+++ b/app/controllers/staff/report_controller.rb
@@ -12,13 +12,50 @@ class Staff::ReportController < Staff::BaseController
   end
 
   def show
-    @scheme = Scheme.find(scheme_id)
-    @presenter = SchemeReportPresenter.new(scheme: @scheme)
+    @report_form = ReportForm.new(from_date: from_date, to_date: to_date)
+    @scheme = scheme
+    @presenter = SchemeReportPresenter.new(scheme: scheme, report_form: @report_form)
   end
 
   private
 
+  def scheme
+    @scheme ||= Scheme.find(scheme_id)
+  end
+
   def scheme_id
     params[:id]
+  end
+
+  def from_date
+    Date.new(from_year, from_month, from_day)
+  end
+
+  def to_date
+    Date.new(to_year, to_month, to_day)
+  end
+
+  def from_day
+    params.fetch(:from_day, scheme.created_at.day).to_i
+  end
+
+  def from_month
+    params.fetch(:from_month, scheme.created_at.month).to_i
+  end
+
+  def from_year
+    params.fetch(:from_year, scheme.created_at.year).to_i
+  end
+
+  def to_day
+    params.fetch(:to_day, Date.current.day).to_i
+  end
+
+  def to_month
+    params.fetch(:to_month, Date.current.month).to_i
+  end
+
+  def to_year
+    params.fetch(:to_year, Date.current.year).to_i
   end
 end

--- a/app/form_objects/report_form.rb
+++ b/app/form_objects/report_form.rb
@@ -1,0 +1,33 @@
+class ReportForm
+  attr_accessor :from_date,
+                :to_date
+
+  def initialize(from_date:, to_date:)
+    self.from_date = from_date.to_date
+    self.to_date = to_date.to_date
+  end
+
+  def from_day
+    from_date.day
+  end
+
+  def from_month
+    from_date.month
+  end
+
+  def from_year
+    from_date.year
+  end
+
+  def to_day
+    to_date.day
+  end
+
+  def to_month
+    to_date.month
+  end
+
+  def to_year
+    to_date.year
+  end
+end

--- a/app/presenters/scheme_report_presenter.rb
+++ b/app/presenters/scheme_report_presenter.rb
@@ -1,18 +1,24 @@
 class SchemeReportPresenter
   delegate :name, to: :scheme
 
-  attr_accessor :scheme
+  attr_accessor :scheme, :report_form
 
-  def initialize(scheme:)
+  def initialize(scheme:,
+                 report_form: ReportForm.new(from_date: scheme.created_at, to_date: Date.current))
     self.scheme = scheme
+    self.report_form = report_form
   end
 
   def defects
     @defects ||= Defect.for_scheme([scheme.id])
+                       .where(
+                         'created_at >= ? and created_at <= ?',
+                         report_form.from_date.beginning_of_day, report_form.to_date.end_of_day
+                       )
   end
 
   def date_range
-    "From #{scheme.created_at} to #{Time.current}"
+    "From #{report_form.from_date} to #{report_form.to_date}"
   end
 
   def defects_by_status(text:)

--- a/app/views/staff/report/show.html.haml
+++ b/app/views/staff/report/show.html.haml
@@ -11,6 +11,44 @@
       %span.govuk-caption-l= @presenter.scheme.contractor_name
       %span.govuk-caption-l= @presenter.date_range
 
+    = form_tag report_scheme_path(scheme: @presenter.scheme.id), class: 'date-filter', method: :get do
+      .govuk-form-group.date-form
+        %h2.govuk-heading-m From
+        .govuk-fieldset
+          .govuk-date-input__item
+            .govuk-form-group
+              = label_tag 'from_day', 'Day', class: 'govuk-label govuk-date-input__label'
+              = text_field_tag 'from_day', @report_form.from_day, class: 'govuk-input govuk-date-input__input govuk-input--width-2', type: :number, pattern: "[0-9]*"
+          .govuk-date-input__item
+            .govuk-form-group
+              = label_tag 'from_month', 'Month', class: 'govuk-label govuk-date-input__label'
+              = text_field_tag 'from_month', @report_form.from_month, class: 'govuk-input govuk-date-input__input govuk-input--width-2', type: :number, pattern: "[0-9]*"
+          .govuk-date-input__item
+            .govuk-form-group
+              = label_tag 'from_year', 'Year', class: 'govuk-label govuk-date-input__label'
+              = text_field_tag 'from_year', @report_form.from_year, class: 'govuk-input govuk-date-input__input govuk-input--width-4', type: :number, pattern: "[0-9]*"
+
+      .govuk-form-group.date-form
+        %h2.govuk-heading-m To
+        .govuk-fieldset
+          .govuk-date-input__item
+            .govuk-form-group
+              = label_tag 'to_day', 'Day', class: 'govuk-label govuk-date-input__label'
+              = text_field_tag 'to_day', @report_form.to_day, class: 'govuk-input govuk-date-input__input govuk-input--width-2', type: :number, pattern: "[0-9]*"
+          .govuk-date-input__item
+            .govuk-form-group
+              = label_tag 'to_month', 'Month', class: 'govuk-label govuk-date-input__label'
+              = text_field_tag 'to_month', @report_form.to_month, class: 'govuk-input govuk-date-input__input govuk-input--width-2', type: :number, pattern: "[0-9]*"
+          .govuk-date-input__item
+            .govuk-form-group
+              = label_tag 'to_year', 'Year', class: 'govuk-label govuk-date-input__label'
+              = text_field_tag 'to_year', @report_form.to_year, class: 'govuk-input govuk-date-input__input govuk-input--width-4', type: :number, pattern: "[0-9]*"
+
+      %br
+      = submit_tag 'Apply dates', class: 'govuk-button mb0'
+
+.govuk-grid-row
+  .govuk-grid-column-full
     = render partial: 'summary', locals: { presenter: @presenter }
     = render partial: 'statuses', locals: { presenter: @presenter }
     = render partial: 'trades', locals: { presenter: @presenter }

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -14,7 +14,7 @@ User.delete_all
 estate = FactoryBot.create(:estate, name: 'Kings Cresent')
 
 # Schemes
-scheme1 = FactoryBot.create(:scheme, estate: estate, name: '1')
+scheme1 = FactoryBot.create(:scheme, estate: estate, name: '1', created_at: 5.days.ago)
 FactoryBot.create(:scheme, estate: estate, name: '2')
 
 # Priorties
@@ -48,7 +48,8 @@ FactoryBot.create(:communal_area, scheme: scheme1)
     10,
     :with_comments,
     property: property,
-    priority: [priority1, priority2, priority3, priority4].sample
+    priority: [priority1, priority2, priority3, priority4].sample,
+    created_at: 2.days.ago
   )
 end
 

--- a/spec/features/anyone_can_view_a_scheme_report_spec.rb
+++ b/spec/features/anyone_can_view_a_scheme_report_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.feature 'Anyone can view a report for a scheme' do
-  let(:scheme) { create(:scheme) }
+  let(:scheme) { create(:scheme, created_at: 5.days.ago) }
   let(:priority) { create(:priority, scheme: scheme) }
   let(:property) { create(:property, scheme: scheme) }
   let(:communal_area) { create(:communal_area, scheme: scheme) }
@@ -17,7 +17,7 @@ RSpec.feature 'Anyone can view a report for a scheme' do
     end
 
     expect(page).to have_content(I18n.t('page_title.staff.reports.scheme.show', name: scheme.name))
-    expect(page).to have_content("From #{scheme.created_at} to #{Time.current}")
+    expect(page).to have_content("From #{scheme.created_at.to_date} to #{Date.current}")
 
     within('.summary') do
       %w[Title Property Communal Total].each do |column_header|
@@ -147,6 +147,38 @@ RSpec.feature 'Anyone can view a report for a scheme' do
 
     within('.priorities') do
       expect(page).to have_content('2')
+    end
+
+    travel_back
+  end
+
+  scenario 'filter defects' do
+    travel_to Time.zone.parse('2019-05-25')
+
+    defect_one = create(:property_defect, created_at: Time.utc(2019, 5, 23), property: property)
+    defect_two = create(:property_defect, created_at: Time.utc(2019, 5, 24), property: property)
+    defect_three = create(:communal_defect, created_at: Time.utc(2019, 5, 24), communal_area: communal_area)
+    defect_four = create(:property_defect, created_at: Time.utc(2019, 5, 25), property: property)
+
+    defects = [defect_one, defect_two, defect_three, defect_four]
+
+    visit report_scheme_path(scheme)
+
+    within('.summary') do
+      expect(page).to have_content(defects.count)
+    end
+
+    within('.date-filter') do
+      fill_in 'from_day', with: '5'
+      fill_in 'from_month', with: '23'
+      fill_in 'from_year', with: '2019'
+      fill_in 'to_day', with: '24'
+      fill_in 'to_month', with: '5'
+      fill_in 'to_year', with: '2019'
+    end
+
+    within('.summary') do
+      expect(page).to have_content('3')
     end
 
     travel_back

--- a/spec/form_objects/report_form_spec.rb
+++ b/spec/form_objects/report_form_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+
+RSpec.describe ReportForm do
+  let(:from_date) { Date.new(2019, 1, 1) }
+  let(:to_date) { Date.new(2019, 12, 1) }
+
+  describe '.initialize' do
+    context 'when the from_date is a time' do
+      it 'returns a date' do
+        result = described_class.new(from_date: Time.current, to_date: to_date)
+        expect(result.from_date.class).to eq(Date)
+      end
+    end
+
+    context 'when the to_date is a time' do
+      it 'returns a date' do
+        result = described_class.new(from_date: from_date, to_date: Time.current)
+        expect(result.to_date.class).to eq(Date)
+      end
+    end
+  end
+
+  describe '#from_day' do
+    it 'returns the from day' do
+      result = described_class.new(from_date: from_date, to_date: to_date).from_day
+      expect(result).to eql(1)
+    end
+  end
+
+  describe '#from_month' do
+    it 'returns the from month' do
+      result = described_class.new(from_date: from_date, to_date: to_date).from_month
+      expect(result).to eql(1)
+    end
+  end
+
+  describe '#from_year' do
+    it 'returns the from year' do
+      result = described_class.new(from_date: from_date, to_date: to_date).from_year
+      expect(result).to eql(2019)
+    end
+  end
+
+  describe '#to_day' do
+    it 'returns the to day' do
+      result = described_class.new(from_date: from_date, to_date: to_date).to_day
+      expect(result).to eql(1)
+    end
+  end
+
+  describe '#to_month' do
+    it 'returns the to month' do
+      result = described_class.new(from_date: from_date, to_date: to_date).to_month
+      expect(result).to eql(12)
+    end
+  end
+
+  describe '#to_year' do
+    it 'returns the to year' do
+      result = described_class.new(from_date: from_date, to_date: to_date).to_year
+      expect(result).to eql(2019)
+    end
+  end
+end


### PR DESCRIPTION
## Changes in this PR:
- default behaviour is still to show all the defect data we have for that scheme since creation
- dates can now be provided to overwrite these defaults, filtering the defect list down
- no form validation added in order to ensure that the from date is before the to date or that a value has been provided at all, with more time we would do this but with the shortness of time we have to trust that the team can use the tools intuitively 
- reuse of form styles from defect overview

## Screenshots of UI changes:

### Desktop
![Screenshot 2019-07-15 at 18 06 56](https://user-images.githubusercontent.com/912473/61234585-5ac80100-a72b-11e9-8903-f651dd4ae2ba.png)

### Mobile 
![Screenshot 2019-07-15 at 18 09 16](https://user-images.githubusercontent.com/912473/61234702-ada1b880-a72b-11e9-90b3-469f900c51e7.png)

