### PR TITLE
[167] Emailing defect information is opt out and can be done manually

### DIFF
--- a/app/controllers/staff/communal_defects_controller.rb
+++ b/app/controllers/staff/communal_defects_controller.rb
@@ -11,20 +11,16 @@ class Staff::CommunalDefectsController < Staff::BaseController
     @defect = BuildDefect.new(defect_params: defect_params, options: options).call
 
     if @defect.valid?
-      SaveCommunalDefect.new(defect: @defect).call
+      SaveCommunalDefect.new(
+        defect: @defect,
+        send_email_to_contractor: send_email_to_contractor,
+        send_email_to_employer_agent: send_email_to_employer_agent
+      ).call
       flash[:success] = I18n.t('generic.notice.create.success', resource: 'defect')
       redirect_to communal_area_path(@communal_area)
     else
       render :new
     end
-  end
-
-  def show
-    @defect = DefectPresenter.new(Defect.find(id))
-  end
-
-  def edit
-    @defect = DefectPresenter.new(Defect.find(id))
   end
 
   def update
@@ -45,6 +41,14 @@ class Staff::CommunalDefectsController < Staff::BaseController
     else
       render :edit
     end
+  end
+
+  def show
+    @defect = DefectPresenter.new(Defect.find(id))
+  end
+
+  def edit
+    @defect = DefectPresenter.new(Defect.find(id))
   end
 
   private
@@ -76,5 +80,13 @@ class Staff::CommunalDefectsController < Staff::BaseController
       :trade,
       :status
     )
+  end
+
+  def send_email_to_contractor
+    params.require(:defect).fetch('send_contractor_email', '1').downcase == '1'
+  end
+
+  def send_email_to_employer_agent
+    params.require(:defect).fetch('send_employer_agent_email', '1').downcase == '1'
   end
 end

--- a/app/controllers/staff/defects/forwarding_controller.rb
+++ b/app/controllers/staff/defects/forwarding_controller.rb
@@ -1,0 +1,21 @@
+class Staff::Defects::ForwardingController < Staff::BaseController
+  include DefectHelper
+
+  def new
+    @defect = Defect.find(id)
+    @other_events = @defect.activities.where(key: 'defect.forwarded_to_contractor')
+  end
+
+  def create
+    defect = Defect.find(id)
+    EmailContractor.new(defect: defect).call
+    redirect_to defect_path_for(defect: defect),
+                flash: { success: I18n.t('page_content.defect.forwarding.success') }
+  end
+
+  private
+
+  def id
+    params[:defect_id]
+  end
+end

--- a/app/controllers/staff/property_defects_controller.rb
+++ b/app/controllers/staff/property_defects_controller.rb
@@ -11,7 +11,11 @@ class Staff::PropertyDefectsController < Staff::BaseController
     @defect = BuildDefect.new(defect_params: defect_params, options: options).call
 
     if @defect.valid?
-      SavePropertyDefect.new(defect: @defect).call
+      SavePropertyDefect.new(
+        defect: @defect,
+        send_email_to_contractor: send_email_to_contractor,
+        send_email_to_employer_agent: send_email_to_employer_agent
+      ).call
       flash[:success] = I18n.t('generic.notice.create.success', resource: 'defect')
       redirect_to property_path(@property)
     else
@@ -75,5 +79,13 @@ class Staff::PropertyDefectsController < Staff::BaseController
       :trade,
       :status
     )
+  end
+
+  def send_email_to_contractor
+    params.require(:defect).fetch('send_contractor_email', '1').downcase == '1'
+  end
+
+  def send_email_to_employer_agent
+    params.require(:defect).fetch('send_employer_agent_email', '1').downcase == '1'
   end
 end

--- a/app/models/defect.rb
+++ b/app/models/defect.rb
@@ -2,6 +2,8 @@ require 'csv'
 
 # rubocop:disable Metrics/ClassLength
 class Defect < ApplicationRecord
+  attr_accessor :send_contractor_email, :send_employer_agent_email
+
   validates :title,
             :description,
             :trade,

--- a/app/services/email_contractor.rb
+++ b/app/services/email_contractor.rb
@@ -1,0 +1,15 @@
+class EmailContractor
+  attr_accessor :defect
+
+  def initialize(defect:)
+    self.defect = defect
+  end
+
+  def call
+    DefectMailer.forward(
+      'contractor',
+      defect.scheme.contractor_email_address,
+      defect.id
+    ).deliver_later
+  end
+end

