### PR TITLE
(fix) Search by reference number for communal defects

### DIFF
--- a/app/controllers/staff/searches_controller.rb
+++ b/app/controllers/staff/searches_controller.rb
@@ -19,7 +19,7 @@ class Staff::SearchesController < Staff::BaseController
     defect = Defect.by_reference_number(number)
 
     if defect
-      redirect_to property_defect_path(defect.property_id, defect)
+      redirect_to helpers.defect_path_for(defect: defect)
     else
       flash[:notice] = I18n.t('page_content.defect.not_found', reference_number: query)
       redirect_to dashboard_path

--- a/spec/features/staff_can_view_a_defect_spec.rb
+++ b/spec/features/staff_can_view_a_defect_spec.rb
@@ -51,8 +51,24 @@ RSpec.feature 'Staff can view a defect' do
     end
   end
 
-  scenario 'a defect can be found by reference number' do
+  scenario 'a property defect can be found by reference number' do
     defect = create(:property_defect)
+
+    visit dashboard_path
+
+    within('form.search') do
+      fill_in 'query', with: defect.reference_number
+      click_on(I18n.t('generic.button.find'))
+    end
+
+    expect(page).to have_content(I18n.t('page_title.staff.defects.show', reference_number: defect.reference_number))
+
+    expect(page).to have_content(defect.reference_number)
+    expect(page).to have_content(defect.title)
+  end
+
+  scenario 'a communal defect can be found by reference number' do
+    defect = create(:communal_defect)
 
     visit dashboard_path
 


### PR DESCRIPTION
Due to an error in using the wrong URL helper method, searching for a communal defect by reference number generates an exception so the user sees an error page.

This commit fixes search so that it works for all defect types.