### PR TITLE
Chore/improve getting started instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,17 @@ Architecture decision records can be found in the doc/architecture/decisions dir
 * [Docker](https://docs.docker.com/docker-for-mac)
 
 ## Getting started
-```bash
-docker-compose up
-```
 
-If you'd like to use the `pry` gem for debugging start with:
+The following command will start all containers, do any database set up if required before leaving you on an interactive prompt within rails server:
+
 ```bash
 bin/dstart
+```
+
+If you'd like to see all logs, like Sidekiq or Redis you can use the default:
+
+```
+docker-compose up
 ```
 
 ## Running the tests

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ A web service that allows Hackney residents to report defects with their newly b
 ## Documentation
 Documentation can be found in the doc directory.
 
+Technical handover and summary information of the beta can be read in a [Hackney Google Sheet](https://docs.google.com/document/d/1qfhREOLLcKOf4VKfXmLAVF1-qHxTTBLZGfYCgIqlVJE/edit).
+
 ## ADRs
 Architecture decision records can be found in the doc/architecture/decisions directory.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Documentation can be found in the doc directory.
 Architecture decision records can be found in the doc/architecture/decisions directory.
 
 ## Prerequisites
-* (Docker)[https://docs.docker.com/docker-for-mac]
+* [Docker](https://docs.docker.com/docker-for-mac)
 
 ## Getting started
 ```bash


### PR DESCRIPTION
## Changes in this PR:
- suggest new default command to get started and why you might want to use it over the conventional docker-compose
- include link to the Hackney google doc for extra context, access credentials etc
- fix a badly formatted markdown link