### PR TITLE
Feature/150 flag a defect

### DIFF
--- a/app/assets/stylesheets/components/forms.scss
+++ b/app/assets/stylesheets/components/forms.scss
@@ -28,3 +28,12 @@
 .collection_radio_buttons {
   @extend .govuk-radios__label;
 }
+
+.govuk-button.defect-flagged {
+  background-color: $lbh-error-colour;
+  font-weight: bold;
+}
+
+.defect-flagged-toggle {
+  display: inline-block;
+}

--- a/app/assets/stylesheets/components/tables.scss
+++ b/app/assets/stylesheets/components/tables.scss
@@ -44,6 +44,17 @@
         color: $lbh-text-colour;
         font-weight: normal;
         font-size: 1rem;
+        display: inline-block;
+      }
+
+      .cell-flagged-label {
+        background-color: $lbh-error-colour;
+        color: $lbh-text-white-colour;
+        font-weight: bold;
+        font-size: 1rem;
+        display: inline-block;
+        padding: 4px 8px;
+        border-radius: 2px;
       }
     }
 

--- a/app/controllers/staff/defect_flags_controller.rb
+++ b/app/controllers/staff/defect_flags_controller.rb
@@ -1,0 +1,17 @@
+class Staff::DefectFlagsController < Staff::BaseController
+  def create
+    defect.update!(flagged: true)
+    redirect_to helpers.defect_path_for(defect: defect)
+  end
+
+  def destroy
+    defect.update!(flagged: false)
+    redirect_to helpers.defect_path_for(defect: defect)
+  end
+
+  private
+
+  def defect
+    @defect ||= Defect.find(params[:defect_id])
+  end
+end

--- a/app/helpers/defect_helper.rb
+++ b/app/helpers/defect_helper.rb
@@ -31,4 +31,8 @@ module DefectHelper
   def event_description_for(event:)
     DefectEventPresenter.new(event).description
   end
+
+  def flag_toggle_button(defect)
+    render partial: 'shared/defects/flag_toggle_button', locals: { defect: defect }
+  end
 end

--- a/app/models/defect.rb
+++ b/app/models/defect.rb
@@ -71,7 +71,7 @@ class Defect < ApplicationRecord
   attr_reader :tracked_changes
 
   def remember_changes_for_activity
-    selected_changes = changes.slice(:status)
+    selected_changes = changes.slice(:flagged, :status)
     @tracked_changes = selected_changes unless selected_changes.empty?
   end
 

--- a/app/presenters/defect_event_presenter.rb
+++ b/app/presenters/defect_event_presenter.rb
@@ -37,7 +37,14 @@ class DefectEventPresenter
   end
 
   def description_for_update
-    if params[:changes]&.key?(:status)
+    changes = params[:changes]
+
+    if changes&.key?(:flagged)
+      case changes[:flagged]
+      when [false, true] then I18n.t('events.defect.flag_added', name: @event.owner.name)
+      when [true, false] then I18n.t('events.defect.flag_removed', name: @event.owner.name)
+      end
+    elsif changes&.key?(:status)
       old, new = params[:changes][:status].map { |status| Defect.format_status(status) }
       I18n.t('events.defect.status_changed', name: @event.owner.name, old: old, new: new)
     else

--- a/app/views/shared/defects/_flag_toggle_button.html.haml
+++ b/app/views/shared/defects/_flag_toggle_button.html.haml
@@ -1,0 +1,15 @@
+- if defect.flagged?
+  %span.govuk-button.defect-flagged
+    Flagged
+
+  = button_to(I18n.t('button.flag.remove'),
+              defect_flag_path(defect),
+              method: :delete,
+              class: 'govuk-button govuk-button--secondary',
+              form_class: 'defect-flagged-toggle')
+- else
+  = button_to(I18n.t('button.flag.add'),
+              defect_flag_path(defect),
+              method: :post,
+              class: 'govuk-button govuk-button--secondary',
+              form_class: 'defect-flagged-toggle')