--- a/app/services/email_employer_agent.rb
+++ b/app/services/email_employer_agent.rb
@@ -1,0 +1,15 @@
+class EmailEmployerAgent
+  attr_accessor :defect
+
+  def initialize(defect:)
+    self.defect = defect
+  end
+
+  def call
+    DefectMailer.forward(
+      'employer_agent',
+      defect.scheme.employer_agent_email_address,
+      defect.id
+    ).deliver_later
+  end
+end

--- a/app/services/save_defect.rb
+++ b/app/services/save_defect.rb
@@ -12,25 +12,7 @@ class SaveDefect
   def call
     defect.save
 
-    send_to_contractor if send_email_to_contractor
-    send_to_employer_agent if send_email_to_employer_agent
-  end
-
-  private
-
-  def send_to_contractor
-    DefectMailer.forward(
-      'contractor',
-      defect.scheme.contractor_email_address,
-      defect.id
-    ).deliver_later
-  end
-
-  def send_to_employer_agent
-    DefectMailer.forward(
-      'employer_agent',
-      defect.scheme.employer_agent_email_address,
-      defect.id
-    ).deliver_later
+    EmailContractor.new(defect: defect).call if send_email_to_contractor
+    EmailEmployerAgent.new(defect: defect).call if send_email_to_employer_agent
   end
 end

--- a/app/services/save_defect.rb
+++ b/app/services/save_defect.rb
@@ -1,15 +1,19 @@
 class SaveDefect
-  attr_accessor :defect
+  attr_accessor :defect,
+                :send_email_to_contractor,
+                :send_email_to_employer_agent
 
-  def initialize(defect:)
+  def initialize(defect:, send_email_to_contractor: true, send_email_to_employer_agent: true)
     self.defect = defect
+    self.send_email_to_contractor = send_email_to_contractor
+    self.send_email_to_employer_agent = send_email_to_employer_agent
   end
 
   def call
     defect.save
 
-    send_to_contractor
-    send_to_employer_agent
+    send_to_contractor if send_email_to_contractor
+    send_to_employer_agent if send_email_to_employer_agent
   end
 
   private

--- a/app/views/staff/communal_defects/new.html.haml
+++ b/app/views/staff/communal_defects/new.html.haml
@@ -49,4 +49,19 @@
                   required: true,
                   selected: @defect.priority,
                   label_method: ->(obj){ priority_form_label(priority: obj) }
+
+        %span.govuk-label.govuk-label
+          %label.required
+            Forwarding
+        = f.input :send_contractor_email,
+                  as: :boolean,
+                  wrapper: :inline_checkbox,
+                  input_html: { checked: @defect.send_contractor_email || true },
+                  wrapper_html: { id: 'send_contractor_email' }
+        = f.input :send_employer_agent_email,
+                  as: :boolean,
+                  wrapper: :inline_checkbox,
+                  input_html: { checked: @defect.send_employer_agent_email || true },
+                  wrapper_html: { id: 'send_employer_agent_email' }
+
       = f.button :submit, I18n.t('button.create.communal_defect')

--- a/app/views/staff/communal_defects/show.html.haml
+++ b/app/views/staff/communal_defects/show.html.haml
@@ -10,7 +10,7 @@
   .govuk-grid-column-one-half
     %h2.govuk-heading-m= @defect.title
     = link_to(I18n.t('button.edit.defect'), edit_communal_area_defect_path(@defect.communal_area, @defect), class: 'govuk-button govuk-button--secondary mb0')
-
+    = link_to(I18n.t('button.forward.contractor'), new_defect_forward_path(@defect), class: 'govuk-button govuk-button--secondary mb0')
 .govuk-grid-row
   .govuk-grid-column-one-half.summary
     = render partial: '/shared/defects/summary_information', locals: { defect: @defect }

--- a/app/views/staff/communal_defects/show.html.haml
+++ b/app/views/staff/communal_defects/show.html.haml
@@ -7,10 +7,12 @@
     %h1.govuk-heading-l
       = I18n.t('page_title.staff.defects.show', reference_number: @defect.reference_number)
 .govuk-grid-row
-  .govuk-grid-column-one-half
+  .govuk-grid-column-full
     %h2.govuk-heading-m= @defect.title
     = link_to(I18n.t('button.edit.defect'), edit_communal_area_defect_path(@defect.communal_area, @defect), class: 'govuk-button govuk-button--secondary mb0')
-    = link_to(I18n.t('button.forward.contractor'), new_defect_forward_path(@defect), class: 'govuk-button govuk-button--secondary mb0')
+    = link_to(I18n.t('button.forward.contractor'), new_defect_forward_path(@defect, recipient_type: :contractor), class: 'govuk-button govuk-button--secondary mb0')
+    = link_to(I18n.t('button.forward.employer_agent'), new_defect_forward_path(@defect, recipient_type: :employer_agent), class: 'govuk-button govuk-button--secondary mb0')
+
 .govuk-grid-row
   .govuk-grid-column-one-half.summary
     = render partial: '/shared/defects/summary_information', locals: { defect: @defect }

