### PR TITLE
Feature/156 edit target completion date

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,5 +17,8 @@ Metrics/BlockLength:
 Metrics/MethodLength:
   Max: 25
 
+Naming/AccessorMethodName:
+  Enabled: false
+
 Style/ClassAndModuleChildren:
   Enabled: false

--- a/app/controllers/staff/communal_defects_controller.rb
+++ b/app/controllers/staff/communal_defects_controller.rb
@@ -32,7 +32,10 @@ class Staff::CommunalDefectsController < Staff::BaseController
     @defect = EditDefect.new(
       defect: defect,
       defect_params: defect_params,
-      options: { priority_id: priority_id }
+      options: {
+        priority_id: priority_id,
+        target_completion_date: target_completion_date,
+      }
     ).call
 
     if @defect.valid?
@@ -56,6 +59,10 @@ class Staff::CommunalDefectsController < Staff::BaseController
 
   def priority_id
     params.require(:defect).permit(:priority)[:priority]
+  end
+
+  def target_completion_date
+    params.require(:target_completion_date).permit(:day, :month, :year)
   end
 
   def defect_params

--- a/app/controllers/staff/property_defects_controller.rb
+++ b/app/controllers/staff/property_defects_controller.rb
@@ -32,7 +32,10 @@ class Staff::PropertyDefectsController < Staff::BaseController
     @defect = EditDefect.new(
       defect: defect,
       defect_params: defect_params,
-      options: { priority_id: priority_id }
+      options: {
+        priority_id: priority_id,
+        target_completion_date: target_completion_date,
+      }
     ).call
 
     if @defect.valid?
@@ -56,6 +59,10 @@ class Staff::PropertyDefectsController < Staff::BaseController
 
   def priority_id
     params.require(:defect).permit(:priority)[:priority]
+  end
+
+  def target_completion_date
+    params.require(:target_completion_date).permit(:day, :month, :year)
   end
 
   def defect_params

--- a/app/controllers/staff/report_controller.rb
+++ b/app/controllers/staff/report_controller.rb
@@ -28,34 +28,20 @@ class Staff::ReportController < Staff::BaseController
   end
 
   def from_date
-    Date.new(from_year, from_month, from_day)
+    date_param(:from_date, scheme.created_at)
   end
 
   def to_date
-    Date.new(to_year, to_month, to_day)
+    date_param(:to_date, Date.current)
   end
 
-  def from_day
-    params.fetch(:from_day, scheme.created_at.day).to_i
-  end
+  def date_param(param_name, default_date)
+    form_value = params.fetch(param_name, {})
 
-  def from_month
-    params.fetch(:from_month, scheme.created_at.month).to_i
-  end
+    day, month, year = %i[day month year].map do |field|
+      form_value.fetch(field, default_date.__send__(field)).to_i
+    end
 
-  def from_year
-    params.fetch(:from_year, scheme.created_at.year).to_i
-  end
-
-  def to_day
-    params.fetch(:to_day, Date.current.day).to_i
-  end
-
-  def to_month
-    params.fetch(:to_month, Date.current.month).to_i
-  end
-
-  def to_year
-    params.fetch(:to_year, Date.current.year).to_i
+    Date.new(year, month, day)
   end
 end

--- a/app/form_objects/report_form.rb
+++ b/app/form_objects/report_form.rb
@@ -6,28 +6,4 @@ class ReportForm
     self.from_date = from_date.to_date
     self.to_date = to_date.to_date
   end
-
-  def from_day
-    from_date.day
-  end
-
-  def from_month
-    from_date.month
-  end
-
-  def from_year
-    from_date.year
-  end
-
-  def to_day
-    to_date.day
-  end
-
-  def to_month
-    to_date.month
-  end
-
-  def to_year
-    to_date.year
-  end
 end

--- a/app/models/defect.rb
+++ b/app/models/defect.rb
@@ -170,10 +170,12 @@ class Defect < ApplicationRecord
     ReferenceNumber.new(sequence_number).to_s
   end
 
-  def set_completion_date
-    return unless priority
-
-    self.target_completion_date = Date.current + priority.days.days
+  def set_completion_date(date = nil)
+    if date
+      self.target_completion_date = date
+    elsif priority
+      self.target_completion_date = Date.current + priority.days.days
+    end
   end
 
   def self.format_status(status)

