### PR TITLE
Change position of 'actual completion date' field

### DIFF
--- a/app/views/staff/communal_defects/edit.html.haml
+++ b/app/views/staff/communal_defects/edit.html.haml
@@ -42,6 +42,14 @@
                   required: true,
                   label_method: ->(obj){ status_form_label(option_array: obj) },
                   value_method: :first
+      - if @defect.actual_completion_date.present?
+        .existing-priority-information
+          %label.govuk-label
+            %span Actual completion date
+            %p.govuk-inset-text= @defect.actual_completion_date
+
+          = render partial: 'shared/defects/date_fields', locals: { name: 'actual_completion_date', date: nil }
+
       .existing-priority-information
         %label.govuk-label
           %span Priority status
@@ -65,13 +73,5 @@
       %p Or, set a different target completion date:
 
       = render partial: 'shared/defects/date_fields', locals: { name: 'target_completion_date', date: nil }
-
-      - if @defect.actual_completion_date.present?
-        .existing-priority-information
-          %label.govuk-label
-            %span Actual completion date
-            %p.govuk-inset-text= @defect.actual_completion_date
-
-          = render partial: 'shared/defects/date_fields', locals: { name: 'actual_completion_date', date: nil }
 
       = f.button :submit, I18n.t('button.update.defect')

--- a/app/views/staff/property_defects/edit.html.haml
+++ b/app/views/staff/property_defects/edit.html.haml
@@ -37,6 +37,16 @@
                   required: true,
                   label_method: ->(obj){ status_form_label(option_array: obj) },
                   value_method: :first
+
+      - if @defect.actual_completion_date.present?
+        .existing-priority-information
+          %label.govuk-label
+            %span Actual completion date
+            %p.govuk-inset-text= @defect.actual_completion_date
+
+          = render partial: 'shared/defects/date_fields', locals: { name: 'actual_completion_date', date: nil }
+
+
       .existing-priority-information
         %label.govuk-label
           %span Priority status
@@ -60,14 +70,5 @@
       %p Or, set a different target completion date:
 
       = render partial: 'shared/defects/date_fields', locals: { name: 'target_completion_date', date: nil }
-
-      - if @defect.actual_completion_date.present?
-        .existing-priority-information
-          %label.govuk-label
-            %span Actual completion date
-            %p.govuk-inset-text= @defect.actual_completion_date
-
-          = render partial: 'shared/defects/date_fields', locals: { name: 'actual_completion_date', date: nil }
-
 
       = f.button :submit, I18n.t('button.update.defect')


### PR DESCRIPTION
It was decided that it was too low, so move it to just under 'status'

## Before

![Screenshot 2019-08-23 at 12 02 26](https://user-images.githubusercontent.com/3166/63756760-d1baf280-c8b0-11e9-8c2b-e31d1e8d646b.png)

## After

<img width="430" alt="Screenshot 2019-08-27 at 09 53 57" src="https://user-images.githubusercontent.com/3166/63756750-cc5da800-c8b0-11e9-8b83-97ffe4d200b5.png">