--- a/app/views/staff/defects/forwarding/new.html.haml
+++ b/app/views/staff/defects/forwarding/new.html.haml
@@ -6,11 +6,11 @@
       = I18n.t('page_title.staff.defects.forwarding.create')
       %span.govuk-caption-l= 'Step 1 of 1'
 
-    %p.govuk-body= I18n.t('page_content.defect.forwarding.new')
+    %p.govuk-body= I18n.t('page_content.defect.forwarding.new', recipient_type: formatted_recipient_type)
 
     - if @other_events.present?
       = render partial: 'shared/events/list', locals: { events: @other_events }
     - else
-      .govuk-inset-text= I18n.t('page_content.defect.forwarding.unsent')
+      .govuk-inset-text= I18n.t('page_content.defect.forwarding.unsent', recipient_type: formatted_recipient_type)
 
-    = button_to I18n.t('generic.button.send'), defect_forward_path, class: 'govuk-button'
+    = button_to I18n.t('generic.button.send'), defect_forward_path(recipient_type: recipient_type), class: 'govuk-button'

--- a/app/views/staff/defects/forwarding/new.html.haml
+++ b/app/views/staff/defects/forwarding/new.html.haml
@@ -1,0 +1,16 @@
+- content_for :page_title_prefix, I18n.t('page_title.staff.defects.forwarding.create')
+
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    %h1.govuk-heading-xl
+      = I18n.t('page_title.staff.defects.forwarding.create')
+      %span.govuk-caption-l= 'Step 1 of 1'
+
+    %p.govuk-body= I18n.t('page_content.defect.forwarding.new')
+
+    - if @other_events.present?
+      = render partial: 'shared/events/list', locals: { events: @other_events }
+    - else
+      .govuk-inset-text= I18n.t('page_content.defect.forwarding.unsent')
+
+    = button_to I18n.t('generic.button.send'), defect_forward_path, class: 'govuk-button'

--- a/app/views/staff/property_defects/new.html.haml
+++ b/app/views/staff/property_defects/new.html.haml
@@ -44,4 +44,19 @@
                   required: true,
                   selected: @defect.priority,
                   label_method: ->(obj){ priority_form_label(priority: obj) }
+
+        %span.govuk-label.govuk-label
+          %label.required
+            Forwarding
+        = f.input :send_contractor_email,
+                  as: :boolean,
+                  wrapper: :inline_checkbox,
+                  input_html: { checked: @defect.send_contractor_email || true },
+                  wrapper_html: { id: 'send_contractor_email' }
+        = f.input :send_employer_agent_email,
+                  as: :boolean,
+                  wrapper: :inline_checkbox,
+                  input_html: { checked: @defect.send_employer_agent_email || true },
+                  wrapper_html: { id: 'send_employer_agent_email' }
+
       = f.button :submit, I18n.t('button.create.property_defect')

--- a/app/views/staff/property_defects/show.html.haml
+++ b/app/views/staff/property_defects/show.html.haml
@@ -10,6 +10,7 @@
   .govuk-grid-column-one-half
     %h2.govuk-heading-m= @defect.title
     = link_to(I18n.t('button.edit.defect'), edit_property_defect_path(@defect.property, @defect), class: 'govuk-button govuk-button--secondary mb0')
+    = link_to(I18n.t('button.forward.contractor'), new_defect_forward_path(@defect), class: 'govuk-button govuk-button--secondary mb0')
 
 .govuk-grid-row
   .govuk-grid-column-one-half.summary

--- a/app/views/staff/property_defects/show.html.haml
+++ b/app/views/staff/property_defects/show.html.haml
@@ -7,10 +7,11 @@
     %h1.govuk-heading-l
       = I18n.t('page_title.staff.defects.show', reference_number: @defect.reference_number)
 .govuk-grid-row
-  .govuk-grid-column-one-half
+  .govuk-grid-column-full
     %h2.govuk-heading-m= @defect.title
     = link_to(I18n.t('button.edit.defect'), edit_property_defect_path(@defect.property, @defect), class: 'govuk-button govuk-button--secondary mb0')