--- a/app/services/edit_defect.rb
+++ b/app/services/edit_defect.rb
@@ -1,12 +1,14 @@
 class EditDefect
   attr_accessor :defect,
                 :defect_params,
-                :priority_id
+                :priority_id,
+                :target_completion_date
 
   def initialize(defect:, defect_params:, options: {})
     self.defect = defect
     self.defect_params = defect_params
     self.priority_id = options[:priority_id]
+    self.target_completion_date = options.fetch(:target_completion_date, {})
   end
 
   def call
@@ -15,8 +17,21 @@ class EditDefect
     if priority_id.present?
       defect.priority = Priority.find(priority_id)
       defect.set_completion_date
+    else
+      set_target_completion_date
     end
 
     defect
+  end
+
+  private
+
+  def set_target_completion_date
+    date_parts = target_completion_date.values_at(:day, :month, :year)
+    return unless date_parts.all?(&:present?)
+
+    day, month, year = date_parts.map(&:to_i)
+    date = Date.new(year, month, day)
+    defect.set_completion_date(date)
   end
 end

--- a/app/views/shared/defects/_date_fields.html.haml
+++ b/app/views/shared/defects/_date_fields.html.haml
@@ -1,0 +1,13 @@
+.govuk-fieldset
+  .govuk-date-input__item
+    .govuk-form-group
+      = label_tag "#{name}_day", 'Day', class: 'govuk-label govuk-date-input__label'
+      = text_field_tag "#{name}[day]", date&.day, class: 'govuk-input govuk-date-input__input govuk-input--width-2', type: :number, pattern: "[0-9]*"
+  .govuk-date-input__item
+    .govuk-form-group
+      = label_tag "#{name}_month", 'Month', class: 'govuk-label govuk-date-input__label'
+      = text_field_tag "#{name}[month]", date&.month, class: 'govuk-input govuk-date-input__input govuk-input--width-2', type: :number, pattern: "[0-9]*"
+  .govuk-date-input__item
+    .govuk-form-group
+      = label_tag "#{name}_year", 'Year', class: 'govuk-label govuk-date-input__label'
+      = text_field_tag "#{name}[year]", date&.year, class: 'govuk-input govuk-date-input__input govuk-input--width-4', type: :number, pattern: "[0-9]*"

--- a/app/views/staff/communal_defects/edit.html.haml
+++ b/app/views/staff/communal_defects/edit.html.haml
@@ -61,4 +61,8 @@
                 selected: @defect.priority,
                 label_method: ->(obj){ priority_form_label(priority: obj) }
 
+      %p Or, set a different target completion date:
+
+      = render partial: 'shared/defects/date_fields', locals: { name: 'target_completion_date', date: nil }
+
       = f.button :submit, I18n.t('button.update.defect')

--- a/app/views/staff/property_defects/edit.html.haml
+++ b/app/views/staff/property_defects/edit.html.haml
@@ -56,4 +56,8 @@
                 selected: @defect.priority,
                 label_method: ->(obj){ priority_form_label(priority: obj) }
 
+      %p Or, set a different target completion date:
+
+      = render partial: 'shared/defects/date_fields', locals: { name: 'target_completion_date', date: nil }
+
       = f.button :submit, I18n.t('button.update.defect')

--- a/app/views/staff/report/show.html.haml
+++ b/app/views/staff/report/show.html.haml
@@ -12,37 +12,8 @@
       %span.govuk-caption-l= @presenter.date_range
 
     = form_tag report_scheme_path(scheme: @presenter.scheme.id), class: 'date-filter', method: :get do
