### PR TITLE
(chore) Use Arial instead of GDS Transport

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,5 +1,6 @@
 $govuk-font-url-function: 'font-url';
 $govuk-image-url-function: 'image-url';
+$govuk-font-family: 'Arial', sans-serif;
 
 @import 'base/frontend';
 @import 'base/mixins';


### PR DESCRIPTION
## Changes in this PR:
* As we aren't hosted on a gov.uk domain we are not licensed to use the GDS Transport font and should instead use the advised Arial which is similar https://designnotes.blog.gov.uk/2015/03/11/can-i-use-the-gov-uk-fonts/

## Screenshots of UI changes:

### Before

![Screenshot 2019-07-17 at 16 16 31](https://user-images.githubusercontent.com/912473/61388129-53316500-a8af-11e9-98e4-a4f942239cc1.png)


### After


![Screenshot 2019-07-17 at 16 22 53](https://user-images.githubusercontent.com/912473/61388111-4ca2ed80-a8af-11e9-8ede-07a139c3abcc.png)
