### PR TITLE
Feature/144 search by reference number

### DIFF
--- a/app/controllers/staff/searches_controller.rb
+++ b/app/controllers/staff/searches_controller.rb
@@ -16,7 +16,7 @@ class Staff::SearchesController < Staff::BaseController
   end
 
   def search_by_reference_number(number)
-    defect = Defect.find_by(sequence_number: number.to_i)
+    defect = Defect.by_reference_number(number)
 
     if defect
       redirect_to property_defect_path(defect.property_id, defect)

--- a/app/controllers/staff/searches_controller.rb
+++ b/app/controllers/staff/searches_controller.rb
@@ -1,11 +1,28 @@
 class Staff::SearchesController < Staff::BaseController
   def index
-    @search_results = Search.new(query: query)
+    number = ReferenceNumber.parse(query)
+
+    if number
+      search_by_reference_number(number)
+    else
+      @search_results = Search.new(query: query)
+    end
   end
 
   private
 
   def query
     params.permit(:query)[:query]
+  end
+
+  def search_by_reference_number(number)
+    defect = Defect.find_by(sequence_number: number.to_i)
+
+    if defect
+      redirect_to property_defect_path(defect.property_id, defect)
+    else
+      flash[:notice] = I18n.t('page_content.defect.not_found', reference_number: query)
+      redirect_to dashboard_path
+    end
   end
 end

--- a/app/models/defect.rb
+++ b/app/models/defect.rb
@@ -163,7 +163,7 @@ class Defect < ApplicationRecord
     return nil if new_record?
 
     reload if sequence_number.blank?
-    format('NB-%06d', sequence_number).gsub(/-(\d{3})/, '-\1-')
+    ReferenceNumber.new(sequence_number).to_s
   end
 
   def set_completion_date

--- a/app/models/defect.rb
+++ b/app/models/defect.rb
@@ -159,6 +159,10 @@ class Defect < ApplicationRecord
     methods.inject(self) { |s, method| s.send(*method) }
   end
 
+  def self.by_reference_number(number)
+    find_by(sequence_number: number.to_i)
+  end
+
   def reference_number
     return nil if new_record?
 

--- a/app/presenters/reference_number.rb
+++ b/app/presenters/reference_number.rb
@@ -1,11 +1,11 @@
 class ReferenceNumber
-  FORMAT = /^ *NB-(\d+)-(\d+) *$/i.freeze
+  FORMAT = /^ *NB([0-9-]+) *$/i.freeze
 
   def self.parse(string)
     match = FORMAT.match(string)
     return nil unless match
 
-    number = (match[1] + match[2]).to_i
+    number = match[1].scan(/\d/).join('').to_i
     new(number)
   end
 

--- a/app/presenters/reference_number.rb
+++ b/app/presenters/reference_number.rb
@@ -1,0 +1,23 @@
+class ReferenceNumber
+  FORMAT = /^ *NB-(\d+)-(\d+) *$/i.freeze
+
+  def self.parse(string)
+    match = FORMAT.match(string)
+    return nil unless match
+
+    number = (match[1] + match[2]).to_i
+    new(number)
+  end
+
+  def initialize(number)
+    @number = number
+  end
+
+  def to_i
+    @number
+  end
+
+  def to_s
+    format('NB-%06d', @number).gsub(/-(\d{3})/, '-\1-')
+  end
+end

--- a/app/views/staff/dashboard/index.html.haml
+++ b/app/views/staff/dashboard/index.html.haml
@@ -11,7 +11,7 @@
 
     = form_tag search_path, method: :get, class: 'search' do |f|
       .govuk-form-group
-        = label_tag 'query', 'Address or communal area name', class: 'govuk-label'
+        = label_tag 'query', 'Reference number, address or communal area name', class: 'govuk-label'
         = search_field_tag :query, @search.query, class: 'govuk-input form-control form-control-communal_area govuk-!-width-three-quarters', placeholder: '1 Hackney Street or Clift House'
       = submit_tag I18n.t('generic.button.find'), class: 'govuk-button mb0'
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -65,6 +65,7 @@ en:
         priorities:
           no_priorities: 'There are no priotities set yet. You need to create them.'
     defect:
+      not_found: 'No defect could be found with reference number %{reference_number}'
       show:
         not_accepted_yet: 'Waiting on the contractor to accept'
       property:

