### PR TITLE
(fix) Detect defects completed on time when they have non-status changes

### DIFF
--- a/app/presenters/scheme_report_presenter.rb
+++ b/app/presenters/scheme_report_presenter.rb
@@ -70,7 +70,7 @@ class SchemeReportPresenter
 
       # TODO: Query parameter JSON at database level rather than in Ruby
       true if updates_before_target_completion.detect do |updated_event|
-        updated_event.parameters[:changes][:status].last == 'completed'
+        updated_event.parameters[:changes][:status]&.last == 'completed'
       end
     end
   end

--- a/spec/presenters/scheme_report_presenter_spec.rb
+++ b/spec/presenters/scheme_report_presenter_spec.rb
@@ -223,6 +223,7 @@ RSpec.describe SchemeReportPresenter do
       # aren't triggered and no Activity records are created as they would be.
       travel_to Time.zone.parse('2019-05-22')
       completed_early_defect.completed!
+      completed_early_defect.update!(flagged: true)
 
       travel_to Time.zone.parse('2019-05-23')
       completed_on_time_defect.completed!


### PR DESCRIPTION
Before this fix, visiting some scheme results would result in a 500 error as we tried to generate the report. The report should now generate successfully.