### PR TITLE
Filtering reports by date makes it clear which date field is for FROM and TO

### DIFF
--- a/app/views/staff/report/show.html.haml
+++ b/app/views/staff/report/show.html.haml
@@ -12,7 +12,9 @@
       %span.govuk-caption-l= @presenter.date_range
 
     = form_tag report_scheme_path(scheme: @presenter.scheme.id), class: 'date-filter', method: :get do
+      %h2.govuk-heading-m From
       = render partial: 'shared/defects/date_fields', locals: { name: 'from_date', date: @report_form.from_date }
+      %h2.govuk-heading-m To
       = render partial: 'shared/defects/date_fields', locals: { name: 'to_date', date: @report_form.to_date }
 
       %br


### PR DESCRIPTION
## Changes in this PR:

## Screenshots of UI changes:

### Before

![Screenshot 2019-07-23 at 11 42 57](https://user-images.githubusercontent.com/912473/61706077-1b0ea400-ad3f-11e9-8425-2a8865b0b787.png)

### After

![Screenshot 2019-07-23 at 11 43 01](https://user-images.githubusercontent.com/912473/61706079-1e099480-ad3f-11e9-9b5b-707afc732bc9.png)