--- a/app/views/staff/communal_defects/show.html.haml
+++ b/app/views/staff/communal_defects/show.html.haml
@@ -9,6 +9,7 @@
 .govuk-grid-row
   .govuk-grid-column-full
     %h2.govuk-heading-m= @defect.title
+    = flag_toggle_button(@defect)
     = link_to(I18n.t('button.edit.defect'), edit_communal_area_defect_path(@defect.communal_area, @defect), class: 'govuk-button govuk-button--secondary mb0')
     = link_to(I18n.t('button.forward.contractor'), new_defect_forward_path(@defect, recipient_type: :contractor), class: 'govuk-button govuk-button--secondary mb0')
     = link_to(I18n.t('button.forward.employer_agent'), new_defect_forward_path(@defect, recipient_type: :employer_agent), class: 'govuk-button govuk-button--secondary mb0')

--- a/app/views/staff/defects/index.html.haml
+++ b/app/views/staff/defects/index.html.haml
@@ -74,6 +74,10 @@
                   %span.cell-trade-label
                     = defect.trade
 
+                  - if defect.flagged?
+                    %span.cell-flagged-label
+                      Flagged
+
               %td.govuk-table__cell.due-date
                 = defect.target_completion_date
 

--- a/app/views/staff/property_defects/show.html.haml
+++ b/app/views/staff/property_defects/show.html.haml
@@ -9,6 +9,7 @@
 .govuk-grid-row
   .govuk-grid-column-full
     %h2.govuk-heading-m= @defect.title
+    = flag_toggle_button(@defect)
     = link_to(I18n.t('button.edit.defect'), edit_property_defect_path(@defect.property, @defect), class: 'govuk-button govuk-button--secondary mb0')
     = link_to(I18n.t('button.forward.contractor'), new_defect_forward_path(@defect, recipient_type: :contractor), class: 'govuk-button govuk-button--secondary mb0')
     = link_to(I18n.t('button.forward.employer_agent'), new_defect_forward_path(@defect, recipient_type: :employer_agent), class: 'govuk-button govuk-button--secondary mb0')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -185,6 +185,8 @@ en:
     defect:
       created: 'Defect was created by %{name}'
       updated: 'Defect was updated by %{name}'
+      flag_added: 'Flag was added by %{name}'
+      flag_removed: 'Flag was removed by %{name}'
       status_changed: 'Status was changed from %{old} to %{new} by %{name}'
       forwarded_to_contractor: 'An email was sent to the contractor (%{email})'
       forwarded_to_employer_agent: 'An email was sent to the employer agent (%{email})'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -125,6 +125,9 @@ en:
     forward:
       contractor: 'Forward to contractor'
       employer_agent: 'Forward to employer agent'
+    flag:
+      add: Flag defect
+      remove: Remove flag
   form:
     property:
       guidance: 'Find address information (Address, Postcode, UPRN) from %{link}.'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,7 @@ Rails.application.routes.draw do
 
   resources :defects, controller: 'staff/defects' do
     resource :forward, controller: 'staff/defects/forwarding', only: %i[new create]
+    resource :flag, controller: 'staff/defect_flags', only: %i[create destroy]
   end
 
   resources :properties, controller: 'staff/properties', only: %i[show] do

--- a/db/migrate/20190722104700_add_flagged_to_defects.rb
+++ b/db/migrate/20190722104700_add_flagged_to_defects.rb
@@ -1,0 +1,7 @@
+class AddFlaggedToDefects < ActiveRecord::Migration[5.2]
+  def change
+    change_table :defects do |t|
+      t.boolean :flagged, null: false, default: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_11_110803) do
+ActiveRecord::Schema.define(version: 2019_07_22_104700) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -72,6 +72,7 @@ ActiveRecord::Schema.define(version: 2019_07_11_110803) do
     t.boolean "communal", default: false
     t.uuid "communal_area_id"
     t.serial "sequence_number", null: false