-    = link_to(I18n.t('button.forward.contractor'), new_defect_forward_path(@defect), class: 'govuk-button govuk-button--secondary mb0')
+    = link_to(I18n.t('button.forward.contractor'), new_defect_forward_path(@defect, recipient_type: :contractor), class: 'govuk-button govuk-button--secondary mb0')
+    = link_to(I18n.t('button.forward.employer_agent'), new_defect_forward_path(@defect, recipient_type: :employer_agent), class: 'govuk-button govuk-button--secondary mb0')
 
 .govuk-grid-row
   .govuk-grid-column-one-half.summary

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -224,7 +224,7 @@ SimpleForm.setup do |config|
     checkbox.use :html5
     checkbox.wrapper class: 'govuk-checkboxes__item' do |field|
       field.use :input, class: 'govuk-checkboxes__input'
-      field.use :label_text, wrap_with: { tag: 'label', class: 'govuk-label govuk-label govuk-checkboxes__label' }
+      field.use :label, wrap_with: { tag: 'span', class: 'govuk-label govuk-label govuk-checkboxes__label' }
     end
 
     checkbox.use :error, wrap_with: { tag: 'div', class: 'help-inline' }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -48,6 +48,8 @@ en:
           communal_area: 'Create communal defect'
         show: 'Defect %{reference_number}'
         edit: 'Update defect'
+        forwarding:
+          create: 'Forward defect'
       comments:
         create: 'Create Comment'
   page_content:
@@ -74,6 +76,10 @@ en:
       communal_area:
         table:
           header: 'Communal defects'
+      forwarding:
+        new: 'Send this defect information to the scheme contractor.'
+        unsent: 'This defect has not been sent to the contractor before.'
+        success: 'Email sent to the contractor'
   error_pages:
     unprocessable_entity: 'Cannot process this request'
   generic:
@@ -86,6 +92,7 @@ en:
       download: 'Download'
       filter: 'Apply filters'
       sign_in: 'Sign in'
+      send: 'Send'
     notice:
       create:
         success:
@@ -113,6 +120,8 @@ en:
     edit:
       scheme: Edit scheme
       defect: Edit defect
+    forward:
+      contractor: 'Forward to contractor'
   form:
     property:
       guidance: 'Find address information (Address, Postcode, UPRN) from %{link}.'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -77,9 +77,9 @@ en:
         table:
           header: 'Communal defects'
       forwarding:
-        new: 'Send this defect information to the scheme contractor.'
-        unsent: 'This defect has not been sent to the contractor before.'
-        success: 'Email sent to the contractor'
+        new: 'Send this defect information to the scheme %{recipient_type}.'
+        unsent: 'This defect has not been sent to the %{recipient_type} before.'
+        success: 'Email sent to the %{recipient_type}'
   error_pages:
     unprocessable_entity: 'Cannot process this request'
   generic:
@@ -122,6 +122,7 @@ en:
       defect: Edit defect
     forward:
       contractor: 'Forward to contractor'
+      employer_agent: 'Forward to employer agent'
   form:
     property:
       guidance: 'Find address information (Address, Postcode, UPRN) from %{link}.'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,9 @@ Rails.application.routes.draw do
   get 'report' => 'staff/report#index'
   get 'report/scheme/:id' => 'staff/report#show', as: :report_scheme
 
-  resources :defects, controller: 'staff/defects'
+  resources :defects, controller: 'staff/defects' do
+    resource :forward, controller: 'staff/defects/forwarding', only: %i[new create]
+  end
 
   resources :properties, controller: 'staff/properties', only: %i[show] do
     resources :defects, controller: 'staff/property_defects', only: %i[new create show edit update]

--- a/spec/features/staff_can_forward_defects_by_email_spec.rb
+++ b/spec/features/staff_can_forward_defects_by_email_spec.rb
@@ -18,15 +18,36 @@ RSpec.feature 'Staff can forward defect information by email' do
 
       click_on(I18n.t('button.forward.contractor'))
 
-      expect(page).to have_content(I18n.t('page_title.staff.defects.forwarding.create'))
-      expect(page).to have_content(I18n.t('page_content.defect.forwarding.new'))
-      expect(page).to have_content(I18n.t('page_content.defect.forwarding.unsent'))
+      expect(page).to have_content(I18n.t('page_title.staff.defects.forwarding.create', recipient_type: 'contractor'))
+      expect(page).to have_content(I18n.t('page_content.defect.forwarding.new', recipient_type: 'contractor'))
+      expect(page).to have_content(I18n.t('page_content.defect.forwarding.unsent', recipient_type: 'contractor'))
 
       expect_any_instance_of(EmailContractor).to receive(:call)
 
       click_on(I18n.t('generic.button.send'))
 
