### PR TITLE
(fix) Styling for the 'Flagged' label on defect page

### DIFF
--- a/app/assets/stylesheets/components/forms.scss
+++ b/app/assets/stylesheets/components/forms.scss
@@ -29,9 +29,17 @@
   @extend .govuk-radios__label;
 }
 
-.govuk-button.defect-flagged {
+.defect-flagged {
   background-color: $lbh-error-colour;
+  color: $lbh-text-white-colour;
+  border-radius: 2px;
+  display: block;
+  font-size: 1.1875rem;
   font-weight: bold;
+  line-height: 1;
+  padding: 9px 10px;
+  width: 4em;
+  margin-bottom: 1em;
 }
 
 .defect-flagged-toggle {

--- a/app/views/shared/defects/_flag_toggle_button.html.haml
+++ b/app/views/shared/defects/_flag_toggle_button.html.haml
@@ -1,5 +1,5 @@
 - if defect.flagged?
-  %span.govuk-button.defect-flagged
+  %span.govuk-body.defect-flagged
     Flagged
 
   = button_to(I18n.t('button.flag.remove'),


### PR DESCRIPTION
The 'Flagged label' is currently being displayed as a button because I
appropriated the `govuk-button` class to make it look like the nearby
buttons/links. So, it has `cursor: pointer` and depresses when clicked.

This changes it to look like the label that appears on the search
listing, and not have those unwanted interaction cues.

## Screenshots of UI changes:

### Before

<img width="881" alt="Screenshot 2019-07-23 at 15 01 02" src="https://user-images.githubusercontent.com/9265/61718373-c37e3180-ad5a-11e9-8211-6d5c6610e66f.png">

### After

<img width="786" alt="Screenshot 2019-07-23 at 15 01 15" src="https://user-images.githubusercontent.com/9265/61718383-c842e580-ad5a-11e9-85b1-1a345a64cf11.png">