+    t.boolean "flagged", default: false, null: false
     t.index ["communal_area_id"], name: "index_defects_on_communal_area_id"
     t.index ["priority_id"], name: "index_defects_on_priority_id"
     t.index ["property_id"], name: "index_defects_on_property_id"

--- a/spec/features/staff_can_create_a_comment_spec.rb
+++ b/spec/features/staff_can_create_a_comment_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Anyone can create a comment' do
+RSpec.feature 'Staff can create a comment' do
   before(:each) do
     stub_authenticated_session(name: 'Alex')
   end

--- a/spec/features/staff_can_create_a_communal_area_spec.rb
+++ b/spec/features/staff_can_create_a_communal_area_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Anyone can create a communal_area' do
+RSpec.feature 'Staff can create a communal_area' do
   before(:each) do
     stub_authenticated_session
   end

--- a/spec/features/staff_can_create_a_communal_defect_spec.rb
+++ b/spec/features/staff_can_create_a_communal_defect_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Anyone can create a defect for a communal_area' do
+RSpec.feature 'Staff can create a defect for a communal_area' do
   before(:each) do
     stub_authenticated_session
   end

--- a/spec/features/staff_can_create_a_priority_spec.rb
+++ b/spec/features/staff_can_create_a_priority_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Anyone can create a priority for a scheme' do
+RSpec.feature 'Staff can create a priority for a scheme' do
   before(:each) do
     stub_authenticated_session
   end

--- a/spec/features/staff_can_create_a_property_defect_spec.rb
+++ b/spec/features/staff_can_create_a_property_defect_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Anyone can create a defect for a property' do
+RSpec.feature 'Staff can create a defect for a property' do
   before(:each) do
     stub_authenticated_session
   end

--- a/spec/features/staff_can_create_a_property_spec.rb
+++ b/spec/features/staff_can_create_a_property_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Anyone can create a property' do
+RSpec.feature 'Staff can create a property' do
   before(:each) do
     stub_authenticated_session
   end

--- a/spec/features/staff_can_create_a_scheme_spec.rb
+++ b/spec/features/staff_can_create_a_scheme_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Anyone can create a scheme' do
+RSpec.feature 'Staff can create a scheme' do
   before(:each) do
     stub_authenticated_session
   end

--- a/spec/features/staff_can_create_an_estate_spec.rb
+++ b/spec/features/staff_can_create_an_estate_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Anyone can create a estate' do
+RSpec.feature 'Staff can create a estate' do
   before(:each) do
     stub_authenticated_session
   end

--- a/spec/features/staff_can_download_defect_csv_spec.rb
+++ b/spec/features/staff_can_download_defect_csv_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Anyone can download defect data' do
+RSpec.feature 'Staff can download defect data' do
   before(:each) do
     stub_authenticated_session
   end

--- a/spec/features/staff_can_find_a_block_spec.rb
+++ b/spec/features/staff_can_find_a_block_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Anyone can find a communal_area' do
+RSpec.feature 'Staff can find a communal_area' do
   before(:each) do
     stub_authenticated_session
   end

--- a/spec/features/staff_can_find_a_property_spec.rb
+++ b/spec/features/staff_can_find_a_property_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Anyone can find a property' do
+RSpec.feature 'Staff can find a property' do
   before(:each) do
     stub_authenticated_session
   end

--- a/spec/features/staff_can_flag_a_communal_defect_spec.rb
+++ b/spec/features/staff_can_flag_a_communal_defect_spec.rb
@@ -12,6 +12,12 @@ RSpec.feature 'Staff can flag a communal defect' do
     click_button I18n.t('button.flag.add')
 
     expect(defect.reload).to be_flagged
+
+    visit defects_path
+
+    within('table.defects tbody th:first-child') do
+      expect(page).to have_content('Flagged')
+    end
   end
 
   scenario 'unflagging a defect' do
@@ -21,5 +27,11 @@ RSpec.feature 'Staff can flag a communal defect' do
     click_button I18n.t('button.flag.remove')
 
     expect(defect.reload).not_to be_flagged