-      .govuk-form-group.date-form
-        %h2.govuk-heading-m From
-        .govuk-fieldset
-          .govuk-date-input__item
-            .govuk-form-group
-              = label_tag 'from_day', 'Day', class: 'govuk-label govuk-date-input__label'
-              = text_field_tag 'from_day', @report_form.from_day, class: 'govuk-input govuk-date-input__input govuk-input--width-2', type: :number, pattern: "[0-9]*"
-          .govuk-date-input__item
-            .govuk-form-group
-              = label_tag 'from_month', 'Month', class: 'govuk-label govuk-date-input__label'
-              = text_field_tag 'from_month', @report_form.from_month, class: 'govuk-input govuk-date-input__input govuk-input--width-2', type: :number, pattern: "[0-9]*"
-          .govuk-date-input__item
-            .govuk-form-group
-              = label_tag 'from_year', 'Year', class: 'govuk-label govuk-date-input__label'
-              = text_field_tag 'from_year', @report_form.from_year, class: 'govuk-input govuk-date-input__input govuk-input--width-4', type: :number, pattern: "[0-9]*"
-
-      .govuk-form-group.date-form
-        %h2.govuk-heading-m To
-        .govuk-fieldset
-          .govuk-date-input__item
-            .govuk-form-group
-              = label_tag 'to_day', 'Day', class: 'govuk-label govuk-date-input__label'
-              = text_field_tag 'to_day', @report_form.to_day, class: 'govuk-input govuk-date-input__input govuk-input--width-2', type: :number, pattern: "[0-9]*"
-          .govuk-date-input__item
-            .govuk-form-group
-              = label_tag 'to_month', 'Month', class: 'govuk-label govuk-date-input__label'
-              = text_field_tag 'to_month', @report_form.to_month, class: 'govuk-input govuk-date-input__input govuk-input--width-2', type: :number, pattern: "[0-9]*"
-          .govuk-date-input__item
-            .govuk-form-group
-              = label_tag 'to_year', 'Year', class: 'govuk-label govuk-date-input__label'
-              = text_field_tag 'to_year', @report_form.to_year, class: 'govuk-input govuk-date-input__input govuk-input--width-4', type: :number, pattern: "[0-9]*"
+      = render partial: 'shared/defects/date_fields', locals: { name: 'from_date', date: @report_form.from_date }
+      = render partial: 'shared/defects/date_fields', locals: { name: 'to_date', date: @report_form.to_date }
 
       %br
       = submit_tag 'Apply dates', class: 'govuk-button mb0'

--- a/spec/features/staff_can_update_a_communal_defect_spec.rb
+++ b/spec/features/staff_can_update_a_communal_defect_spec.rb
@@ -7,9 +7,9 @@ RSpec.feature 'Anyone can update a communal_area defect' do
 
   let(:scheme) { create(:scheme, :with_priorities) }
   let(:communal_area) { create(:communal_area, scheme: scheme) }
+  let!(:defect) { create(:communal_defect, communal_area: communal_area) }
 
   scenario 'a defect can be updated' do
-    defect = create(:communal_defect, communal_area: communal_area)
     new_priority = create(:priority, scheme: communal_area.scheme, days: 999)
 
     visit communal_area_defect_path(defect.communal_area, defect)
@@ -51,8 +51,6 @@ RSpec.feature 'Anyone can update a communal_area defect' do
   end
 
   scenario 'any defect status can be chosen' do
-    defect = create(:communal_defect, communal_area: communal_area)
-
     visit edit_communal_area_defect_path(defect.communal_area, defect)
 
     expected_statues = %w[outstanding completed closed raised_in_error follow_on end_of_year referral rejected dispute]
@@ -69,8 +67,6 @@ RSpec.feature 'Anyone can update a communal_area defect' do
   end
 
   scenario 'an invalid defect cannot be updated' do
-    defect = create(:communal_defect, communal_area: communal_area)
-
     visit communal_area_defect_path(defect.communal_area, defect)
 
     expect(page).to have_content(I18n.t('page_title.staff.defects.show', reference_number: defect.reference_number))
@@ -93,9 +89,21 @@ RSpec.feature 'Anyone can update a communal_area defect' do
     end
   end
 
-  scenario 'updating the priority is optional' do
-    defect = create(:communal_defect, communal_area: communal_area)
+  scenario 'setting the completion date' do
+    visit edit_communal_area_defect_path(defect.communal_area, defect)
 
+    within('form.edit_defect') do
+      fill_in 'target_completion_date_day', with: '31'
+      fill_in 'target_completion_date_month', with: '7'
+      fill_in 'target_completion_date_year', with: '2020'
+      click_on(I18n.t('button.update.defect'))
+    end
+
+    expect(page).to have_content(I18n.t('generic.notice.update.success', resource: 'defect'))
+    expect(page).to have_content('31 July 2020')
+  end
+
+  scenario 'updating the priority is optional' do
     visit edit_communal_area_defect_path(defect.communal_area, defect)
 
     within('.existing-priority-information') do

