### PR TITLE
Uses "Date created" in place of "Created on"

### DIFF
--- a/app/views/shared/defects/_summary_information.html.haml
+++ b/app/views/shared/defects/_summary_information.html.haml
@@ -8,7 +8,7 @@
     %dt.govuk-summary-list__key Status
     %dd.govuk-summary-list__value= defect.status
   %div.govuk-summary-list__row
-    %dt.govuk-summary-list__key Created on
+    %dt.govuk-summary-list__key= I18n.t('generic.label.created_date')
     %dd.govuk-summary-list__value= defect.created_at
   %div.govuk-summary-list__row
     %dt.govuk-summary-list__key Target date

--- a/app/views/shared/defects/_table.html.haml
+++ b/app/views/shared/defects/_table.html.haml
@@ -10,7 +10,7 @@
       %th.govuk-table__header
         Priority
       %th.govuk-table__header
-        Created on
+        = I18n.t('generic.label.created_date')
       %th.govuk-table__header
         Target completion date
       %th.govuk-table__header

--- a/app/views/staff/communal_defects/edit.html.haml
+++ b/app/views/staff/communal_defects/edit.html.haml
@@ -14,7 +14,7 @@
       .govuk-form-group
         .govuk-form-group
           %label.govuk-label.govuk-label{for: 'created_at_day'}
-            = 'Created On'
+            = I18n.t('generic.label.created_date')
           = render partial: 'shared/defects/date_fields', locals: { name: 'created_at', date: Time.zone.now }
 
         = f.input :title,

--- a/app/views/staff/communal_defects/new.html.haml
+++ b/app/views/staff/communal_defects/new.html.haml
@@ -12,7 +12,7 @@
       .govuk-form-group
         .govuk-form-group
           %label.govuk-label.govuk-label{for: 'created_at_day'}
-            = 'Created On'
+            = I18n.t('generic.label.created_date')
           = render partial: 'shared/defects/date_fields', locals: { name: 'created_at', date: Time.zone.now }
 
         = f.input :title,

--- a/app/views/staff/defects/index.html.haml
+++ b/app/views/staff/defects/index.html.haml
@@ -52,7 +52,7 @@
             %th.govuk-table__header{scope:'col', class: 'govuk-!-width-one-third'}
               Defect reference and name
             %th.govuk-table__header{scope:'col'}
-              Created on
+              = I18n.t('generic.label.created_date')
             %th.govuk-table__header{scope:'col'}
               Due by
             %th.govuk-table__header{scope:'col'}

--- a/app/views/staff/property_defects/edit.html.haml
+++ b/app/views/staff/property_defects/edit.html.haml
@@ -14,7 +14,7 @@
       .govuk-form-group
         .govuk-form-group
           %label.govuk-label.govuk-label{for: 'created_at_day'}
-            = 'Created On'
+            = I18n.t('generic.label.created_date')
           = render partial: 'shared/defects/date_fields', locals: { name: 'created_at', date: Time.zone.now }
 
         = f.input :title,

--- a/app/views/staff/property_defects/new.html.haml
+++ b/app/views/staff/property_defects/new.html.haml
@@ -12,7 +12,7 @@
       .govuk-form-group
         .govuk-form-group
           %label.govuk-label.govuk-label{for: 'created_at_day'}
-            = 'Created On'
+            = I18n.t('generic.label.created_date')
           = render partial: 'shared/defects/date_fields', locals: { name: 'created_at', date: Time.zone.now }
 
         = f.input :title,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -104,6 +104,8 @@ en:
       update:
         success:
           'The %{resource} has successfully been updated.'
+    label:
+      created_date: 'Date created'
   button:
     report:
       download_all: Download all defect data


### PR DESCRIPTION
We had hardcoded this in a few places, I've taken this chance to put this wording into our i18n file.

This change does not impact the labelling we use within the app, we are still referencing the `created_at` field via a date Presenter.

## Screenshots of UI changes:

<details>
<summary>Example of "Date created" being shown in tables</summary>

![Screenshot 2019-11-21 at 10 46 53](https://user-images.githubusercontent.com/456902/69331252-5ae18b80-0c4c-11ea-9c8b-7afcd9dbf8b3.png)

</details>
<details>
<summary>Example of "Date created" being shown in lists</summary>

![Screenshot 2019-11-21 at 10 46 44](https://user-images.githubusercontent.com/456902/69331254-5ae18b80-0c4c-11ea-8dfd-0ad909ea6e99.png)

</details>

<details>
<summary>Example of "Date created" being shown in forms</summary>

![Screenshot 2019-11-21 at 10 46 37](https://user-images.githubusercontent.com/456902/69331255-5b7a2200-0c4c-11ea-9d05-a8b0dca02e69.png)

</details>

