### PR TITLE
Feature/102 send a text message to contact on sending to the contractor

### DIFF
--- a/app/jobs/notify_defect_sent_to_contractor_job.rb
+++ b/app/jobs/notify_defect_sent_to_contractor_job.rb
@@ -5,6 +5,8 @@ class NotifyDefectSentToContractorJob < ApplicationJob
 
   def perform(defect_id)
     defect = Defect.find(defect_id)
+    return if defect.contact_phone_number.blank?
+
     client.send_sms(
       phone_number: defect.contact_phone_number,
       template_id: Figaro.env.NOTIFY_DEFECT_SENT_TO_CONTRACTOR_TEMPLATE,

--- a/app/jobs/notify_defect_sent_to_contractor_job.rb
+++ b/app/jobs/notify_defect_sent_to_contractor_job.rb
@@ -1,0 +1,26 @@
+require 'notifications/client'
+
+class NotifyDefectSentToContractorJob < ApplicationJob
+  queue_as :default
+
+  def perform(defect_id)
+    defect = Defect.find(defect_id)
+    client.send_sms(
+      phone_number: defect.contact_phone_number,
+      template_id: Figaro.env.NOTIFY_DEFECT_SENT_TO_CONTRACTOR_TEMPLATE,
+      personalisation: {
+        short_title: defect.title,
+        reference_number: defect.reference_number,
+        contractor_name: defect.scheme.contractor_name,
+        scheme_name: defect.scheme.name,
+      }
+    )
+    defect.create_activity key: 'defect.notification.contact.sent_to_contractor', owner: nil
+  end
+
+  private
+
+  def client
+    @client ||= Notifications::Client.new(Figaro.env.NOTIFY_KEY)
+  end
+end

--- a/app/models/defect.rb
+++ b/app/models/defect.rb
@@ -189,7 +189,7 @@ class Defect < ApplicationRecord
   end
 
   def contact_phone_number=(value)
-    super(value.tr(' ', ''))
+    super(value&.tr(' ', ''))
   end
 
   def token

--- a/app/presenters/defect_event_presenter.rb
+++ b/app/presenters/defect_event_presenter.rb
@@ -3,7 +3,7 @@ class DefectEventPresenter
     @event = event
   end
 
-  def description
+  def description # rubocop:disable Metrics/CyclomaticComplexity
     case @event.key
     when 'defect.create' then
       description_for_create
@@ -15,6 +15,8 @@ class DefectEventPresenter
       description_for_forwarded_to_employer_agent
     when 'defect.accepted' then
       description_for_accepted
+    when 'defect.notification.contact.sent_to_contractor' then
+      description_for_sent_on_to_contact
     else
       @event.key
     end
@@ -57,6 +59,13 @@ class DefectEventPresenter
     I18n.t(
       'events.defect.accepted',
       email: @event.trackable.scheme.contractor_email_address
+    )
+  end
+
+  def description_for_sent_on_to_contact
+    I18n.t(
+      'events.defect.notification.contact.sent_to_contractor',
+      phone_number: @event.trackable.contact_phone_number
     )
   end
 

--- a/app/services/email_contractor.rb
+++ b/app/services/email_contractor.rb
@@ -11,5 +11,7 @@ class EmailContractor
       defect.scheme.contractor_email_address,
       defect.id
     ).deliver_later
+
+    NotifyDefectSentToContractorJob.perform_later(defect.id)
   end
 end

--- a/app/views/staff/communal_defects/edit.html.haml
+++ b/app/views/staff/communal_defects/edit.html.haml
@@ -27,7 +27,8 @@
                   input_html: { rows: 5 }
         = f.input :contact_name
         = f.input :contact_email_address
-        = f.input :contact_phone_number
+        = f.input :contact_phone_number,
+                  hint: I18n.t('form.defect.contact_phone_number.hint')
         = f.input :trade,
                   wrapper: 'select',
                   input_html: { class: 'trades' },

--- a/app/views/staff/communal_defects/new.html.haml
+++ b/app/views/staff/communal_defects/new.html.haml
@@ -25,7 +25,8 @@
           input_html: { rows: 5 }
         = f.input :contact_name
         = f.input :contact_email_address
-        = f.input :contact_phone_number
+        = f.input :contact_phone_number,
+                  hint: I18n.t('form.defect.contact_phone_number.hint')
         = f.input :trade,
                   wrapper: 'select',
                   input_html: { class: 'trades' },

