### PR TITLE
Make actual completion date editable on all completed defects

### DIFF
--- a/app/views/staff/communal_defects/edit.html.haml
+++ b/app/views/staff/communal_defects/edit.html.haml
@@ -42,15 +42,13 @@
                   required: true,
                   label_method: ->(obj){ status_form_label(option_array: obj) },
                   value_method: :first
-      - if @defect.actual_completion_date.present?
-        .existing-priority-information
+
+      .existing-priority-information
+        - if @defect.status.downcase == 'completed'
           %label.govuk-label
             %span Actual completion date
             %p.govuk-inset-text= @defect.actual_completion_date
-
           = render partial: 'shared/defects/date_fields', locals: { name: 'actual_completion_date', date: nil }
-
-      .existing-priority-information
         %label.govuk-label
           %span Priority status
           %p.govuk-inset-text= @defect.priority.name

--- a/app/views/staff/property_defects/edit.html.haml
+++ b/app/views/staff/property_defects/edit.html.haml
@@ -38,16 +38,12 @@
                   label_method: ->(obj){ status_form_label(option_array: obj) },
                   value_method: :first
 
-      - if @defect.actual_completion_date.present?
-        .existing-priority-information
+      .existing-priority-information
+        - if @defect.status.downcase == 'completed'
           %label.govuk-label
             %span Actual completion date
             %p.govuk-inset-text= @defect.actual_completion_date
-
           = render partial: 'shared/defects/date_fields', locals: { name: 'actual_completion_date', date: nil }
-
-
-      .existing-priority-information
         %label.govuk-label
           %span Priority status
           %p.govuk-inset-text= @defect.priority.name

--- a/spec/features/staff_can_update_a_communal_defect_spec.rb
+++ b/spec/features/staff_can_update_a_communal_defect_spec.rb
@@ -162,6 +162,22 @@ RSpec.feature 'Staff can update a communal_area defect' do
     expect(page).to have_content('29 July 2020')
   end
 
+  scenario 'adding an actual completion date after completion' do
+    defect = create(:communal_defect, :completed, communal_area: communal_area, actual_completion_date: nil)
+
+    visit edit_communal_area_defect_path(defect.communal_area, defect)
+
+    within('form.edit_defect') do
+      fill_in 'actual_completion_date_day', with: '29'
+      fill_in 'actual_completion_date_month', with: '7'
+      fill_in 'actual_completion_date_year', with: '2020'
+      click_on(I18n.t('button.update.defect'))
+    end
+
+    expect(page).to have_content(I18n.t('generic.notice.update.success', resource: 'defect'))
+    expect(page).to have_content('29 July 2020')
+  end
+
   scenario 'attempting to update the actual completion date before completion' do
     defect = create(:communal_defect, communal_area: communal_area, status: :outstanding)
 

--- a/spec/features/staff_can_update_a_property_defect_spec.rb
+++ b/spec/features/staff_can_update_a_property_defect_spec.rb
@@ -180,6 +180,22 @@ RSpec.feature 'Staff can update a defect' do
     expect(page).to have_content('28 July 2020')
   end
 
+  scenario 'adding an actual completion date after completion' do
+    defect = create(:property_defect, :completed, property: property, actual_completion_date: nil)
+
+    visit edit_property_defect_path(defect.property, defect)
+
+    within('form.edit_defect') do
+      fill_in 'actual_completion_date_day', with: '29'
+      fill_in 'actual_completion_date_month', with: '7'
+      fill_in 'actual_completion_date_year', with: '2020'
+      click_on(I18n.t('button.update.defect'))
+    end
+
+    expect(page).to have_content(I18n.t('generic.notice.update.success', resource: 'defect'))
+    expect(page).to have_content('29 July 2020')
+  end
+
   scenario 'updating the actual completion date' do
     defect = create(:property_defect, :completed, property: property)
 


### PR DESCRIPTION
This allows retroactively setting them for defects without actual completion dates set.