-      expect(page).to have_content(I18n.t('page_content.defect.forwarding.success'))
+      expect(page).to have_content(I18n.t('page_content.defect.forwarding.success', recipient_type: 'contractor'))
+      expect(page).to have_content(I18n.t('page_title.staff.defects.show', reference_number: defect.reference_number))
+    end
+
+    scenario 'a defect can be forwarded to the employer agent' do
+      defect = create(:property_defect, property: property)
+
+      visit property_defect_path(defect.property, defect)
+
+      expect(page).not_to have_content('An email was sent to the employer agent')
+
+      click_on(I18n.t('button.forward.employer_agent'))
+
+      expect(page).to have_content(I18n.t('page_title.staff.defects.forwarding.create', recipient_type: 'employer agent'))
+      expect(page).to have_content(I18n.t('page_content.defect.forwarding.new', recipient_type: 'employer agent'))
+      expect(page).to have_content(I18n.t('page_content.defect.forwarding.unsent', recipient_type: 'employer agent'))
+
+      expect_any_instance_of(EmailEmployerAgent).to receive(:call)
+
+      click_on(I18n.t('generic.button.send'))
+
+      expect(page).to have_content(I18n.t('page_content.defect.forwarding.success', recipient_type: 'employer agent'))
       expect(page).to have_content(I18n.t('page_title.staff.defects.show', reference_number: defect.reference_number))
     end
   end
@@ -42,15 +63,36 @@ RSpec.feature 'Staff can forward defect information by email' do
 
       click_on(I18n.t('button.forward.contractor'))
 
-      expect(page).to have_content(I18n.t('page_title.staff.defects.forwarding.create'))
-      expect(page).to have_content(I18n.t('page_content.defect.forwarding.new'))
-      expect(page).to have_content(I18n.t('page_content.defect.forwarding.unsent'))
+      expect(page).to have_content(I18n.t('page_title.staff.defects.forwarding.create', recipient_type: 'contractor'))
+      expect(page).to have_content(I18n.t('page_content.defect.forwarding.new', recipient_type: 'contractor'))
+      expect(page).to have_content(I18n.t('page_content.defect.forwarding.unsent', recipient_type: 'contractor'))
 
       expect_any_instance_of(EmailContractor).to receive(:call)
 
       click_on(I18n.t('generic.button.send'))
 
-      expect(page).to have_content(I18n.t('page_content.defect.forwarding.success'))
+      expect(page).to have_content(I18n.t('page_content.defect.forwarding.success', recipient_type: 'contractor'))
+      expect(page).to have_content(I18n.t('page_title.staff.defects.show', reference_number: defect.reference_number))
+    end
+
+    scenario 'a defect can be forwarded to the employer agent' do
+      defect = create(:communal_defect, communal_area: communal_area)
+
+      visit communal_area_defect_path(defect.communal_area, defect)
+
+      expect(page).not_to have_content('An email was sent to the employer agent')
+
+      click_on(I18n.t('button.forward.employer_agent'))
+
+      expect(page).to have_content(I18n.t('page_title.staff.defects.forwarding.create', recipient_type: 'employer agent'))
+      expect(page).to have_content(I18n.t('page_content.defect.forwarding.new', recipient_type: 'employer agent'))
+      expect(page).to have_content(I18n.t('page_content.defect.forwarding.unsent', recipient_type: 'employer agent'))
+
+      expect_any_instance_of(EmailEmployerAgent).to receive(:call)
+
+      click_on(I18n.t('generic.button.send'))
+
+      expect(page).to have_content(I18n.t('page_content.defect.forwarding.success', recipient_type: 'employer agent'))
       expect(page).to have_content(I18n.t('page_title.staff.defects.show', reference_number: defect.reference_number))
     end
   end