--- a/app/views/staff/defects/forwarding/new.html.haml
+++ b/app/views/staff/defects/forwarding/new.html.haml
@@ -6,7 +6,7 @@
       = I18n.t('page_title.staff.defects.forwarding.create')
       %span.govuk-caption-l= 'Step 1 of 1'
 
-    %p.govuk-body= I18n.t('page_content.defect.forwarding.new', recipient_type: formatted_recipient_type)
+    %p.govuk-body= I18n.t("page_content.defect.forwarding.new.#{formatted_recipient_type}")
 
     - if @other_events.present?
       = render partial: 'shared/events/list', locals: { events: @other_events }

--- a/app/views/staff/property_defects/edit.html.haml
+++ b/app/views/staff/property_defects/edit.html.haml
@@ -22,7 +22,8 @@
                   required: true
         = f.input :contact_name
         = f.input :contact_email_address
-        = f.input :contact_phone_number
+        = f.input :contact_phone_number,
+                  hint: I18n.t('form.defect.contact_phone_number.hint')
         = f.input :trade,
                   wrapper: 'select',
                   input_html: { class: 'trades' },

--- a/app/views/staff/property_defects/new.html.haml
+++ b/app/views/staff/property_defects/new.html.haml
@@ -20,7 +20,8 @@
                   required: true
         = f.input :contact_name
         = f.input :contact_email_address
-        = f.input :contact_phone_number
+        = f.input :contact_phone_number,
+            hint: I18n.t('form.defect.contact_phone_number.hint')
         = f.input :trade,
                   wrapper: 'select',
                   input_html: { class: 'trades' },

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -181,6 +181,9 @@ en:
       forwarded_to_contractor: 'An email was sent to the contractor (%{email})'
       forwarded_to_employer_agent: 'An email was sent to the employer agent (%{email})'
       accepted: 'Defect was accepted by %{email}'
+      notification:
+        contact:
+          sent_to_contractor: 'An SMS was sent to the contact explaining that this is now waiting on the contractor (%{phone_number})'
   activerecord:
     attributes:
       property:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -77,7 +77,9 @@ en:
         table:
           header: 'Communal defects'
       forwarding:
-        new: 'Send this defect information to the scheme %{recipient_type}.'
+        new:
+          contractor: 'Send this defect information to the scheme contractor, this will also notify the contact phone number that this defect is waiting on the contractor.'
+          employer_agent: 'Send this defect information to the scheme employer agent.'
         unsent: 'This defect has not been sent to the %{recipient_type} before.'
         success: 'Email sent to the %{recipient_type}'
   error_pages:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -144,6 +144,8 @@ en:
         description: 'This will be how this defect is described to residents in status notifications'
       access_information:
         description: 'Help the contractor gain access to this communal area'
+      contact_phone_number:
+        hint: 'This number will be used to send updates to by text message'
     priority:
       code:
         label: 'Priority code'

--- a/spec/features/staff_can_forward_defects_by_email_spec.rb
+++ b/spec/features/staff_can_forward_defects_by_email_spec.rb
@@ -19,7 +19,7 @@ RSpec.feature 'Staff can forward defect information by email' do
       click_on(I18n.t('button.forward.contractor'))
 
       expect(page).to have_content(I18n.t('page_title.staff.defects.forwarding.create', recipient_type: 'contractor'))
-      expect(page).to have_content(I18n.t('page_content.defect.forwarding.new', recipient_type: 'contractor'))
+      expect(page).to have_content(I18n.t('page_content.defect.forwarding.new.contractor'))
       expect(page).to have_content(I18n.t('page_content.defect.forwarding.unsent', recipient_type: 'contractor'))
 
       expect_any_instance_of(EmailContractor).to receive(:call)
@@ -40,7 +40,7 @@ RSpec.feature 'Staff can forward defect information by email' do
       click_on(I18n.t('button.forward.employer_agent'))
 
       expect(page).to have_content(I18n.t('page_title.staff.defects.forwarding.create', recipient_type: 'employer agent'))
-      expect(page).to have_content(I18n.t('page_content.defect.forwarding.new', recipient_type: 'employer agent'))
+      expect(page).to have_content(I18n.t('page_content.defect.forwarding.new.employer agent'))
       expect(page).to have_content(I18n.t('page_content.defect.forwarding.unsent', recipient_type: 'employer agent'))
 
       expect_any_instance_of(EmailEmployerAgent).to receive(:call)
@@ -64,7 +64,7 @@ RSpec.feature 'Staff can forward defect information by email' do
       click_on(I18n.t('button.forward.contractor'))
 
       expect(page).to have_content(I18n.t('page_title.staff.defects.forwarding.create', recipient_type: 'contractor'))