+
+    visit defects_path
+
+    within('table.defects tbody th:first-child') do
+      expect(page).not_to have_content('Flagged')
+    end
   end
 end

--- a/spec/features/staff_can_flag_a_communal_defect_spec.rb
+++ b/spec/features/staff_can_flag_a_communal_defect_spec.rb
@@ -5,33 +5,45 @@ RSpec.feature 'Staff can flag a communal defect' do
     stub_authenticated_session
   end
 
-  scenario 'flagging a defect' do
-    defect = create(:communal_defect, flagged: false)
+  context 'flagging a defect' do
+    let(:defect) { create(:communal_defect, flagged: false) }
 
-    visit communal_area_defect_path(defect.communal_area, defect)
-    click_button I18n.t('button.flag.add')
+    before do
+      visit communal_area_defect_path(defect.communal_area, defect)
+      click_button I18n.t('button.flag.add')
+    end
 
-    expect(defect.reload).to be_flagged
+    it 'marks the defect as flagged' do
+      expect(defect.reload).to be_flagged
+    end
 
-    visit defects_path
+    it 'shows the flag in the list of defects' do
+      visit defects_path
 
-    within('table.defects tbody th:first-child') do
-      expect(page).to have_content('Flagged')
+      within('table.defects tbody th:first-child') do
+        expect(page).to have_content('Flagged')
+      end
     end
   end
 
-  scenario 'unflagging a defect' do
-    defect = create(:communal_defect, flagged: true)
+  context 'unflagging a defect' do
+    let(:defect) { create(:communal_defect, flagged: true) }
 
-    visit communal_area_defect_path(defect.communal_area, defect)
-    click_button I18n.t('button.flag.remove')
+    before do
+      visit communal_area_defect_path(defect.communal_area, defect)
+      click_button I18n.t('button.flag.remove')
+    end
 
-    expect(defect.reload).not_to be_flagged
+    it 'removes the flag from the defect' do
+      expect(defect.reload).not_to be_flagged
+    end
 
-    visit defects_path
+    it 'does not show a flag in the list of defects' do
+      visit defects_path
 
-    within('table.defects tbody th:first-child') do
-      expect(page).not_to have_content('Flagged')
+      within('table.defects tbody th:first-child') do
+        expect(page).not_to have_content('Flagged')
+      end
     end
   end
 end

--- a/spec/features/staff_can_flag_a_communal_defect_spec.rb
+++ b/spec/features/staff_can_flag_a_communal_defect_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.feature 'Staff can flag a communal defect' do
+  before(:each) do
+    stub_authenticated_session
+  end
+
+  scenario 'flagging a defect' do
+    defect = create(:communal_defect, flagged: false)
+
+    visit communal_area_defect_path(defect.communal_area, defect)
+    click_button I18n.t('button.flag.add')
+
+    expect(defect.reload).to be_flagged
+  end
+
+  scenario 'unflagging a defect' do
+    defect = create(:communal_defect, flagged: true)
+
+    visit communal_area_defect_path(defect.communal_area, defect)
+    click_button I18n.t('button.flag.remove')
+
+    expect(defect.reload).not_to be_flagged
+  end
+end

--- a/spec/features/staff_can_flag_a_communal_defect_spec.rb
+++ b/spec/features/staff_can_flag_a_communal_defect_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.feature 'Staff can flag a communal defect' do
   before(:each) do
-    stub_authenticated_session
+    stub_authenticated_session(name: 'Bob')
   end
 
   context 'flagging a defect' do
@@ -15,6 +15,14 @@ RSpec.feature 'Staff can flag a communal defect' do
 
     it 'marks the defect as flagged' do
       expect(defect.reload).to be_flagged
+    end
+
+    it 'shows the flag being added in the activity log' do
+      within('.events') do
+        expect(page).to have_content(
+          I18n.t('events.defect.flag_added', name: 'Bob')
+        )
+      end
     end
 
     it 'shows the flag in the list of defects' do