--- a/spec/features/staff_can_forward_defects_by_email_spec.rb
+++ b/spec/features/staff_can_forward_defects_by_email_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+RSpec.feature 'Staff can forward defect information by email' do
+  before(:each) do
+    stub_authenticated_session
+  end
+
+  let(:scheme) { create(:scheme, :with_priorities) }
+
+  context 'when the defect is a property defect' do
+    let(:property) { create(:property, scheme: scheme) }
+    scenario 'a defect can be forwarded to the contractor' do
+      defect = create(:property_defect, property: property)
+
+      visit property_defect_path(defect.property, defect)
+
+      expect(page).not_to have_content('An email was sent to the contractor')
+
+      click_on(I18n.t('button.forward.contractor'))
+
+      expect(page).to have_content(I18n.t('page_title.staff.defects.forwarding.create'))
+      expect(page).to have_content(I18n.t('page_content.defect.forwarding.new'))
+      expect(page).to have_content(I18n.t('page_content.defect.forwarding.unsent'))
+
+      expect_any_instance_of(EmailContractor).to receive(:call)
+
+      click_on(I18n.t('generic.button.send'))
+
+      expect(page).to have_content(I18n.t('page_content.defect.forwarding.success'))
+      expect(page).to have_content(I18n.t('page_title.staff.defects.show', reference_number: defect.reference_number))
+    end
+  end
+
+  context 'when the defect is a communal defect' do
+    let(:communal_area) { create(:communal_area, scheme: scheme) }
+    scenario 'a defect can be forwarded to the contractor' do
+      defect = create(:communal_defect, communal_area: communal_area)
+
+      visit communal_area_defect_path(defect.communal_area, defect)
+
+      expect(page).not_to have_content('An email was sent to the contractor')
+
+      click_on(I18n.t('button.forward.contractor'))
+
+      expect(page).to have_content(I18n.t('page_title.staff.defects.forwarding.create'))
+      expect(page).to have_content(I18n.t('page_content.defect.forwarding.new'))
+      expect(page).to have_content(I18n.t('page_content.defect.forwarding.unsent'))
+
+      expect_any_instance_of(EmailContractor).to receive(:call)
+
+      click_on(I18n.t('generic.button.send'))
+
+      expect(page).to have_content(I18n.t('page_content.defect.forwarding.success'))
+      expect(page).to have_content(I18n.t('page_title.staff.defects.show', reference_number: defect.reference_number))
+    end
+  end
+end

--- a/spec/requests/defect_creation_sends_emails_spec.rb
+++ b/spec/requests/defect_creation_sends_emails_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe 'Defect creation', type: :request do
+  before(:each) do
+    ActionMailer::Base.delivery_method = :test
+    ActionMailer::Base.perform_deliveries = true
+    ActionMailer::Base.deliveries = []
+  end
+
+  after(:each) do
+    ActionMailer::Base.deliveries.clear
+  end
+
+  let(:property) { create(:property) }
+
+  it 'forwards the email to the contractor and employer agent' do
+    allow_any_instance_of(Secured)
+      .to receive(:logged_in_using_omniauth?)
+      .and_return(true)
+
+    defect_attributes = build(:property_defect).attributes
+    defect_attributes.merge!(priority: create(:priority).id)
+    params = {
+      defect: defect_attributes,
+    }
+
+    contractor_message_delivery = instance_double(ActionMailer::MessageDelivery)
+    expect(DefectMailer).to receive(:forward)
+      .with('contractor', property.scheme.contractor_email_address, anything)
+      .and_return(contractor_message_delivery)
+    expect(contractor_message_delivery).to receive(:deliver_later)
+
+    employer_agent_message_delivery = instance_double(ActionMailer::MessageDelivery)
+    expect(DefectMailer).to receive(:forward)
+      .with('employer_agent', property.scheme.employer_agent_email_address, anything)
+      .and_return(employer_agent_message_delivery)
+    expect(employer_agent_message_delivery).to receive(:deliver_later)
+
+    post property_defects_path(property), params: params
+  end
+end

--- a/spec/requests/defect_creation_sends_emails_spec.rb
+++ b/spec/requests/defect_creation_sends_emails_spec.rb
@@ -5,37 +5,69 @@ RSpec.describe 'Defect creation', type: :request do
     ActionMailer::Base.delivery_method = :test
     ActionMailer::Base.perform_deliveries = true
     ActionMailer::Base.deliveries = []
+
+    allow_any_instance_of(Secured)
+      .to receive(:logged_in_using_omniauth?)
+      .and_return(true)
   end
 
   after(:each) do
     ActionMailer::Base.deliveries.clear
   end
 
-  let(:property) { create(:property) }
+  context 'when the defect is for a property' do
+    let(:property) { create(:property) }
 
-  it 'forwards the email to the contractor and employer agent' do
-    allow_any_instance_of(Secured)
-      .to receive(:logged_in_using_omniauth?)
-      .and_return(true)
+    it 'forwards the email to the contractor and employer agent' do
+      defect_attributes = build(:property_defect).attributes
+      defect_attributes.merge!(priority: create(:priority).id)
+      params = {
+        defect: defect_attributes,
+        send_email_to_contractor: 'true',
+        send_email_to_employer_agent: 'true',
+      }
 
-    defect_attributes = build(:property_defect).attributes
-    defect_attributes.merge!(priority: create(:priority).id)
-    params = {
-      defect: defect_attributes,
-    }
+      contractor_message_delivery = instance_double(ActionMailer::MessageDelivery)
+      expect(DefectMailer).to receive(:forward)
+        .with('contractor', property.scheme.contractor_email_address, anything)
+        .and_return(contractor_message_delivery)
+      expect(contractor_message_delivery).to receive(:deliver_later)
 
