### PR TITLE
(172) Include actual completion date in defect overview

### DIFF
--- a/app/views/staff/defects/index.html.haml
+++ b/app/views/staff/defects/index.html.haml
@@ -54,6 +54,8 @@
             %th.govuk-table__header{scope:'col'}
               Due by
             %th.govuk-table__header{scope:'col'}
+              Actual completion
+            %th.govuk-table__header{scope:'col'}
               Status and priority
             %th.govuk-table__header{scope:'col', class: 'govuk-!-width-one-third'}
               Location
@@ -80,6 +82,9 @@
 
               %td.govuk-table__cell.due-date
                 = defect.target_completion_date
+
+              %td.govuk-table__cell.due-date
+                = defect.actual_completion_date
 
               %td.govuk-table__cell.lbh-table-cell
                 %span{ class: "cell-status-label #{defect.status.downcase}" }

--- a/spec/features/staff_can_view_all_defects_spec.rb
+++ b/spec/features/staff_can_view_all_defects_spec.rb
@@ -43,7 +43,7 @@ RSpec.feature 'Staff can view all defects' do
 
   scenario 'closed defects can be shown' do
     _open_defect = DefectPresenter.new(create(:property_defect, status: :outstanding))
-    closed_defect = DefectPresenter.new(create(:property_defect, status: :completed))
+    closed_defect = DefectPresenter.new(create(:property_defect, :completed))
 
     visit dashboard_path
 
@@ -57,6 +57,7 @@ RSpec.feature 'Staff can view all defects' do
     within '.defects' do
       expect(page).to have_content(closed_defect.reference_number)
       expect(page).to have_content(closed_defect.status)
+      expect(page).to have_content(closed_defect.actual_completion_date)
     end
   end
 


### PR DESCRIPTION
## Changes in this PR:

- Defect overview page now shows the 'Actual completion' next to the 'Due by' date

## Screenshots of UI changes:

### Before

<img width="1276" alt="Screenshot 2019-08-20 at 16 33 26" src="https://user-images.githubusercontent.com/3166/63361563-45687700-c368-11e9-89a9-8cf2683f049d.png">

### After

<img width="1288" alt="Screenshot 2019-08-20 at 16 34 24" src="https://user-images.githubusercontent.com/3166/63361675-73e65200-c368-11e9-86ea-c876534b0452.png">

