### PR TITLE
(173) Allow actual completion date to be editable

### DIFF
--- a/app/controllers/staff/communal_defects_controller.rb
+++ b/app/controllers/staff/communal_defects_controller.rb
@@ -31,6 +31,7 @@ class Staff::CommunalDefectsController < Staff::BaseController
       options: {
         priority_id: priority_id,
         target_completion_date: target_completion_date,
+        actual_completion_date: actual_completion_date,
       }
     ).call
 
@@ -70,6 +71,10 @@ class Staff::CommunalDefectsController < Staff::BaseController
 
   def target_completion_date
     params.require(:target_completion_date).permit(:day, :month, :year)
+  end
+
+  def actual_completion_date
+    params.fetch(:actual_completion_date, {}).permit(:day, :month, :year)
   end
 
   def defect_params

--- a/app/controllers/staff/property_defects_controller.rb
+++ b/app/controllers/staff/property_defects_controller.rb
@@ -39,6 +39,7 @@ class Staff::PropertyDefectsController < Staff::BaseController
       options: {
         priority_id: priority_id,
         target_completion_date: target_completion_date,
+        actual_completion_date: actual_completion_date,
       }
     ).call
 
@@ -70,6 +71,10 @@ class Staff::PropertyDefectsController < Staff::BaseController
 
   def target_completion_date
     params.require(:target_completion_date).permit(:day, :month, :year)
+  end
+
+  def actual_completion_date
+    params.fetch(:actual_completion_date, {}).permit(:day, :month, :year)
   end
 
   def defect_params

--- a/app/views/staff/communal_defects/edit.html.haml
+++ b/app/views/staff/communal_defects/edit.html.haml
@@ -66,4 +66,12 @@
 
       = render partial: 'shared/defects/date_fields', locals: { name: 'target_completion_date', date: nil }
 
+      - if @defect.actual_completion_date.present?
+        .existing-priority-information
+          %label.govuk-label
+            %span Actual completion date
+            %p.govuk-inset-text= @defect.actual_completion_date
+
+          = render partial: 'shared/defects/date_fields', locals: { name: 'actual_completion_date', date: nil }
+
       = f.button :submit, I18n.t('button.update.defect')

--- a/app/views/staff/property_defects/edit.html.haml
+++ b/app/views/staff/property_defects/edit.html.haml
@@ -61,4 +61,13 @@
 
       = render partial: 'shared/defects/date_fields', locals: { name: 'target_completion_date', date: nil }
 
+      - if @defect.actual_completion_date.present?
+        .existing-priority-information
+          %label.govuk-label
+            %span Actual completion date
+            %p.govuk-inset-text= @defect.actual_completion_date
+
+          = render partial: 'shared/defects/date_fields', locals: { name: 'actual_completion_date', date: nil }
+
+
       = f.button :submit, I18n.t('button.update.defect')

--- a/spec/features/staff_can_update_a_communal_defect_spec.rb
+++ b/spec/features/staff_can_update_a_communal_defect_spec.rb
@@ -145,4 +145,32 @@ RSpec.feature 'Staff can update a communal_area defect' do
     expect(page).to have_content(I18n.t('generic.notice.update.success', resource: 'defect'))
     expect(page).to have_content('28 July 2020')
   end
+
+  scenario 'updating the actual completion date' do
+    defect = create(:communal_defect, :completed, communal_area: communal_area)
+
+    visit edit_communal_area_defect_path(defect.communal_area, defect)
+
+    within('form.edit_defect') do
+      fill_in 'actual_completion_date_day', with: '29'
+      fill_in 'actual_completion_date_month', with: '7'
+      fill_in 'actual_completion_date_year', with: '2020'
+      click_on(I18n.t('button.update.defect'))
+    end
+
+    expect(page).to have_content(I18n.t('generic.notice.update.success', resource: 'defect'))
+    expect(page).to have_content('29 July 2020')
+  end
+
+  scenario 'attempting to update the actual completion date before completion' do
+    defect = create(:communal_defect, communal_area: communal_area, status: :outstanding)
+
+    visit edit_communal_area_defect_path(defect.communal_area, defect)
+
+    within('form.edit_defect') do
+      expect(page).to_not have_field 'actual_completion_date[day]'
+      expect(page).to_not have_field 'actual_completion_date[month]'
+      expect(page).to_not have_field 'actual_completion_date[year]'
+    end
+  end
 end

--- a/spec/features/staff_can_update_a_property_defect_spec.rb
+++ b/spec/features/staff_can_update_a_property_defect_spec.rb
@@ -179,4 +179,32 @@ RSpec.feature 'Staff can update a defect' do
     expect(page).to have_content(I18n.t('generic.notice.update.success', resource: 'defect'))
     expect(page).to have_content('28 July 2020')
   end
+
+  scenario 'updating the actual completion date' do
+    defect = create(:property_defect, :completed, property: property)
+
+    visit edit_property_defect_path(defect.property, defect)
+
+    within('form.edit_defect') do
+      fill_in 'actual_completion_date_day', with: '29'
+      fill_in 'actual_completion_date_month', with: '7'
+      fill_in 'actual_completion_date_year', with: '2020'
+      click_on(I18n.t('button.update.defect'))
+    end
+
+    expect(page).to have_content(I18n.t('generic.notice.update.success', resource: 'defect'))
+    expect(page).to have_content('29 July 2020')
+  end
+
+  scenario 'attempting to update the actual completion date before completion' do
+    defect = create(:property_defect, property: property, status: :outstanding)
+
+    visit edit_property_defect_path(defect.property, defect)
+
+    within('form.edit_defect') do
+      expect(page).to_not have_field 'actual_completion_date[day]'
+      expect(page).to_not have_field 'actual_completion_date[month]'
+      expect(page).to_not have_field 'actual_completion_date[year]'
+    end
+  end
 end


### PR DESCRIPTION
Previously, we only allowed the actual completion date to be filled in
immediately after setting a defect's status to 'completed'.

Because users need to adjust this after the fact, allow it to be edited
in the standard 'edit defect' form once it contains a value.

## Screenshots of UI changes:

### After

![Screenshot 2019-08-23 at 12 02 26](https://user-images.githubusercontent.com/3166/63588240-edb35100-c59d-11e9-8573-7dc094da44a2.png)