@@ -36,6 +44,14 @@ RSpec.feature 'Staff can flag a communal defect' do
 
     it 'removes the flag from the defect' do
       expect(defect.reload).not_to be_flagged
+    end
+
+    it 'shows the flag being removed in the activity log' do
+      within('.events') do
+        expect(page).to have_content(
+          I18n.t('events.defect.flag_removed', name: 'Bob')
+        )
+      end
     end
 
     it 'does not show a flag in the list of defects' do

--- a/spec/features/staff_can_flag_a_property_defect_spec.rb
+++ b/spec/features/staff_can_flag_a_property_defect_spec.rb
@@ -17,6 +17,14 @@ RSpec.feature 'Staff can flag a property defect' do
       expect(defect.reload).to be_flagged
     end
 
+    it 'shows the flag being added in the activity log' do
+      within('.events') do
+        expect(page).to have_content(
+          I18n.t('events.defect.flag_added', name: 'Bob')
+        )
+      end
+    end
+
     it 'shows the flag in the list of defects' do
       visit defects_path
 
@@ -36,6 +44,14 @@ RSpec.feature 'Staff can flag a property defect' do
 
     it 'removes the flag from the defect' do
       expect(defect.reload).not_to be_flagged
+    end
+
+    it 'shows the flag being removed in the activity log' do
+      within('.events') do
+        expect(page).to have_content(
+          I18n.t('events.defect.flag_removed', name: 'Bob')
+        )
+      end
     end
 
     it 'does not show a flag in the list of defects' do

--- a/spec/features/staff_can_flag_a_property_defect_spec.rb
+++ b/spec/features/staff_can_flag_a_property_defect_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.feature 'Staff can flag a property defect' do
+  before(:each) do
+    stub_authenticated_session
+  end
+
+  scenario 'flagging a defect' do
+    defect = create(:property_defect, flagged: false)
+
+    visit property_defect_path(defect.property, defect)
+    click_button I18n.t('button.flag.add')
+
+    expect(defect.reload).to be_flagged
+  end
+
+  scenario 'unflagging a defect' do
+    defect = create(:property_defect, flagged: true)
+
+    visit property_defect_path(defect.property, defect)
+    click_button I18n.t('button.flag.remove')
+
+    expect(defect.reload).not_to be_flagged
+  end
+end

--- a/spec/features/staff_can_flag_a_property_defect_spec.rb
+++ b/spec/features/staff_can_flag_a_property_defect_spec.rb
@@ -12,6 +12,12 @@ RSpec.feature 'Staff can flag a property defect' do
     click_button I18n.t('button.flag.add')
 
     expect(defect.reload).to be_flagged
+
+    visit defects_path
+
+    within('table.defects tbody th:first-child') do
+      expect(page).to have_content('Flagged')
+    end
   end
 
   scenario 'unflagging a defect' do
@@ -21,5 +27,11 @@ RSpec.feature 'Staff can flag a property defect' do
     click_button I18n.t('button.flag.remove')
 
     expect(defect.reload).not_to be_flagged
+
+    visit defects_path
+
+    within('table.defects tbody th:first-child') do
+      expect(page).not_to have_content('Flagged')
+    end
   end
 end

--- a/spec/features/staff_can_flag_a_property_defect_spec.rb
+++ b/spec/features/staff_can_flag_a_property_defect_spec.rb
@@ -2,36 +2,48 @@ require 'rails_helper'
 
 RSpec.feature 'Staff can flag a property defect' do
   before(:each) do
-    stub_authenticated_session
+    stub_authenticated_session(name: 'Bob')
   end
 
-  scenario 'flagging a defect' do
-    defect = create(:property_defect, flagged: false)
+  context 'flagging a defect' do
+    let(:defect) { create(:property_defect, flagged: false) }
 
-    visit property_defect_path(defect.property, defect)
-    click_button I18n.t('button.flag.add')
+    before do
+      visit property_defect_path(defect.property, defect)
+      click_button I18n.t('button.flag.add')
+    end
 
