### PR TITLE
Fixes mismatches between lists of trades

### DIFF
--- a/app/models/defect.rb
+++ b/app/models/defect.rb
@@ -117,38 +117,12 @@ class Defect < ApplicationRecord
     'Roof work',
   ].freeze
 
-  TRADES = [
-    'Blinds',
-    'Boiler work',
-    'Brickwork',
-    'Carpentry',
-    'Carpentry/Doors',
-    'Connectivity',
-    'Cosmetic',
-    'Damp',
-    'Decoration',
-    'Door work',
-    'Drainage',
-    'Electrical',
-    'Electrical/Mechanical',
-    'Fan/Ventilation',
-    'Filters',
-    'Fire Safety',
-    'Floor work',
-    'Heating',
-    'Intercoms/Entry Phones',
-    'Lifts',
-    'Lighting',
-    'Mastic',
-    'Metal work',
-    'MVHR',
-    'Plastering',
-    'Plumbing',
-    'Roof work',
-    'Tile work',
-    'Water Temperature/Supply',
-    'Window Work',
-  ].freeze
+  TRADES = (
+    PLUMBING_TRADES +
+    ELECTRICAL_TRADES +
+    CARPENTRY_TRADES +
+    COSMETIC_TRADES
+  ).sort.uniq.freeze
 
   CATEGORIES = {
     'Plumbing' => PLUMBING_TRADES,

--- a/app/models/defect.rb
+++ b/app/models/defect.rb
@@ -78,30 +78,30 @@ class Defect < ApplicationRecord
   PLUMBING_TRADES = [
     'Plumbing',
     'Drainage',
-    'Water temp / supply',
+    'Water Temperature/Supply',
   ].freeze
 
   ELECTRICAL_TRADES = [
     'Electrical',
+    'Electrical/Mechanical',
     'Connectivity',
     'Lighting',
     'Boiler work',
     'MVHR',
-    'Fan / Ventilation',
-    'Fire safety',
+    'Fan/Ventilation',
+    'Fire Safety',
     'Lifts',
     'Heating',
-    'Intercoms / Entry Phones',
+    'Intercoms/Entry Phones',
     'Filters',
   ].freeze
 
   CARPENTRY_TRADES = [
     'Carpentry',
+    'Carpentry/Doors',
     'Door work',
-    'Window work',
+    'Window Work',
     'Metal work',
-    'Locks',
-    'Adapted bathrooms',
   ].freeze
 
   COSMETIC_TRADES = [
@@ -114,7 +114,7 @@ class Defect < ApplicationRecord
     'Plastering',
     'Blinds',
     'Brickwork',
-    'Roof',
+    'Roof work',
   ].freeze
 
   TRADES = [

--- a/spec/models/defect_spec.rb
+++ b/spec/models/defect_spec.rb
@@ -320,4 +320,17 @@ RSpec.describe Defect, type: :model do
       end
     end
   end
+
+  describe '::TRADES' do
+    it 'includes all the trades, and only those trades, that are in the trades-by-category lists' do
+      expect(Defect::TRADES.sort).to eq(
+        (
+          Defect::ELECTRICAL_TRADES +
+          Defect::PLUMBING_TRADES +
+          Defect::CARPENTRY_TRADES +
+          Defect::COSMETIC_TRADES
+        ).sort
+      )
+    end
+  end
 end

--- a/spec/models/defect_spec.rb
+++ b/spec/models/defect_spec.rb
@@ -322,15 +322,21 @@ RSpec.describe Defect, type: :model do
   end
 
   describe '::TRADES' do
-    it 'includes all the trades, and only those trades, that are in the trades-by-category lists' do
-      expect(Defect::TRADES.sort).to eq(
-        (
-          Defect::ELECTRICAL_TRADES +
-          Defect::PLUMBING_TRADES +
-          Defect::CARPENTRY_TRADES +
-          Defect::COSMETIC_TRADES
-        ).sort
-      )
+    it 'includes all the trades, and only those trades, that are in trades by category' do
+      expect(
+        Defect::ELECTRICAL_TRADES +
+        Defect::PLUMBING_TRADES +
+        Defect::CARPENTRY_TRADES +
+        Defect::COSMETIC_TRADES
+      ).to match_array(Defect::TRADES)
+    end
+
+    it 'does not have duplicates' do
+      expect(Defect::TRADES).to eq(Defect::TRADES.uniq)
+    end
+
+    it 'is sorted alphabetically' do
+      expect(Defect::TRADES).to eq(Defect::TRADES.sort)
     end
   end
 end


### PR DESCRIPTION
Solves https://dxw.zendesk.com/agent/tickets/10096

## Changes in this PR:

Previously, the trade names listed in the trades-by-category arrays were out of sync with the aggregated list of all trades.

Source for TRADES: https://trello.com/c/hO8pC4gH/19-data-get-trades-list-for-defects-and-types

Source for trades by category: https://trello.com/c/4v3uUoVd/155-add-categories-as-parent-level-to-trades-to-support-reporting

We are using the list in `Defect::TRADES` as the canonical list because it is the list used to create new defects.

There are no existing defects, open or closed, using the mistyped strings.

## Screenshots of UI changes:
N/A