-    contractor_message_delivery = instance_double(ActionMailer::MessageDelivery)
-    expect(DefectMailer).to receive(:forward)
-      .with('contractor', property.scheme.contractor_email_address, anything)
-      .and_return(contractor_message_delivery)
-    expect(contractor_message_delivery).to receive(:deliver_later)
+      employer_agent_message_delivery = instance_double(ActionMailer::MessageDelivery)
+      expect(DefectMailer).to receive(:forward)
+        .with('employer_agent', property.scheme.employer_agent_email_address, anything)
+        .and_return(employer_agent_message_delivery)
+      expect(employer_agent_message_delivery).to receive(:deliver_later)
 
-    employer_agent_message_delivery = instance_double(ActionMailer::MessageDelivery)
-    expect(DefectMailer).to receive(:forward)
-      .with('employer_agent', property.scheme.employer_agent_email_address, anything)
-      .and_return(employer_agent_message_delivery)
-    expect(employer_agent_message_delivery).to receive(:deliver_later)
+      post property_defects_path(property), params: params
+    end
+  end
 
-    post property_defects_path(property), params: params
+  context 'when the defect is for a communal_area' do
+    let(:communal_area) { create(:communal_area) }
+
+    it 'forwards the email to the contractor and employer agent' do
+      defect_attributes = build(:communal_defect).attributes
+      defect_attributes.merge!(priority: create(:priority).id)
+      params = {
+        defect: defect_attributes,
+        send_email_to_contractor: 'true',
+        send_email_to_employer_agent: 'true',
+      }
+
+      contractor_message_delivery = instance_double(ActionMailer::MessageDelivery)
+      expect(DefectMailer).to receive(:forward)
+        .with('contractor', communal_area.scheme.contractor_email_address, anything)
+        .and_return(contractor_message_delivery)
+      expect(contractor_message_delivery).to receive(:deliver_later)
+
+      employer_agent_message_delivery = instance_double(ActionMailer::MessageDelivery)
+      expect(DefectMailer).to receive(:forward)
+        .with('employer_agent', communal_area.scheme.employer_agent_email_address, anything)
+        .and_return(employer_agent_message_delivery)
+      expect(employer_agent_message_delivery).to receive(:deliver_later)
+
+      post communal_area_defects_path(communal_area), params: params
+    end
   end
 end

--- a/spec/services/email_contractor_spec.rb
+++ b/spec/services/email_contractor_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe EmailContractor do
+  let(:defect) { create(:property_defect) }
+
+  describe '#call' do
+    it 'emails the contractor' do
+      contractor_message_delivery = instance_double(ActionMailer::MessageDelivery)
+      expect(DefectMailer).to receive(:forward)
+        .with('contractor', defect.scheme.contractor_email_address, defect.id)
+        .and_return(contractor_message_delivery)
+      expect(contractor_message_delivery).to receive(:deliver_later)
+
+      described_class.new(defect: defect).call
+    end
+  end
+end

--- a/spec/services/email_employer_agent_spec.rb
+++ b/spec/services/email_employer_agent_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe EmailEmployerAgent do
+  let(:defect) { create(:property_defect) }
+
+  describe '#call' do
+    it 'emails the employer agent' do
+      employer_agent_message_delivery = instance_double(ActionMailer::MessageDelivery)
+      expect(DefectMailer).to receive(:forward)
+        .with('employer_agent', defect.scheme.employer_agent_email_address, defect.id)
+        .and_return(employer_agent_message_delivery)
+      expect(employer_agent_message_delivery).to receive(:deliver_later)
+
+      described_class.new(defect: defect).call
+    end
+  end
+end

--- a/spec/services/save_defect_spec.rb
+++ b/spec/services/save_defect_spec.rb
@@ -30,35 +30,27 @@ RSpec.describe SaveDefect do
     end
 
     it 'sends the email asynchronously by default' do
-      contractor_message_delivery = instance_double(ActionMailer::MessageDelivery)
-      expect(DefectMailer).to receive(:forward)
-        .with('contractor', defect.scheme.contractor_email_address, defect.id)
-        .and_return(contractor_message_delivery)
-      expect(contractor_message_delivery).to receive(:deliver_later)
+      email_contractor_double = double(EmailContractor)
+      expect(EmailContractor).to receive(:new).with(defect: defect).and_return(email_contractor_double)
+      expect(email_contractor_double).to receive(:call)
 
