### PR TITLE
[155] Defect reports show trade categories rather than all trades

### DIFF
--- a/app/models/defect.rb
+++ b/app/models/defect.rb
@@ -50,7 +50,7 @@ class Defect < ApplicationRecord
     for_properties_or_communal_areas(property_ids, communal_area_ids)
   })
 
-  scope :for_trade, (->(trade) { where(trade: trade) })
+  scope :for_trades, (->(trade_names) { where(trade: trade_names) })
 
   belongs_to :property, optional: true
   belongs_to :communal_area, optional: true
@@ -74,13 +74,6 @@ class Defect < ApplicationRecord
     selected_changes = changes.slice(:status)
     @tracked_changes = selected_changes unless selected_changes.empty?
   end
-
-  CATEGORIES = [
-    'Plumbing',
-    'Electrical/Mechanical',
-    'Carpentry/Doors',
-    'Cosmetic',
-  ].freeze
 
   PLUMBING_TRADES = [
     'Plumbing',
@@ -156,6 +149,13 @@ class Defect < ApplicationRecord
     'Water Temperature/Supply',
     'Window Work',
   ].freeze
+
+  CATEGORIES = {
+    'Plumbing' => PLUMBING_TRADES,
+    'Electrical/Mechanical' => ELECTRICAL_TRADES,
+    'Carpentry/Doors' => CARPENTRY_TRADES,
+    'Cosmetic' => COSMETIC_TRADES,
+  }.freeze
 
   def self.send_chain(methods)
     methods.inject(self) { |s, method| s.send(*method) }

--- a/app/models/defect.rb
+++ b/app/models/defect.rb
@@ -75,6 +75,55 @@ class Defect < ApplicationRecord
     @tracked_changes = selected_changes unless selected_changes.empty?
   end
 