-      expect(page).to have_content(I18n.t('page_content.defect.forwarding.new', recipient_type: 'contractor'))
+      expect(page).to have_content(I18n.t('page_content.defect.forwarding.new.contractor'))
       expect(page).to have_content(I18n.t('page_content.defect.forwarding.unsent', recipient_type: 'contractor'))
 
       expect_any_instance_of(EmailContractor).to receive(:call)
@@ -85,7 +85,7 @@ RSpec.feature 'Staff can forward defect information by email' do
       click_on(I18n.t('button.forward.employer_agent'))
 
       expect(page).to have_content(I18n.t('page_title.staff.defects.forwarding.create', recipient_type: 'employer agent'))
-      expect(page).to have_content(I18n.t('page_content.defect.forwarding.new', recipient_type: 'employer agent'))
+      expect(page).to have_content(I18n.t('page_content.defect.forwarding.new.employer agent'))
       expect(page).to have_content(I18n.t('page_content.defect.forwarding.unsent', recipient_type: 'employer agent'))
 
       expect_any_instance_of(EmailEmployerAgent).to receive(:call)
@@ -95,5 +95,16 @@ RSpec.feature 'Staff can forward defect information by email' do
       expect(page).to have_content(I18n.t('page_content.defect.forwarding.success', recipient_type: 'employer agent'))
       expect(page).to have_content(I18n.t('page_title.staff.defects.show', reference_number: defect.reference_number))
     end
+  end
+
+  scenario 'forwarding to a contractor' do
+    communal_area = create(:communal_area, scheme: scheme)
+    defect = create(:communal_defect, communal_area: communal_area)
+
+    visit communal_area_defect_path(defect.communal_area, defect)
+
+    click_on(I18n.t('button.forward.contractor'))
+
+    expect(page).to have_content(I18n.t('page_content.defect.forwarding.new.contractor'))
   end
 end

--- a/spec/helpers/defect_helper_spec.rb
+++ b/spec/helpers/defect_helper_spec.rb
@@ -134,6 +134,15 @@ RSpec.describe DefectHelper, type: :helper do
                                      email: event.trackable.scheme.contractor_email_address))
       end
     end
+
+    context 'when the key is defect.notification.contact.sent_to_contractor' do
+      it 'returns the event description' do
+        event = PublicActivity::Activity.new(trackable: defect, owner: user, key: 'defect.notification.contact.sent_to_contractor')
+        result = helper.event_description_for(event: event)
+        expect(result).to eql(I18n.t('events.defect.notification.contact.sent_to_contractor',
+                                     phone_number: event.trackable.contact_phone_number))
+      end
+    end
   end
 
   describe '#format_status' do

--- a/spec/jobs/notify_defect_sent_to_contractor_job_spec.rb
+++ b/spec/jobs/notify_defect_sent_to_contractor_job_spec.rb
@@ -55,5 +55,18 @@ RSpec.describe NotifyDefectSentToContractorJob, type: :job do
       described_class.perform_now(defect.id)
       expect(PublicActivity::Activity.where(key: 'defect.notification.contact.sent_to_contractor').count).to eq(1)
     end
+
+    context 'when the defect does not have a contact_phone_number' do
+      let(:defect) { create(:property_defect, contact_phone_number: nil) }
+      it 'does not enqueue a job' do
+        expect_any_instance_of(Notifications::Client).not_to receive(:send_sms)
+        described_class.perform_now(defect.id)
+      end
+
+      it 'does not create an activity event' do
+        described_class.perform_now(defect.id)
+        expect(PublicActivity::Activity.where(key: 'defect.notification.contact.sent_to_contractor').count).to eq(0)
+      end
+    end
   end
 end