--- a/spec/features/staff_can_view_a_defect_spec.rb
+++ b/spec/features/staff_can_view_a_defect_spec.rb
@@ -67,6 +67,22 @@ RSpec.feature 'Anyone can view a defect' do
     expect(page).to have_content(defect.title)
   end
 
+  scenario 'a defect can be found by reformatted reference number' do
+    defect = create(:property_defect)
+
+    visit dashboard_path
+
+    within('form.search') do
+      fill_in 'query', with: defect.reference_number.gsub('-', '')
+      click_on(I18n.t('generic.button.find'))
+    end
+
+    expect(page).to have_content(I18n.t('page_title.staff.defects.show', reference_number: defect.reference_number))
+
+    expect(page).to have_content(defect.reference_number)
+    expect(page).to have_content(defect.title)
+  end
+
   scenario 'entering an unknown reference number' do
     visit dashboard_path
 

--- a/spec/features/staff_can_view_a_defect_spec.rb
+++ b/spec/features/staff_can_view_a_defect_spec.rb
@@ -51,6 +51,36 @@ RSpec.feature 'Anyone can view a defect' do
     end
   end
 
+  scenario 'a defect can be found by reference number' do
+    defect = create(:property_defect)
+
+    visit dashboard_path
+
+    within('form.search') do
+      fill_in 'query', with: defect.reference_number
+      click_on(I18n.t('generic.button.find'))
+    end
+
+    expect(page).to have_content(I18n.t('page_title.staff.defects.show', reference_number: defect.reference_number))
+
+    expect(page).to have_content(defect.reference_number)
+    expect(page).to have_content(defect.title)
+  end
+
+  scenario 'entering an unknown reference number' do
+    visit dashboard_path
+
+    reference_number = ReferenceNumber.new(0)
+
+    within('form.search') do
+      fill_in 'query', with: reference_number.to_s
+      click_on(I18n.t('generic.button.find'))
+    end
+
+    expect(page).to have_content(I18n.t('page_title.staff.dashboard'))
+    expect(page).to have_content(I18n.t('page_content.defect.not_found', reference_number: reference_number.to_s))
+  end
+
   scenario 'can use breadcrumbs to navigate back to a property' do
     defect = create(:property_defect)
 

--- a/spec/presenters/reference_number_spec.rb
+++ b/spec/presenters/reference_number_spec.rb
@@ -5,6 +5,11 @@ RSpec.describe ReferenceNumber do
       expect(number.to_i).to eq(123_456)
     end
 
+    it 'matches a reference number string with non-canonical formatting' do
+      number = ReferenceNumber.parse('NB12---34')
+      expect(number.to_i).to eq(1234)
+    end
+
     it 'does not match any other string' do
       number = ReferenceNumber.parse('not a reference number')
       expect(number).to be_nil

--- a/spec/presenters/reference_number_spec.rb
+++ b/spec/presenters/reference_number_spec.rb
@@ -1,0 +1,20 @@
+RSpec.describe ReferenceNumber do
+  describe '.parse' do
+    it 'matches a reference number string' do
+      number = ReferenceNumber.parse('NB-123-456')
+      expect(number.to_i).to eq(123_456)
+    end
+
+    it 'does not match any other string' do
+      number = ReferenceNumber.parse('not a reference number')
+      expect(number).to be_nil
+    end
+  end
+
+  describe '#to_s' do
+    it 'formats the number' do
+      number = ReferenceNumber.new(123_456)
+      expect(number.to_s).to eq('NB-123-456')
+    end
+  end
+end


### PR DESCRIPTION
## Changes in this PR

Staff members can search for defects by reference number. If they enter `NB` followed by a sequence of digits and dashes into the search input, the app takes them directly to that defect.

The search form allows the reference number to be formatted flexibly, for example it's fine to omit the dashes or skip leading zeroes. This should help with people reading reference numbers over the phone.

If no such defect is found, the user stays on the search page and an error message appears.

## Screenshots of UI changes:

<img width="634" alt="Screenshot 2019-07-18 at 12 39 15" src="https://user-images.githubusercontent.com/9265/61454579-32bde500-a959-11e9-899f-6a3bcc2e34c2.png">

<img width="625" alt="Screenshot 2019-07-18 at 12 39 33" src="https://user-images.githubusercontent.com/9265/61454586-36ea0280-a959-11e9-8723-5ebdcb0442c6.png">

<img width="1224" alt="Screenshot 2019-07-18 at 12 39 59" src="https://user-images.githubusercontent.com/9265/61454594-39e4f300-a959-11e9-80b9-6edb5bd69380.png">