-    expect(defect.reload).to be_flagged
+    it 'marks the defect as flagged' do
+      expect(defect.reload).to be_flagged
+    end
 
-    visit defects_path
+    it 'shows the flag in the list of defects' do
+      visit defects_path
 
-    within('table.defects tbody th:first-child') do
-      expect(page).to have_content('Flagged')
+      within('table.defects tbody th:first-child') do
+        expect(page).to have_content('Flagged')
+      end
     end
   end
 
-  scenario 'unflagging a defect' do
-    defect = create(:property_defect, flagged: true)
+  context 'unflagging a defect' do
+    let(:defect) { create(:property_defect, flagged: true) }
 
-    visit property_defect_path(defect.property, defect)
-    click_button I18n.t('button.flag.remove')
+    before do
+      visit property_defect_path(defect.property, defect)
+      click_button I18n.t('button.flag.remove')
+    end
 
-    expect(defect.reload).not_to be_flagged
+    it 'removes the flag from the defect' do
+      expect(defect.reload).not_to be_flagged
+    end
 
-    visit defects_path
+    it 'does not show a flag in the list of defects' do
+      visit defects_path
 
-    within('table.defects tbody th:first-child') do
-      expect(page).not_to have_content('Flagged')
+      within('table.defects tbody th:first-child') do
+        expect(page).not_to have_content('Flagged')
+      end
     end
   end
 end

--- a/spec/features/staff_can_update_a_communal_area_spec.rb
+++ b/spec/features/staff_can_update_a_communal_area_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Anyone can update a communal_area' do
+RSpec.feature 'Staff can update a communal_area' do
   before(:each) do
     stub_authenticated_session
   end

--- a/spec/features/staff_can_update_a_communal_defect_spec.rb
+++ b/spec/features/staff_can_update_a_communal_defect_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Anyone can update a communal_area defect' do
+RSpec.feature 'Staff can update a communal_area defect' do
   before(:each) do
     stub_authenticated_session
   end

--- a/spec/features/staff_can_update_a_property_defect_spec.rb
+++ b/spec/features/staff_can_update_a_property_defect_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Anyone can update a defect' do
+RSpec.feature 'Staff can update a defect' do
   before(:each) do
     stub_authenticated_session
   end

--- a/spec/features/staff_can_update_a_property_spec.rb
+++ b/spec/features/staff_can_update_a_property_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Anyone can update a property' do
+RSpec.feature 'Staff can update a property' do
   before(:each) do
     stub_authenticated_session
   end

--- a/spec/features/staff_can_update_a_scheme_spec.rb
+++ b/spec/features/staff_can_update_a_scheme_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Anyone can update a scheme' do
+RSpec.feature 'Staff can update a scheme' do
   before(:each) do
     stub_authenticated_session
   end

--- a/spec/features/staff_can_view_a_block_spec.rb
+++ b/spec/features/staff_can_view_a_block_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Anyone can view a communal_area' do
+RSpec.feature 'Staff can view a communal_area' do
   before(:each) do
     stub_authenticated_session
   end

--- a/spec/features/staff_can_view_a_defect_spec.rb
+++ b/spec/features/staff_can_view_a_defect_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Anyone can view a defect' do
+RSpec.feature 'Staff can view a defect' do
   before(:each) do
     stub_authenticated_session
   end

--- a/spec/features/staff_can_view_a_property_spec.rb
+++ b/spec/features/staff_can_view_a_property_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Anyone can view a property' do
+RSpec.feature 'Staff can view a property' do
   before(:each) do
     stub_authenticated_session
   end

--- a/spec/features/staff_can_view_a_scheme_report_spec.rb
+++ b/spec/features/staff_can_view_a_scheme_report_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Anyone can view a report for a scheme' do
+RSpec.feature 'Staff can view a report for a scheme' do
   before(:each) do
     stub_authenticated_session
   end

--- a/spec/features/staff_can_view_a_scheme_spec.rb
+++ b/spec/features/staff_can_view_a_scheme_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Anyone can view a scheme' do
+RSpec.feature 'Staff can view a scheme' do
   before(:each) do
     stub_authenticated_session
   end