--- a/spec/features/staff_can_update_a_property_defect_spec.rb
+++ b/spec/features/staff_can_update_a_property_defect_spec.rb
@@ -7,9 +7,9 @@ RSpec.feature 'Anyone can update a defect' do
 
   let(:scheme) { create(:scheme, :with_priorities) }
   let(:property) { create(:property, scheme: scheme) }
+  let!(:defect) { create(:communal_defect, property: property) }
 
   scenario 'a defect can be updated' do
-    defect = create(:property_defect, property: property)
     new_priority = create(:priority, scheme: property.scheme, days: 999)
 
     visit property_defect_path(defect.property, defect)
@@ -52,8 +52,6 @@ RSpec.feature 'Anyone can update a defect' do
   end
 
   scenario 'a defect status can be updated' do
-    defect = create(:property_defect, property: property)
-
     visit edit_property_defect_path(defect.property, defect)
 
     within('form.edit_defect') do
@@ -87,8 +85,6 @@ RSpec.feature 'Anyone can update a defect' do
   end
 
   scenario 'any defect status can be chosen' do
-    defect = create(:property_defect, property: property)
-
     visit edit_property_defect_path(defect.property, defect)
 
     expected_statues = %w[outstanding completed closed raised_in_error follow_on end_of_year referral rejected dispute]
@@ -105,8 +101,6 @@ RSpec.feature 'Anyone can update a defect' do
   end
 
   scenario 'an invalid defect cannot be updated' do
-    defect = create(:property_defect, property: property)
-
     visit property_defect_path(defect.property, defect)
 
     expect(page).to have_content(I18n.t('page_title.staff.defects.show', reference_number: defect.reference_number))
@@ -129,9 +123,21 @@ RSpec.feature 'Anyone can update a defect' do
     end
   end
 
-  scenario 'updating the priority is optional' do
-    defect = create(:property_defect, property: property)
+  scenario 'setting the completion date' do
+    visit edit_property_defect_path(defect.communal_area, defect)
 
+    within('form.edit_defect') do
+      fill_in 'target_completion_date_day', with: '31'
+      fill_in 'target_completion_date_month', with: '7'
+      fill_in 'target_completion_date_year', with: '2020'
+      click_on(I18n.t('button.update.defect'))
+    end
+
+    expect(page).to have_content(I18n.t('generic.notice.update.success', resource: 'defect'))
+    expect(page).to have_content('31 July 2020')
+  end
+
+  scenario 'updating the priority is optional' do
     visit edit_property_defect_path(defect.property, defect)
 
     within('.existing-priority-information') do

--- a/spec/features/staff_can_view_a_scheme_report_spec.rb
+++ b/spec/features/staff_can_view_a_scheme_report_spec.rb
@@ -159,30 +159,30 @@ RSpec.feature 'Anyone can view a report for a scheme' do
   scenario 'filter defects' do
     travel_to Time.zone.parse('2019-05-25')
 
-    defect_one = create(:property_defect, created_at: Time.utc(2019, 5, 23), property: property)
-    defect_two = create(:property_defect, created_at: Time.utc(2019, 5, 24), property: property)
-    defect_three = create(:communal_defect, created_at: Time.utc(2019, 5, 24), communal_area: communal_area)
-    defect_four = create(:property_defect, created_at: Time.utc(2019, 5, 25), property: property)
-
-    defects = [defect_one, defect_two, defect_three, defect_four]
+    create(:property_defect, created_at: Time.utc(2019, 5, 23), property: property)
+    create(:property_defect, created_at: Time.utc(2019, 5, 24), property: property)
+    create(:communal_defect, created_at: Time.utc(2019, 5, 24), communal_area: communal_area)
+    create(:property_defect, created_at: Time.utc(2019, 5, 25), property: property)
 
     visit report_scheme_path(scheme)
 
     within('.summary') do
-      expect(page).to have_content(defects.count)
+      expect(page).to have_content('Total defects 3 1 4')
     end
 
     within('.date-filter') do
