### PR TITLE
(chore) Remove `defects.reference_number`

### DIFF
--- a/db/migrate/20190711111359_remove_defects_reference_number.rb
+++ b/db/migrate/20190711111359_remove_defects_reference_number.rb
@@ -1,0 +1,5 @@
+class RemoveDefectsReferenceNumber < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :defects, :reference_number
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -62,7 +62,6 @@ ActiveRecord::Schema.define(version: 2019_07_22_104700) do
     t.string "trade"
     t.date "target_completion_date"
     t.integer "status", default: 0
-    t.string "reference_number"
     t.uuid "property_id"
     t.uuid "priority_id"
     t.datetime "created_at", null: false


### PR DESCRIPTION
As part of implementing search by reference number, this column was
replaced with the serial column `defects.sequence_number`. It is now no
longer used and can be removed.