--- a/spec/features/staff_can_view_all_defects_spec.rb
+++ b/spec/features/staff_can_view_all_defects_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Anyone can view all defects' do
+RSpec.feature 'Staff can view all defects' do
   before(:each) do
     stub_authenticated_session
   end

--- a/spec/features/staff_can_visit_the_service_spec.rb
+++ b/spec/features/staff_can_visit_the_service_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Anyone can visit the service' do
+RSpec.feature 'Staff can visit the service' do
   scenario 'visit the home page' do
     visit dashboard_path
     expect(page).to have_content(I18n.t('service.name'))

--- a/spec/helpers/defect_helper_spec.rb
+++ b/spec/helpers/defect_helper_spec.rb
@@ -92,6 +92,32 @@ RSpec.describe DefectHelper, type: :helper do
       end
     end
 
+    context 'when the event describes a flag being added' do
+      it 'returns the event description' do
+        event = PublicActivity::Activity.new(
+          trackable: defect,
+          owner: user,
+          key: 'defect.update',
+          parameters: { changes: { flagged: [false, true] } }
+        )
+        result = helper.event_description_for(event: event)
+        expect(result).to eql(I18n.t('events.defect.flag_added', name: event.owner.name))
+      end
+    end
+
+    context 'when the event describes a flag being removed' do
+      it 'returns the event description' do
+        event = PublicActivity::Activity.new(
+          trackable: defect,
+          owner: user,
+          key: 'defect.update',
+          parameters: { changes: { flagged: [true, false] } }
+        )
+        result = helper.event_description_for(event: event)
+        expect(result).to eql(I18n.t('events.defect.flag_removed', name: event.owner.name))
+      end
+    end
+
     context 'when the event describes a status change' do
       it 'returns the event description' do
         event = PublicActivity::Activity.new(

--- a/spec/models/defect_spec.rb
+++ b/spec/models/defect_spec.rb
@@ -153,8 +153,18 @@ RSpec.describe Defect, type: :model do
       defect = build(:defect, status: 'outstanding')
       defect.follow_on!
 
-      event = defect.activities.last
+      event = defect.activities.first
       expect(event.parameters[:changes]).to eq('status' => %w[outstanding follow_on])
+    end
+  end
+
+  describe '#flagged' do
+    it 'records changes in the activity log' do
+      defect = build(:defect, status: 'outstanding', flagged: false)
+      defect.update!(flagged: true)
+
+      event = defect.activities.first
+      expect(event.parameters[:changes]).to eq('flagged' => [false, true])
     end
   end
 


### PR DESCRIPTION
## Changes in this PR:

This PR adds the ability to flag defects so that they can be escalated and prioritised by staff. We add a toggle button to the defect page, we show changes to this state in the event log, and we show which defects are flagged in search results.

## Screenshots of UI changes:

A defect begins in the unflagged state, and a button exists to flag it.

<img width="781" alt="Screenshot 2019-07-22 at 17 17 07" src="https://user-images.githubusercontent.com/9265/61647215-c3235f00-aca4-11e9-8d59-4d171771e714.png">

Once flagged, it is labelled as such, and the button changes to remove the flag.

<img width="759" alt="Screenshot 2019-07-22 at 17 17 19" src="https://user-images.githubusercontent.com/9265/61647216-c3235f00-aca4-11e9-8721-17418b959247.png">

Changes to the flag state are displayed in the event log.

<img width="585" alt="Screenshot 2019-07-22 at 17 17 41" src="https://user-images.githubusercontent.com/9265/61647217-c3235f00-aca4-11e9-8441-6c2d5c4a60bf.png">

Finally, we display the flagged state of each defect in the search listing.
<img width="1226" alt="Screenshot 2019-07-22 at 17 18 12" src="https://user-images.githubusercontent.com/9265/61647218-c3235f00-aca4-11e9-97ed-42c21b2377d7.png">