-      fill_in 'from_day', with: '5'
-      fill_in 'from_month', with: '23'
+      fill_in 'from_day', with: '23'
+      fill_in 'from_month', with: '5'
       fill_in 'from_year', with: '2019'
       fill_in 'to_day', with: '24'
       fill_in 'to_month', with: '5'
       fill_in 'to_year', with: '2019'
     end
 
+    click_button 'Apply dates'
+
     within('.summary') do
-      expect(page).to have_content('3')
+      expect(page).to have_content('Total defects 2 1 3')
     end
 
     travel_back

--- a/spec/features/staff_can_view_a_scheme_report_spec.rb
+++ b/spec/features/staff_can_view_a_scheme_report_spec.rb
@@ -171,12 +171,12 @@ RSpec.feature 'Anyone can view a report for a scheme' do
     end
 
     within('.date-filter') do
-      fill_in 'from_day', with: '23'
-      fill_in 'from_month', with: '5'
-      fill_in 'from_year', with: '2019'
-      fill_in 'to_day', with: '24'
-      fill_in 'to_month', with: '5'
-      fill_in 'to_year', with: '2019'
+      fill_in 'from_date[day]', with: '23'
+      fill_in 'from_date[month]', with: '5'
+      fill_in 'from_date[year]', with: '2019'
+      fill_in 'to_date[day]', with: '24'
+      fill_in 'to_date[month]', with: '5'
+      fill_in 'to_date[year]', with: '2019'
     end
 
     click_button 'Apply dates'

--- a/spec/form_objects/report_form_spec.rb
+++ b/spec/form_objects/report_form_spec.rb
@@ -19,46 +19,4 @@ RSpec.describe ReportForm do
       end
     end
   end
-
-  describe '#from_day' do
-    it 'returns the from day' do
-      result = described_class.new(from_date: from_date, to_date: to_date).from_day
-      expect(result).to eql(1)
-    end
-  end
-
-  describe '#from_month' do
-    it 'returns the from month' do
-      result = described_class.new(from_date: from_date, to_date: to_date).from_month
-      expect(result).to eql(1)
-    end
-  end
-
-  describe '#from_year' do
-    it 'returns the from year' do
-      result = described_class.new(from_date: from_date, to_date: to_date).from_year
-      expect(result).to eql(2019)
-    end
-  end
-
-  describe '#to_day' do
-    it 'returns the to day' do
-      result = described_class.new(from_date: from_date, to_date: to_date).to_day
-      expect(result).to eql(1)
-    end
-  end
-
-  describe '#to_month' do
-    it 'returns the to month' do
-      result = described_class.new(from_date: from_date, to_date: to_date).to_month
-      expect(result).to eql(12)
-    end
-  end
-
-  describe '#to_year' do
-    it 'returns the to year' do
-      result = described_class.new(from_date: from_date, to_date: to_date).to_year
-      expect(result).to eql(2019)
-    end
-  end
 end


### PR DESCRIPTION
## Changes in this PR:

This adds the ability to set the target completion date for a defect explicitly, instead of assigning it implicitly by assigning a priority.

## Screenshots of UI changes:

A new set of date fields appear after the priority field:

<img width="416" alt="Screenshot 2019-07-18 at 17 30 08" src="https://user-images.githubusercontent.com/9265/61475075-ee930a80-a981-11e9-8080-9e2aacc0012b.png">

Staff can enter a date here:

<img width="304" alt="Screenshot 2019-07-18 at 17 30 33" src="https://user-images.githubusercontent.com/9265/61475076-ee930a80-a981-11e9-9a98-7b140220abe3.png">

And it will be applied to the defect

<img width="621" alt="Screenshot 2019-07-18 at 17 30 45" src="https://user-images.githubusercontent.com/9265/61475079-ef2ba100-a981-11e9-98eb-392fafa892be.png">

If they enter a priority...

<img width="317" alt="Screenshot 2019-07-18 at 17 30 57" src="https://user-images.githubusercontent.com/9265/61475080-ef2ba100-a981-11e9-810d-f478d8458974.png">

... this continues to set the date as before

<img width="626" alt="Screenshot 2019-07-18 at 17 31 18" src="https://user-images.githubusercontent.com/9265/61475082-ef2ba100-a981-11e9-8649-20350c6aba24.png">