-      employer_agent_message_delivery = instance_double(ActionMailer::MessageDelivery)
-      expect(DefectMailer).to receive(:forward)
-        .with('employer_agent', defect.scheme.employer_agent_email_address, defect.id)
-        .and_return(employer_agent_message_delivery)
-      expect(employer_agent_message_delivery).to receive(:deliver_later)
+      email_contractor_double = double(EmailEmployerAgent)
+      expect(EmailEmployerAgent).to receive(:new).with(defect: defect).and_return(email_contractor_double)
+      expect(email_contractor_double).to receive(:call)
 
       described_class.new(defect: defect).call
     end
 
     context 'when send_email_to_contractor is false' do
       it 'does not send the contractor email' do
-        expect(DefectMailer).not_to receive(:forward)
-          .with('contractor', defect.scheme.contractor_email_address, defect.id)
-
+        expect_any_instance_of(EmailContractor).not_to receive(:call)
         described_class.new(defect: defect, send_email_to_contractor: false, send_email_to_employer_agent: false).call
       end
     end
 
     context 'when send_email_to_employer_agent is false' do
       it 'does not send the employer agent email' do
-        expect(DefectMailer).not_to receive(:forward)
-          .with('employer_agent', defect.scheme.employer_agent_email_address, defect.id)
-
+        expect_any_instance_of(EmailEmployerAgent).not_to receive(:call)
         described_class.new(defect: defect, send_email_to_contractor: false, send_email_to_employer_agent: false).call
       end
     end

--- a/spec/services/save_defect_spec.rb
+++ b/spec/services/save_defect_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe SaveDefect do
       described_class.new(defect: defect).call
     end
 
-    it 'sends the email asynchronously' do
+    it 'sends the email asynchronously by default' do
       contractor_message_delivery = instance_double(ActionMailer::MessageDelivery)
       expect(DefectMailer).to receive(:forward)
         .with('contractor', defect.scheme.contractor_email_address, defect.id)
@@ -43,6 +43,24 @@ RSpec.describe SaveDefect do
       expect(employer_agent_message_delivery).to receive(:deliver_later)
 
       described_class.new(defect: defect).call
+    end
+
+    context 'when send_email_to_contractor is false' do
+      it 'does not send the contractor email' do
+        expect(DefectMailer).not_to receive(:forward)
+          .with('contractor', defect.scheme.contractor_email_address, defect.id)
+
+        described_class.new(defect: defect, send_email_to_contractor: false, send_email_to_employer_agent: false).call
+      end
+    end
+
+    context 'when send_email_to_employer_agent is false' do
+      it 'does not send the employer agent email' do
+        expect(DefectMailer).not_to receive(:forward)
+          .with('employer_agent', defect.scheme.employer_agent_email_address, defect.id)
+
+        described_class.new(defect: defect, send_email_to_contractor: false, send_email_to_employer_agent: false).call
+      end
     end
   end
 end


### PR DESCRIPTION
## Changes in this PR:
* When creating a defect (not updating) the user can now opt out of sending emails straight to contractors and/or employer agents
* There is a small form for the act of forwarding to enable us to present any past emails that were sent, just incase the same content in the event log was missed. We hope this will avoid spamming of the contractor which may cause them to eventually ignore our emails
* Adding extra fields to the Defect model to facilitate this change to the create form felt icky since it is not data we plan to store in the database. Our use of models to construct forms starts to fall away with more complex business logic like this. I attempted to refactor the existing form and fell down a rabbit hole, deciding it was best to avoid this again with 3 days to go. I also noted that James is also adding a new change to the create and edit form around target completion date, any refactoring at this point could cause a messy delay
* Refactoring the class responsible for sending emails so that it can be reused for this function

## Screenshots of UI changes:

![Screenshot 2019-07-18 at 18 05 48](https://user-images.githubusercontent.com/912473/61477303-d5408d00-a986-11e9-9d35-1aa0628153ad.png)
![Screenshot 2019-07-18 at 18 05 55](https://user-images.githubusercontent.com/912473/61477305-d5408d00-a986-11e9-863c-48962c4d244d.png)
![Screenshot 2019-07-18 at 18 05 58](https://user-images.githubusercontent.com/912473/61477306-d5d92380-a986-11e9-8c2e-6702134b6273.png)
![Screenshot 2019-07-18 at 18 06 01](https://user-images.githubusercontent.com/912473/61477308-d5d92380-a986-11e9-90e3-82fb693d2ead.png)
![Screenshot 2019-07-18 at 18 06 05](https://user-images.githubusercontent.com/912473/61477310-d5d92380-a986-11e9-978c-86c32cdbccac.png)