--- a/spec/jobs/notify_defect_sent_to_contractor_job_spec.rb
+++ b/spec/jobs/notify_defect_sent_to_contractor_job_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+RSpec.describe NotifyDefectSentToContractorJob, type: :job do
+  let(:fake_notify_key) { '123-456-789' }
+  let(:fake_notify_template) { 'asd87f9-hgf8-gdf8-vd8os-asdf879asdo' }
+  let(:defect) { create(:property_defect, contact_phone_number: '07123456789') }
+  let(:sent_message_double) { double(:sent_message, content: { body: 'Lorem ipsum' }) }
+
+  before(:each) do
+    fake_env = double.as_null_object
+    allow(Figaro).to receive(:env).and_return(fake_env)
+    allow(fake_env).to receive(:NOTIFY_KEY).and_return(fake_notify_key)
+    allow(fake_env).to receive(:NOTIFY_DEFECT_SENT_TO_CONTRACTOR_TEMPLATE).and_return(fake_notify_template)
+  end
+
+  describe '#perform_later' do
+    it 'enqueues a job asynchronously on the default queue' do
+      ActiveJob::Base.queue_adapter = :test
+
+      expect do
+        described_class.perform_later(defect.id)
+      end.to have_enqueued_job.with(defect.id).on_queue('default')
+    end
+
+    it 'asks GOV.UK Notify to send an SMS' do
+      notify_client = double(Notifications::Client, send_sms: sent_message_double)
+      expect(Notifications::Client)
+        .to receive(:new)
+        .with(fake_notify_key)
+        .and_return(notify_client)
+
+      expect(notify_client)
+        .to receive(:send_sms)
+        .with(
+          personalisation: {
+            contractor_name: defect.scheme.contractor_name,
+            reference_number: defect.reference_number,
+            scheme_name: defect.scheme.name,
+            short_title: defect.title,
+          },
+          phone_number: defect.contact_phone_number,
+          template_id: fake_notify_template
+        )
+
+      described_class.perform_now(defect.id)
+    end
+
+    it 'stores an activity event' do
+      notify_client = double(Notifications::Client, send_sms: sent_message_double)
+      expect(Notifications::Client)
+        .to receive(:new)
+        .with(fake_notify_key)
+        .and_return(notify_client)
+
+      described_class.perform_now(defect.id)
+      expect(PublicActivity::Activity.where(key: 'defect.notification.contact.sent_to_contractor').count).to eq(1)
+    end
+  end
+end

--- a/spec/models/defect_spec.rb
+++ b/spec/models/defect_spec.rb
@@ -289,4 +289,20 @@ RSpec.describe Defect, type: :model do
       end
     end
   end
+
+  describe '.contact_phone_number=' do
+    it 'strips whitespace' do
+      defect = described_class.new
+      defect.contact_phone_number = '123 456'
+      expect(defect.contact_phone_number).to eq('123456')
+    end
+
+    context 'when there is no value' do
+      it 'returns nil' do
+        defect = described_class.new
+        defect.contact_phone_number = nil
+        expect(defect.contact_phone_number).to eq(nil)
+      end
+    end
+  end
 end

--- a/spec/services/email_contractor_spec.rb
+++ b/spec/services/email_contractor_spec.rb
@@ -13,5 +13,10 @@ RSpec.describe EmailContractor do
 
       described_class.new(defect: defect).call
     end
+
+    it 'sends an SMS to the contact phone number' do
+      expect(NotifyDefectSentToContractorJob).to receive(:perform_later).with(defect.id)
+      described_class.new(defect: defect).call
+    end
   end
 end


### PR DESCRIPTION
## Changes in this PR:
- whenever the contractor is emailed either automatically during creation or manually afterwards, an SMS is sent to the `contact_phone_number` if one is set on the Defect
- user expectations are set when adding or editing this information that it will now be used to send notifications
- when forwarding to contractors manually, the user is informed again that this will send another SMS to the contact 
- the wording of the text message is tricky since it can be sent one or multiple times with the new button which could be used to 'nudge' the contractor (although we have not observed this behaviour yet). Since it is not able to communicate the contractors acceptance or rejection of a defect, at this point it has to be an open message saying that it is with the contractor and if it's approved expect them to be in touch. In future this may be more clear when SMS are sent when a defect is accepted or rejected

## Screenshots of UI changes:

When you create a defect with no number (or in this case not a valid test number)
![Screenshot 2019-07-22 at 13 06 15](https://user-images.githubusercontent.com/912473/61631577-a413d580-ac82-11e9-9ae0-91b82557cd35.png)

No SMS is sent to the contact

![Screenshot 2019-07-22 at 13 06 43](https://user-images.githubusercontent.com/912473/61631604-b5f57880-ac82-11e9-8036-dd9c5b93422a.png)


![Screenshot 2019-07-22 at 13 06 59](https://user-images.githubusercontent.com/912473/61631623-c0b00d80-ac82-11e9-8126-d128ee3875b4.png)

When a defect is edited to have a valid number, forwarding to the contractor will now send the SMS to contact phone number
![Screenshot 2019-07-22 at 13 07 04](https://user-images.githubusercontent.com/912473/61631666-dfae9f80-ac82-11e9-9749-a470a4ce2cc2.png)

![Image from iOS](https://user-images.githubusercontent.com/912473/61631754-1389c500-ac83-11e9-9fdd-0f0cec0564ee.png)
