### PR TITLE
(fix) Send completion notification once a defect is valid

### DIFF
--- a/app/controllers/staff/communal_defects_controller.rb
+++ b/app/controllers/staff/communal_defects_controller.rb
@@ -35,7 +35,7 @@ class Staff::CommunalDefectsController < Staff::BaseController
     ).call
 
     if @defect.valid?
-      @defect.save
+      UpdateDefect.new(defect: @defect).call
       flash[:success] = I18n.t('generic.notice.update.success', resource: 'defect')
       redirect_to communal_area_defect_path(@defect.communal_area, @defect)
     else

--- a/app/controllers/staff/property_defects_controller.rb
+++ b/app/controllers/staff/property_defects_controller.rb
@@ -43,7 +43,7 @@ class Staff::PropertyDefectsController < Staff::BaseController
     ).call
 
     if @defect.valid?
-      @defect.save
+      UpdateDefect.new(defect: @defect).call
       flash[:success] = I18n.t('generic.notice.update.success', resource: 'defect')
       redirect_to property_defect_path(@defect.property, @defect)
     else

--- a/app/services/edit_defect.rb
+++ b/app/services/edit_defect.rb
@@ -21,7 +21,6 @@ class EditDefect
       set_target_completion_date
     end
 
-    NotifyDefectCompletedJob.perform_later(defect.id) if defect.status_changed? && defect.completed?
     defect
   end
 

--- a/app/services/update_defect.rb
+++ b/app/services/update_defect.rb
@@ -1,0 +1,14 @@
+class UpdateDefect
+  attr_accessor :defect
+
+  def initialize(defect:)
+    self.defect = defect
+  end
+
+  def call
+    NotifyDefectCompletedJob.perform_later(defect.id) if defect.status_changed? && defect.completed?
+
+    defect.save
+    defect
+  end
+end

--- a/spec/features/staff_can_update_a_communal_defect_spec.rb
+++ b/spec/features/staff_can_update_a_communal_defect_spec.rb
@@ -120,4 +120,17 @@ RSpec.feature 'Staff can update a communal_area defect' do
 
     expect(page).to have_content(I18n.t('generic.notice.update.success', resource: 'defect'))
   end
+
+  scenario 'updating a status to completed' do
+    defect = create(:communal_defect, communal_area: communal_area, status: :outstanding)
+
+    visit edit_communal_area_defect_path(defect.communal_area, defect)
+
+    expect(NotifyDefectCompletedJob).to receive(:perform_later).with(defect.id)
+
+    within('form.edit_defect') do
+      select 'Completed', from: 'defect[status]'
+      click_on(I18n.t('button.update.defect'))
+    end
+  end
 end

--- a/spec/features/staff_can_update_a_property_defect_spec.rb
+++ b/spec/features/staff_can_update_a_property_defect_spec.rb
@@ -154,4 +154,17 @@ RSpec.feature 'Staff can update a defect' do
 
     expect(page).to have_content(I18n.t('generic.notice.update.success', resource: 'defect'))
   end
+
+  scenario 'updating a status to completed' do
+    defect = create(:property_defect, property: property, status: :outstanding)
+
+    visit edit_property_defect_path(defect.property, defect)
+
+    expect(NotifyDefectCompletedJob).to receive(:perform_later).with(defect.id)
+
+    within('form.edit_defect') do
+      select 'Completed', from: 'defect[status]'
+      click_on(I18n.t('button.update.defect'))
+    end
+  end
 end

--- a/spec/services/edit_defect_spec.rb
+++ b/spec/services/edit_defect_spec.rb
@@ -43,23 +43,6 @@ RSpec.describe EditDefect do
       end
     end
 
-    context 'when the new status is changed to completed' do
-      let(:defect) { create(:property_defect) }
-      let(:defect_params) do
-        build(:property_defect, status: :completed)
-          .attributes
-          .except!('id')
-      end
-
-      it 'enqueues a job to notify the contact' do
-        expect(NotifyDefectCompletedJob)
-          .to receive(:perform_later)
-          .with(defect.id)
-
-        service.call
-      end
-    end
-
     context 'when the status was already completed' do
       let(:defect) { create(:property_defect, status: :completed) }
       let(:defect_params) do

--- a/spec/services/update_defect_spec.rb
+++ b/spec/services/update_defect_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe UpdateDefect do
+  let(:defect) { create(:property_defect) }
+
+  describe '#call' do
+    let(:service) do
+      described_class.new(defect: defect)
+    end
+
+    it 'returns a defect object' do
+      expect(service.call).to be_kind_of(Defect)
+    end
+
+    it 'does not enqueue a notification' do
+      expect(NotifyDefectCompletedJob).not_to receive(:perform_later).with(defect.id)
+      service.call
+    end
+
+    context 'when the defect has had its status changed to completed' do
+      it 'enqueues a notification' do
+        defect = create(:property_defect, status: :outstanding)
+        defect.status = :completed
+
+        expect(NotifyDefectCompletedJob).to receive(:perform_later).with(defect.id)
+
+        described_class.new(defect: defect).call
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Changes in this PR:

* notifications were being sent to users during the edit phase, which could fail validation. It is more reliable to send this notification after validation has been approved to avoid any duplicat messages being sent
* refactor into a service object to share the code between property and communal area controllers

