### PR TITLE
[161] Acceptance email includes what to do to reject a defect

### DIFF
--- a/app/views/defect_mailer/forward_to_contractor.html.haml
+++ b/app/views/defect_mailer/forward_to_contractor.html.haml
@@ -18,3 +18,4 @@
 = "#{I18n.t('email.defect.forward.headings.title.target_completion_date')}: #{@presenter.target_completion_date}"
 \---
 = "#{accept_defect_ownership_link(@defect.token)}"
+= I18n.t('email.defect.forward.rejection')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -174,6 +174,7 @@ en:
             contractor: 'Contractor'
             priority_name: 'Priority'
             target_completion_date: 'Target completion date'
+        rejection: 'Or, to reject ownership please email newbuild@hackney.gov.uk and include the reference number.'
         accept:
           link: 'Accept ownership of this defect'
         # alternate: 'Call us if not'

--- a/spec/mailers/defect_spec.rb
+++ b/spec/mailers/defect_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe DefectMailer, type: :mailer do
       expect(body_lines[16].strip).to match("#{I18n.t('email.defect.forward.headings.title.priority_name')}: #{presenter.priority_name}")
       expect(body_lines[17].strip).to match("#{I18n.t('email.defect.forward.headings.title.target_completion_date')}: #{presenter.target_completion_date}")
       expect(body_lines[19]).to match(%r{http:\/\/localhost:3000\/defects\/#{defect.token}\/accept})
+      expect(body_lines[20]).to match(I18n.t('email.defect.forward.rejection'))
     end
 
     it 'sends an email to employer_agent' do


### PR DESCRIPTION
## Changes in this PR:

* This is simply steering the contractor into following the existing process but being explicit about it in the hope that there is a more consistent experience on how rejections are raised.

## Screenshots of UI changes:

![Screenshot 2019-07-22 at 17 42 25](https://user-images.githubusercontent.com/912473/61648842-2662c080-aca8-11e9-9cd5-67a2b48a1ff5.png)