+  CATEGORIES = [
+    'Plumbing',
+    'Electrical/Mechanical',
+    'Carpentry/Doors',
+    'Cosmetic',
+  ].freeze
+
+  PLUMBING_TRADES = [
+    'Plumbing',
+    'Drainage',
+    'Water temp / supply',
+  ].freeze
+
+  ELECTRICAL_TRADES = [
+    'Electrical',
+    'Connectivity',
+    'Lighting',
+    'Boiler work',
+    'MVHR',
+    'Fan / Ventilation',
+    'Fire safety',
+    'Lifts',
+    'Heating',
+    'Intercoms / Entry Phones',
+    'Filters',
+  ].freeze
+
+  CARPENTRY_TRADES = [
+    'Carpentry',
+    'Door work',
+    'Window work',
+    'Metal work',
+    'Locks',
+    'Adapted bathrooms',
+  ].freeze
+
+  COSMETIC_TRADES = [
+    'Cosmetic',
+    'Damp',
+    'Floor work',
+    'Mastic',
+    'Decoration',
+    'Tile work',
+    'Plastering',
+    'Blinds',
+    'Brickwork',
+    'Roof',
+  ].freeze
+
   TRADES = [
     'Blinds',
     'Boiler work',
@@ -156,6 +205,7 @@ class Defect < ApplicationRecord
       type
       status
       trade
+      category
       priority_name
       priority_duration
       target_completion_date

--- a/app/presenters/defect_presenter.rb
+++ b/app/presenters/defect_presenter.rb
@@ -30,6 +30,15 @@ class DefectPresenter < SimpleDelegator
     super.to_s
   end
 
+  def category
+    return 'Plumbing' if Defect::PLUMBING_TRADES.include?(trade)
+    return 'Electrical/Mechanical' if Defect::ELECTRICAL_TRADES.include?(trade)
+    return 'Carpentry/Doors' if Defect::CARPENTRY_TRADES.include?(trade)
+    return 'Cosmetic' if Defect::COSMETIC_TRADES.include?(trade)
+    trade
+  end
+
+  # rubocop:disable Metrics/AbcSize
   def to_row
     [
       reference_number,
@@ -38,6 +47,7 @@ class DefectPresenter < SimpleDelegator
       defect_type,
       status,
       trade,
+      category,
       priority.name,
       priority.days,
       target_completion_date,
@@ -50,4 +60,5 @@ class DefectPresenter < SimpleDelegator
       access_information,
     ]
   end
+  # rubocop:enable Metrics/AbcSize
 end

--- a/app/presenters/scheme_report_presenter.rb
+++ b/app/presenters/scheme_report_presenter.rb
@@ -25,13 +25,14 @@ class SchemeReportPresenter
     defects.where(status: text)
   end
 
-  def defects_by_trade(text:)
-    defects.for_trade(text)
+  def defects_by_category(category:)
+    trade_names = Defect::CATEGORIES[category]
+    defects.for_trades(trade_names)
   end
 
-  def trade_percentage(text:)
+  def category_percentage(category:)
     percentage_for(
-      number: Float(defects_by_trade(text: text).count),
+      number: Float(defects_by_category(category: category).count),
       total: Float(defects.count)
     )
   end

--- a/app/views/staff/report/_trades.html.haml
+++ b/app/views/staff/report/_trades.html.haml
@@ -9,8 +9,8 @@
       %th.govuk-table__header
         Total
   %tbody.govuk-table__body
-    - Defect::TRADES.each do |trade|
+    - Defect::CATEGORIES.each do |category, trades|
       %tr.govuk-table__row
-        %td.govuk-table__cell= trade
-        %td.govuk-table__cell= presenter.trade_percentage(text: trade)
-        %td.govuk-table__cell= presenter.defects_by_trade(text: trade).count
+        %td.govuk-table__cell= category
+        %td.govuk-table__cell= presenter.category_percentage(category: category)
+        %td.govuk-table__cell= presenter.defects_by_category(category: category).count

--- a/spec/features/anyone_can_download_defect_csv_spec.rb
+++ b/spec/features/anyone_can_download_defect_csv_spec.rb
@@ -20,6 +20,7 @@ RSpec.feature 'Anyone can download defect data' do
       type
       status
       trade
+      category
       priority_name
       priority_duration
       target_completion_date
@@ -43,6 +44,7 @@ RSpec.feature 'Anyone can download defect data' do
     expect(page).to have_content(property_defect.defect_type)
     expect(page).to have_content(property_defect.status)
     expect(page).to have_content(property_defect.trade)
+    expect(page).to have_content(property_defect.category)
     expect(page).to have_content(property_defect.priority.name)
     expect(page).to have_content(property_defect.priority.days)
     expect(page).to have_content(property_defect.target_completion_date)

--- a/spec/features/anyone_can_view_a_scheme_report_spec.rb
+++ b/spec/features/anyone_can_view_a_scheme_report_spec.rb
@@ -74,8 +74,8 @@ RSpec.feature 'Anyone can view a report for a scheme' do
         expect(page).to have_content(header)
       end
 
-      Defect::TRADES.each do |trade|
-        expect(page).to have_content(trade)
+      Defect::CATEGORIES.each do |category, _trades|
+        expect(page).to have_content(category)
       end
 
       expect(page).to have_content('30.0%')

--- a/spec/fixtures/download_defects.csv
+++ b/spec/fixtures/download_defects.csv
@@ -1,3 +1,3 @@
-reference_number,created_at,title,type,status,trade,priority_name,priority_duration,target_completion_date,estate,scheme,property_address,communal_area_name,communal_area_location,description,access_information
-456ABC,"1st October 2017, 13:13",a shorter title,Communal,Outstanding,Electrical,P1,1, 1 October 2019,estate,scheme,,Pine Creek,1-100 Hackney Street,a longer description,The communal door will be unlocked
-123ABC,"1st October 2018, 13:13",a short title,Property,Outstanding,Electrical,P1,1, 1 October 2020,estate,scheme,1 Hackney Street,,,a long description,The key is under the garden pot
+reference_number,created_at,title,type,status,trade,category,priority_name,priority_duration,target_completion_date,estate,scheme,property_address,communal_area_name,communal_area_location,description,access_information
+456ABC,"1st October 2017, 13:13",a shorter title,Communal,Outstanding,Electrical,Electrical/Mechanical,P1,1, 1 October 2019,estate,scheme,,Pine Creek,1-100 Hackney Street,a longer description,The communal door will be unlocked
+123ABC,"1st October 2018, 13:13",a short title,Property,Outstanding,Electrical,Electrical/Mechanical,P1,1, 1 October 2020,estate,scheme,1 Hackney Street,,,a long description,The key is under the garden pot

--- a/spec/models/defect_spec.rb
+++ b/spec/models/defect_spec.rb
@@ -243,6 +243,7 @@ RSpec.describe Defect, type: :model do
           type
           status
           trade
+          category
           priority_name
           priority_duration
           target_completion_date

--- a/spec/presenters/defect_presenter_spec.rb
+++ b/spec/presenters/defect_presenter_spec.rb
@@ -143,8 +143,8 @@ RSpec.describe DefectPresenter do
   describe '.to_row' do
     context 'when the defect is for a property' do
       it 'returns an array of values as they should appear in a CSV row' do
-        defect = create(:property_defect)
-        result = described_class.new(defect).to_row
+        defect = described_class.new(create(:property_defect))
+        result = defect.to_row
         expect(result).to eq(
           [
             defect.reference_number,
@@ -153,6 +153,7 @@ RSpec.describe DefectPresenter do
             'Property',
             defect.status,
             defect.trade,
+            defect.category,
             defect.priority.name,
             defect.priority.days,
             defect.target_completion_date.to_s,
@@ -170,8 +171,8 @@ RSpec.describe DefectPresenter do
 
     context 'when the defect is for a communal area' do
       it 'returns an array of values as they should appear in a CSV row' do
-        defect = create(:communal_defect)
-        result = described_class.new(defect).to_row
+        defect = described_class.new(create(:communal_defect))
+        result = defect.to_row
         expect(result).to eq(
           [
             defect.reference_number,
@@ -180,6 +181,7 @@ RSpec.describe DefectPresenter do
             'Communal',
             defect.status,
             defect.trade,
+            defect.category,
             defect.priority.name,
             defect.priority.days,
             defect.target_completion_date.to_s,
@@ -192,6 +194,72 @@ RSpec.describe DefectPresenter do
             defect.access_information,
           ]
         )
+      end
+    end
+  end
+
+  describe '#category' do
+    context 'when the trade belongs to the Plumbing category' do
+      it 'returns "Plumbing"' do
+        defect = create(:property_defect, trade: 'Drainage')
+        result = described_class.new(defect).category
+        expect(result).to eql('Plumbing')
+      end
+
+      context 'when the trade is the same as a category' do
+        it 'returns "Plumbing"' do
+          defect = create(:property_defect, trade: 'Plumbing')
+          result = described_class.new(defect).category
+          expect(result).to eql('Plumbing')
+        end
+      end
+    end
+
+    context 'when the trade belongs to the Electrical category' do
+      it 'returns "Electrical/Mechanical"' do
+        defect = create(:property_defect, trade: 'Lighting')
+        result = described_class.new(defect).category
+        expect(result).to eql('Electrical/Mechanical')
+      end
+
+      context 'when the trade is the same as a category' do
+        it 'returns "Electrical/Mechanical"' do
+          defect = create(:property_defect, trade: 'Electrical/Mechanical')
+          result = described_class.new(defect).category
+          expect(result).to eql('Electrical/Mechanical')
+        end
+      end
+    end
+
+    context 'when the trade belongs to the Carpentry category' do
+      it 'returns "Carpentry/Doors"' do
+        defect = create(:property_defect, trade: 'Door work')
+        result = described_class.new(defect).category
+        expect(result).to eql('Carpentry/Doors')
+      end
+
+      context 'when the trade is the same as a category' do
+        it 'returns "Carpentry / Doors"' do
+          defect = create(:property_defect, trade: 'Carpentry/Doors')
+          result = described_class.new(defect).category
+          expect(result).to eql('Carpentry/Doors')
+        end
+      end
+    end
+
+    context 'when the trade belongs to the Cosmetic category' do
+      it 'returns "Cosmetic"' do
+        defect = create(:property_defect, trade: 'Damp')
+        result = described_class.new(defect).category
+        expect(result).to eql('Cosmetic')
+      end
+
+      context 'when the trade is the same as a category' do
+        it 'returns "Cosmetic"' do
+          defect = create(:property_defect, trade: 'Cosmetic')
+          result = described_class.new(defect).category
+          expect(result).to eql('Cosmetic')
+        end
       end
     end
   end

--- a/spec/presenters/scheme_report_presenter_spec.rb
+++ b/spec/presenters/scheme_report_presenter_spec.rb
@@ -80,23 +80,23 @@ RSpec.describe SchemeReportPresenter do
     end
   end
 
-  describe '#defects_by_trade' do
-    it 'returns a count for all defects for the given trade' do
+  describe '#defects_by_category' do
+    it 'returns a count for all defects where the trade matches the category' do
       electrical_defect = create(:property_defect, property: property, trade: 'Electrical')
-      plumbing_defect = create(:property_defect, property: property, trade: 'Plumbing')
+      plumbing_defect = create(:property_defect, property: property, trade: 'Drainage')
 
-      result = described_class.new(scheme: scheme).defects_by_trade(text: 'Plumbing')
+      result = described_class.new(scheme: scheme).defects_by_category(category: 'Plumbing')
 
       expect(result).to include(plumbing_defect)
       expect(result).not_to include(electrical_defect)
     end
   end
 
-  describe '#trade_percentage' do
-    it 'returns the percentage of defects with this trade ' do
+  describe '#category_percentage' do
+    it 'returns the percentage of defects with this category ' do
       create(:property_defect, property: property, trade: 'Plumbing')
       create(:property_defect, property: property, trade: 'Electrical')
-      result = described_class.new(scheme: scheme).trade_percentage(text: 'Electrical')
+      result = described_class.new(scheme: scheme).category_percentage(category: 'Electrical/Mechanical')
       expect(result).to eql('50.0%')
     end
 
@@ -105,14 +105,14 @@ RSpec.describe SchemeReportPresenter do
         create(:property_defect, property: property, trade: 'Electrical')
         create(:property_defect, property: property, trade: 'Plumbing')
         create(:property_defect, property: property, trade: 'Plumbing')
-        result = described_class.new(scheme: scheme).trade_percentage(text: 'Electrical')
+        result = described_class.new(scheme: scheme).category_percentage(category: 'Electrical/Mechanical')
         expect(result).to eql('33.33%')
       end
     end
 
     context 'when there are no defects with that trade' do
       it 'returns 0.0%' do
-        result = described_class.new(scheme: scheme).trade_percentage(text: 'Electrical')
+        result = described_class.new(scheme: scheme).category_percentage(category: 'Electrical/Mechanical')
         expect(result).to eql('0.0%')
       end
     end


### PR DESCRIPTION
## Changes in this PR:
- CSV shows both trades and categories
- HTML reports no longer show specific trades but instead show the broader category they belong to
- Support for trades that are assigned where they are also the same name as the overall category

## Screenshots of UI changes:

### Before
![Screenshot 2019-07-16 at 12 47 00](https://user-images.githubusercontent.com/912473/61291951-d8414f00-a7c7-11e9-9219-d1476c301e14.png)
### After
![Screenshot 2019-07-16 at 12 46 46](https://user-images.githubusercontent.com/912473/61291950-d8414f00-a7c7-11e9-893c-6a55fb481dc9.png)

