### PR TITLE
Combined reporting

### DIFF
--- a/app/controllers/staff/report_controller.rb
+++ b/app/controllers/staff/report_controller.rb
@@ -35,7 +35,7 @@ class Staff::ReportController < Staff::BaseController
   end
 
   def scheme_ids
-    @scheme_ids ||= params[:schemes] || Scheme.within_14_months.pluck(:id)
+    @scheme_ids ||= params[:schemes] || Scheme.recent.pluck(:id)
   end
 
   def from_date
@@ -43,7 +43,7 @@ class Staff::ReportController < Staff::BaseController
   end
 
   def combined_from_date
-    date_param(:from_date, 14.months.ago)
+    date_param(:from_date, Scheme::REPORT_MONTHS.months.ago)
   end
 
   def to_date

--- a/app/controllers/staff/report_controller.rb
+++ b/app/controllers/staff/report_controller.rb
@@ -4,6 +4,9 @@ class Staff::ReportController < Staff::BaseController
   def index
     filter = DefectFilter.new(statuses: %i[open closed])
     @defects = DefectFinder.new(filter: filter).call
+    @report_form = ReportForm.new(from_date: combined_from_date, to_date: to_date)
+    @scheme_list = Scheme.all.order(:name)
+    @presenter = CombinedReportPresenter.new(schemes: schemes, report_form: @report_form)
 
     respond_to do |format|
       format.html
@@ -27,8 +30,20 @@ class Staff::ReportController < Staff::BaseController
     params[:id]
   end
 
+  def schemes
+    @schemes || Scheme.find(scheme_ids)
+  end
+
+  def scheme_ids
+    @scheme_ids ||= params[:schemes] || Scheme.within_14_months.pluck(:id)
+  end
+
   def from_date
     date_param(:from_date, scheme.created_at)
+  end
+
+  def combined_from_date
+    date_param(:from_date, 14.months.ago)
   end
 
   def to_date

--- a/app/controllers/staff/schemes_controller.rb
+++ b/app/controllers/staff/schemes_controller.rb
@@ -7,6 +7,7 @@ class Staff::SchemesController < Staff::BaseController
   def create
     @estate = Estate.find(estate_id)
     @scheme = Scheme.new(scheme_params)
+    @scheme.set_start_date(start_date)
     @scheme.estate = @estate
 
     if @scheme.valid?
@@ -29,6 +30,7 @@ class Staff::SchemesController < Staff::BaseController
   def update
     @scheme = Scheme.find(scheme_id)
     @scheme.assign_attributes(scheme_params)
+    @scheme.set_start_date(start_date)
 
     if @scheme.valid?
       @scheme.save
@@ -47,6 +49,10 @@ class Staff::SchemesController < Staff::BaseController
 
   def scheme_id
     params[:id]
+  end
+
+  def start_date
+    params.fetch(:start_date, {}).permit(:day, :month, :year)
   end
 
   def scheme_params

--- a/app/form_objects/report_form.rb
+++ b/app/form_objects/report_form.rb
@@ -6,4 +6,8 @@ class ReportForm
     self.from_date = from_date.to_date
     self.to_date = to_date.to_date
   end
+
+  def date_range
+    (from_date.beginning_of_day)..(to_date.end_of_day)
+  end
 end

--- a/app/models/scheme.rb
+++ b/app/models/scheme.rb
@@ -17,4 +17,13 @@ class Scheme < ApplicationRecord
 
   include PublicActivity::Model
   tracked owner: ->(controller, _) { controller.current_user if controller }
+
+  def set_start_date(date)
+    date_parts = date.values_at(:day, :month, :year)
+    return unless date_parts.all?(&:present?)
+
+    day, month, year = date_parts.map(&:to_i)
+    date = Date.new(year, month, day)
+    self.start_date = date
+  end
 end

--- a/app/models/scheme.rb
+++ b/app/models/scheme.rb
@@ -15,6 +15,8 @@ class Scheme < ApplicationRecord
             format: { with: URI::MailTo::EMAIL_REGEXP },
             allow_blank: true
 
+  scope :within_14_months, (-> { where(start_date: [14.months.ago..Time.zone.now]) })
+
   include PublicActivity::Model
   tracked owner: ->(controller, _) { controller.current_user if controller }
 

--- a/app/models/scheme.rb
+++ b/app/models/scheme.rb
@@ -23,11 +23,7 @@ class Scheme < ApplicationRecord
   tracked owner: ->(controller, _) { controller.current_user if controller }
 
   def set_start_date(date)
-    date_parts = date.values_at(:day, :month, :year)
-    return unless date_parts.all?(&:present?)
-
-    day, month, year = date_parts.map(&:to_i)
-    date = Date.new(year, month, day)
-    self.start_date = date
+    date = BuildDate.new(date).call
+    self.start_date = date if date.present?
   end
 end

--- a/app/models/scheme.rb
+++ b/app/models/scheme.rb
@@ -1,4 +1,6 @@
 class Scheme < ApplicationRecord
+  REPORT_MONTHS = 14
+
   has_many :priorities, dependent: :destroy
   has_many :communal_areas, dependent: :destroy
   has_many :properties, dependent: :destroy
@@ -15,7 +17,7 @@ class Scheme < ApplicationRecord
             format: { with: URI::MailTo::EMAIL_REGEXP },
             allow_blank: true
 
-  scope :within_14_months, (-> { where(start_date: [14.months.ago..Time.zone.now]) })
+  scope :recent, (-> { where(start_date: [REPORT_MONTHS.months.ago..Time.zone.now]) })
 
   include PublicActivity::Model
   tracked owner: ->(controller, _) { controller.current_user if controller }

--- a/app/presenters/combined_report_presenter.rb
+++ b/app/presenters/combined_report_presenter.rb
@@ -15,9 +15,8 @@ class CombinedReportPresenter < ReportPresenter
 
   def defects_by_priority(priority:)
     priorities = Priority.joins(:scheme)
-                         .where('schemes.id IN (?) AND priorities.name = ?',
-                                schemes.pluck(:id),
-                                priority)
+                         .where(schemes: { id: schemes.pluck(:id) })
+                         .where(priorities: { name: priority })
     defects.for_priorities(priorities)
   end
 

--- a/app/presenters/combined_report_presenter.rb
+++ b/app/presenters/combined_report_presenter.rb
@@ -1,0 +1,27 @@
+class CombinedReportPresenter < ReportPresenter
+  def initialize(schemes: [],
+                 report_form: ReportForm.new(from_date: 14.months.ago, to_date: Date.current))
+    self.schemes = schemes
+    self.report_form = report_form
+  end
+
+  def defects
+    @defects ||= Defect.for_scheme(schemes.pluck(:id))
+                       .where(
+                         'created_at >= ? and created_at <= ?',
+                         report_form.from_date.beginning_of_day, report_form.to_date.end_of_day
+                       )
+  end
+
+  def defects_by_priority(priority:)
+    priorities = Priority.joins(:scheme)
+                         .where('schemes.id IN (?) AND priorities.name = ?',
+                                schemes.pluck(:id),
+                                priority)
+    defects.for_priorities(priorities)
+  end
+
+  def priorities
+    Priority.group(:name).pluck(:name).sort
+  end
+end

--- a/app/presenters/combined_report_presenter.rb
+++ b/app/presenters/combined_report_presenter.rb
@@ -7,10 +7,7 @@ class CombinedReportPresenter < ReportPresenter
 
   def defects
     @defects ||= Defect.for_scheme(schemes.pluck(:id))
-                       .where(
-                         'created_at >= ? and created_at <= ?',
-                         report_form.from_date.beginning_of_day, report_form.to_date.end_of_day
-                       )
+                       .where(created_at: report_form.date_range)
   end
 
   def defects_by_priority(priority:)

--- a/app/presenters/combined_report_presenter.rb
+++ b/app/presenters/combined_report_presenter.rb
@@ -1,6 +1,7 @@
 class CombinedReportPresenter < ReportPresenter
   def initialize(schemes: [],
-                 report_form: ReportForm.new(from_date: 14.months.ago, to_date: Date.current))
+                 report_form: ReportForm.new(from_date: Scheme::REPORT_MONTHS.months.ago,
+                                             to_date: Date.current))
     self.schemes = schemes
     self.report_form = report_form
   end

--- a/app/presenters/combined_report_presenter.rb
+++ b/app/presenters/combined_report_presenter.rb
@@ -20,4 +20,8 @@ class CombinedReportPresenter < ReportPresenter
   def priorities
     Priority.group(:name).pluck(:name).sort
   end
+
+  def priorities_with_defects
+    priorities.select { |priority| defects_by_priority(priority: priority).any? }
+  end
 end

--- a/app/presenters/report_presenter.rb
+++ b/app/presenters/report_presenter.rb
@@ -1,0 +1,68 @@
+class ReportPresenter
+  attr_accessor :schemes, :report_form
+
+  def date_range
+    "From #{report_form.from_date} to #{report_form.to_date}"
+  end
+
+  def defects_by_status(text:)
+    defects.where(status: text)
+  end
+
+  def defects_by_category(category:)
+    trade_names = Defect::CATEGORIES[category]
+    defects.for_trades(trade_names)
+  end
+
+  def category_percentage(category:)
+    percentage_for(
+      number: Float(defects_by_category(category: category).count),
+      total: Float(defects.count)
+    )
+  end
+
+  def priority_percentage(priority:)
+    percentage_for(
+      number: Float(defects_by_priority(priority: priority).count),
+      total: Float(defects.count)
+    )
+  end
+
+  def due_defects_by_priority(priority:)
+    defects = defects_by_priority(priority: priority)
+    defects.where('target_completion_date >= ?', Date.current)
+  end
+
+  def overdue_defects_by_priority(priority:)
+    defects = defects_by_priority(priority: priority)
+    defects.where('target_completion_date < ?', Date.current)
+  end
+
+  def defects_completed_on_time(priority:)
+    completed_defects(priority: priority).select do |completed_defect|
+      completed_defect_activities = completed_defect.activities.where(key: 'defect.update')
+      activities_on_time = completed_defect_activities.select do |activity|
+        activity.created_at.to_date <= completed_defect.target_completion_date
+      end
+
+      # TODO: Query parameter JSON at database level rather than in Ruby
+      true if activities_on_time.detect do |update_activity|
+        update_activity.parameters &&
+        update_activity.parameters[:changes] &&
+        update_activity.parameters[:changes][:status]&.last == 'completed'
+      end
+    end
+  end
+
+  private
+
+  def percentage_for(number:, total:)
+    return '0.0%' if number.zero? || total.zero?
+    percentage = (number / total) * 100
+    "#{percentage.round(2)}%"
+  end
+
+  def completed_defects(priority:)
+    defects_by_priority(priority: priority).completed
+  end
+end

--- a/app/presenters/report_presenter.rb
+++ b/app/presenters/report_presenter.rb
@@ -23,8 +23,8 @@ class ReportPresenter
 
   def priority_percentage(priority:)
     percentage_for(
-      number: Float(defects_by_priority(priority: priority).count),
-      total: Float(defects.count)
+      number: Float(defects_completed_on_time(priority: priority).count),
+      total: Float(defects_by_priority(priority: priority).count)
     )
   end
 

--- a/app/presenters/scheme_report_presenter.rb
+++ b/app/presenters/scheme_report_presenter.rb
@@ -1,7 +1,6 @@
-class SchemeReportPresenter
+class SchemeReportPresenter < ReportPresenter
+  attr_accessor :scheme
   delegate :name, to: :scheme
-
-  attr_accessor :scheme, :report_form
 
   def initialize(scheme:,
                  report_form: ReportForm.new(from_date: scheme.created_at, to_date: Date.current))
@@ -17,72 +16,7 @@ class SchemeReportPresenter
                        )
   end
 
-  def date_range
-    "From #{report_form.from_date} to #{report_form.to_date}"
-  end
-
-  def defects_by_status(text:)
-    defects.where(status: text)
-  end
-
-  def defects_by_category(category:)
-    trade_names = Defect::CATEGORIES[category]
-    defects.for_trades(trade_names)
-  end
-
-  def category_percentage(category:)
-    percentage_for(
-      number: Float(defects_by_category(category: category).count),
-      total: Float(defects.count)
-    )
-  end
-
   def defects_by_priority(priority:)
     defects.for_priorities([priority.id])
-  end
-
-  def priority_percentage(priority:)
-    percentage_for(
-      number: Float(defects_by_priority(priority: priority).count),
-      total: Float(defects.count)
-    )
-  end
-
-  def due_defects_by_priority(priority:)
-    defects = defects_by_priority(priority: priority)
-    defects.where('target_completion_date >= ?', Date.current)
-  end
-
-  def overdue_defects_by_priority(priority:)
-    defects = defects_by_priority(priority: priority)
-    defects.where('target_completion_date < ?', Date.current)
-  end
-
-  def defects_completed_on_time(priority:)
-    completed_defects(priority: priority).select do |completed_defect|
-      completed_defect_activities = completed_defect.activities.where(key: 'defect.update')
-      activities_on_time = completed_defect_activities.select do |activity|
-        activity.created_at.to_date <= completed_defect.target_completion_date
-      end
-
-      # TODO: Query parameter JSON at database level rather than in Ruby
-      true if activities_on_time.detect do |update_activity|
-        update_activity.parameters &&
-        update_activity.parameters[:changes] &&
-        update_activity.parameters[:changes][:status]&.last == 'completed'
-      end
-    end
-  end
-
-  private
-
-  def percentage_for(number:, total:)
-    return '0.0%' if number.zero? || total.zero?
-    percentage = (number / total) * 100
-    "#{percentage.round(2)}%"
-  end
-
-  def completed_defects(priority:)
-    defects_by_priority(priority: priority).completed
   end
 end

--- a/app/presenters/scheme_report_presenter.rb
+++ b/app/presenters/scheme_report_presenter.rb
@@ -10,10 +10,7 @@ class SchemeReportPresenter < ReportPresenter
 
   def defects
     @defects ||= Defect.for_scheme([scheme.id])
-                       .where(
-                         'created_at >= ? and created_at <= ?',
-                         report_form.from_date.beginning_of_day, report_form.to_date.end_of_day
-                       )
+                       .where(created_at: report_form.date_range)
   end
 
   def defects_by_priority(priority:)

--- a/app/services/build_date.rb
+++ b/app/services/build_date.rb
@@ -1,0 +1,15 @@
+class BuildDate
+  attr_accessor :date
+
+  def initialize(date)
+    self.date = date
+  end
+
+  def call
+    date_parts = date.values_at(:day, :month, :year)
+    return unless date_parts.all?(&:present?)
+
+    day, month, year = date_parts.map(&:to_i)
+    Date.new(year, month, day)
+  end
+end

--- a/app/services/defect_builder.rb
+++ b/app/services/defect_builder.rb
@@ -7,11 +7,7 @@ class DefectBuilder
   private
 
   def set_created_at
-    date_parts = created_at.values_at(:day, :month, :year)
-    return unless date_parts.all?(&:present?)
-
-    day, month, year = date_parts.map(&:to_i)
-    date = Date.new(year, month, day)
-    defect.set_created_at(date)
+    date = BuildDate.new(created_at).call
+    defect.set_created_at(date) if date.present?
   end
 end

--- a/app/services/edit_defect.rb
+++ b/app/services/edit_defect.rb
@@ -30,20 +30,12 @@ class EditDefect < DefectBuilder
   private
 
   def set_target_completion_date
-    date_parts = target_completion_date.values_at(:day, :month, :year)
-    return unless date_parts.all?(&:present?)
-
-    day, month, year = date_parts.map(&:to_i)
-    date = Date.new(year, month, day)
-    defect.set_target_completion_date(date)
+    date = BuildDate.new(target_completion_date).call
+    defect.set_target_completion_date(date) if date.present?
   end
 
   def set_actual_completion_date
-    date_parts = actual_completion_date.values_at(:day, :month, :year)
-    return unless date_parts.all?(&:present?)
-
-    day, month, year = date_parts.map(&:to_i)
-    date = Date.new(year, month, day)
-    defect.set_actual_completion_date(date)
+    date = BuildDate.new(actual_completion_date).call
+    defect.set_actual_completion_date(date) if date.present?
   end
 end

--- a/app/views/staff/dashboard/index.html.haml
+++ b/app/views/staff/dashboard/index.html.haml
@@ -3,7 +3,7 @@
 .govuk-grid-row
   .govuk-grid-column-two-thirds
     %h1.govuk-heading-xl= I18n.t('page_title.staff.dashboard')
-    
+
     %h3.govuk-heading-m
       = I18n.t('page_content.dashboard.header.find_defect')
     %p.govuk-body-s
@@ -48,6 +48,7 @@
           %tr.govuk-table__row
             %td.govuk-table__cell= scheme.name
             %td.govuk-table__cell= link_to(I18n.t('generic.link.show'), report_scheme_path(scheme), class: 'govuk-link')
+    = link_to(I18n.t('button.report.view_combined'), report_path, class: 'govuk-button')
 
   .govuk-grid-column-one-third
     %h2.govuk-heading-m

--- a/app/views/staff/report/_combined_priorities.html.haml
+++ b/app/views/staff/report/_combined_priorities.html.haml
@@ -16,6 +16,7 @@
         Percentage completed on time
   %tbody.govuk-table__body
     - presenter.priorities.each do |priority|
+      - next if presenter.defects_by_priority(priority: priority).count < 1
       %tr.govuk-table__row
         %td.govuk-table__cell= priority
         %td.govuk-table__cell= presenter.due_defects_by_priority(priority: priority).count

--- a/app/views/staff/report/_combined_priorities.html.haml
+++ b/app/views/staff/report/_combined_priorities.html.haml
@@ -1,0 +1,25 @@
+%h1.govuk-heading-m.section-heading Priorities
+%table.govuk-table.priorities
+  %thead.govuk-table__head
+    %tr.govuk-table__row
+      %th.govuk-table__header
+        Code
+      %th.govuk-table__header
+        Percentage
+      %th.govuk-table__header
+        Due
+      %th.govuk-table__header
+        Overdue
+      %th.govuk-table__header
+        Total
+      %th.govuk-table__header
+        Completed on time
+  %tbody.govuk-table__body
+    - presenter.priorities.each do |priority|
+      %tr.govuk-table__row
+        %td.govuk-table__cell= priority
+        %td.govuk-table__cell= presenter.priority_percentage(priority: priority)
+        %td.govuk-table__cell= presenter.due_defects_by_priority(priority: priority).count
+        %td.govuk-table__cell= presenter.overdue_defects_by_priority(priority: priority).count
+        %td.govuk-table__cell= presenter.defects_by_priority(priority: priority).count
+        %td.govuk-table__cell= presenter.defects_completed_on_time(priority: priority).count

--- a/app/views/staff/report/_combined_priorities.html.haml
+++ b/app/views/staff/report/_combined_priorities.html.haml
@@ -15,8 +15,7 @@
       %th.govuk-table__header
         Percentage completed on time
   %tbody.govuk-table__body
-    - presenter.priorities.each do |priority|
-      - next if presenter.defects_by_priority(priority: priority).count < 1
+    - presenter.priorities_with_defects.each do |priority|
       %tr.govuk-table__row
         %td.govuk-table__cell= priority
         %td.govuk-table__cell= presenter.due_defects_by_priority(priority: priority).count

--- a/app/views/staff/report/_combined_priorities.html.haml
+++ b/app/views/staff/report/_combined_priorities.html.haml
@@ -5,8 +5,6 @@
       %th.govuk-table__header
         Code
       %th.govuk-table__header
-        Percentage
-      %th.govuk-table__header
         Due
       %th.govuk-table__header
         Overdue
@@ -14,12 +12,14 @@
         Total
       %th.govuk-table__header
         Completed on time
+      %th.govuk-table__header
+        Percentage completed on time
   %tbody.govuk-table__body
     - presenter.priorities.each do |priority|
       %tr.govuk-table__row
         %td.govuk-table__cell= priority
-        %td.govuk-table__cell= presenter.priority_percentage(priority: priority)
         %td.govuk-table__cell= presenter.due_defects_by_priority(priority: priority).count
         %td.govuk-table__cell= presenter.overdue_defects_by_priority(priority: priority).count
         %td.govuk-table__cell= presenter.defects_by_priority(priority: priority).count
         %td.govuk-table__cell= presenter.defects_completed_on_time(priority: priority).count
+        %td.govuk-table__cell= presenter.priority_percentage(priority: priority)

--- a/app/views/staff/report/_priorities.html.haml
+++ b/app/views/staff/report/_priorities.html.haml
@@ -7,8 +7,6 @@
       %th.govuk-table__header
         Days
       %th.govuk-table__header
-        Percentage
-      %th.govuk-table__header
         Due
       %th.govuk-table__header
         Overdue
@@ -16,13 +14,15 @@
         Total
       %th.govuk-table__header
         Completed on time
+      %th.govuk-table__header
+        Percentage completed on time
   %tbody.govuk-table__body
     - presenter.scheme.priorities.each do |priority|
       %tr.govuk-table__row
         %td.govuk-table__cell= priority.name
         %td.govuk-table__cell= priority.days
-        %td.govuk-table__cell= presenter.priority_percentage(priority: priority)
         %td.govuk-table__cell= presenter.due_defects_by_priority(priority: priority).count
         %td.govuk-table__cell= presenter.overdue_defects_by_priority(priority: priority).count
         %td.govuk-table__cell= presenter.defects_by_priority(priority: priority).count
         %td.govuk-table__cell= presenter.defects_completed_on_time(priority: priority).count
+        %td.govuk-table__cell= presenter.priority_percentage(priority: priority)

--- a/app/views/staff/report/_trades.html.haml
+++ b/app/views/staff/report/_trades.html.haml
@@ -5,12 +5,12 @@
       %th.govuk-table__header
         Name
       %th.govuk-table__header
-        Percentage
-      %th.govuk-table__header
         Total
+      %th.govuk-table__header
+        Percentage
   %tbody.govuk-table__body
     - Defect::CATEGORIES.each do |category, trades|
       %tr.govuk-table__row
         %td.govuk-table__cell= category
-        %td.govuk-table__cell= presenter.category_percentage(category: category)
         %td.govuk-table__cell= presenter.defects_by_category(category: category).count
+        %td.govuk-table__cell= presenter.category_percentage(category: category)

--- a/app/views/staff/report/index.html.haml
+++ b/app/views/staff/report/index.html.haml
@@ -1,0 +1,32 @@
+- content_for :page_title_prefix, I18n.t('page_title.staff.reports.index')
+
+.govuk-breadcrumbs
+  %ol.govuk-breadcrumbs__list
+    = breadcrumb_link_to('Home', dashboard_path)
+
+.govuk-grid-row
+  .govuk-grid-column-full
+    %h1.govuk-heading-l
+      = I18n.t('page_title.staff.reports.index')
+      %span.govuk-caption-l= @presenter.date_range
+
+    = form_tag report_path, class: 'date-filter', method: :get do
+      %h2.govuk-heading-m From
+      = render partial: 'shared/defects/date_fields', locals: { name: 'from_date', date: @report_form.from_date }
+      %h2.govuk-heading-m To
+      = render partial: 'shared/defects/date_fields', locals: { name: 'to_date', date: @report_form.to_date }
+      %h2.govuk-heading-m For schemes
+      .govuk-checkboxes.checkbox-group.govuk-checkboxes--small
+      - @scheme_list.each do |scheme|
+        .govuk-checkboxes__item
+          = check_box_tag 'schemes[]', scheme.id, @scheme_ids&.include?(scheme.id), id: scheme.id, class: 'govuk-checkboxes__input'
+          = label_tag 'schemes[]', scheme.name, for: scheme.id, class: 'govuk-label govuk-checkboxes__label'
+      %br
+      = submit_tag 'Apply filters', class: 'govuk-button mb0'
+
+.govuk-grid-row
+  .govuk-grid-column-full
+    = render partial: 'summary', locals: { presenter: @presenter }
+    = render partial: 'statuses', locals: { presenter: @presenter }
+    = render partial: 'trades', locals: { presenter: @presenter }
+    = render partial: 'combined_priorities', locals: { presenter: @presenter }

--- a/app/views/staff/report/index.html.haml
+++ b/app/views/staff/report/index.html.haml
@@ -10,7 +10,7 @@
       = I18n.t('page_title.staff.reports.index')
       %span.govuk-caption-l= @presenter.date_range
 
-    = form_tag report_path, class: 'date-filter', method: :get do
+    = form_tag report_path, class: 'report-filter', method: :get do
       %h2.govuk-heading-m From
       = render partial: 'shared/defects/date_fields', locals: { name: 'from_date', date: @report_form.from_date }
       %h2.govuk-heading-m To

--- a/app/views/staff/schemes/edit.html.haml
+++ b/app/views/staff/schemes/edit.html.haml
@@ -13,4 +13,8 @@
         = f.input :contractor_email_address
         = f.input :employer_agent_name
         = f.input :employer_agent_email_address
+        .govuk-form-group
+          %label.govuk-label.govuk-label{for: 'start_date_day'}
+            Start date
+          = render partial: 'shared/defects/date_fields', locals: { name: 'start_date', date: @scheme.start_date }
       = f.button :submit, I18n.t('button.update.scheme')

--- a/app/views/staff/schemes/new.html.haml
+++ b/app/views/staff/schemes/new.html.haml
@@ -17,4 +17,8 @@
         = f.input :contractor_email_address
         = f.input :employer_agent_name
         = f.input :employer_agent_email_address
+        .govuk-form-group
+          %label.govuk-label.govuk-label{for: 'start_date_day'}
+            Start date
+          = render partial: 'shared/defects/date_fields', locals: { name: 'start_date', date: @scheme.start_date }
       = f.button :submit, I18n.t('button.create.scheme')

--- a/app/views/staff/schemes/show.html.haml
+++ b/app/views/staff/schemes/show.html.haml
@@ -9,6 +9,7 @@
 .govuk-grid-row
   .govuk-grid-column-full
     %h1.govuk-heading-l= I18n.t('page_title.staff.schemes.show', name: @scheme.name)
+    %p.scheme_information.scheme_start_date= "Start date: #{@scheme.start_date}" if @scheme.start_date.present?
     %p.scheme_information.scheme_name_and_estate
       #{I18n.t('page_title.staff.schemes.show', name: @scheme.name)} belongs to #{I18n.t('page_title.staff.estates.show', name: @scheme.estate.name)}
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -16,6 +16,7 @@ en:
     staff:
       dashboard: 'Dashboard'
       reports:
+        index: 'Combined report'
         scheme:
           show: 'Scheme report for %{name}'
       search:
@@ -111,6 +112,7 @@ en:
   button:
     report:
       download_all: Download all defect data
+      view_combined: View combined report
     create:
       estate: 'Create estate'
       scheme: 'Create scheme'

--- a/db/migrate/20191122133859_add_start_date_to_schemes.rb
+++ b/db/migrate/20191122133859_add_start_date_to_schemes.rb
@@ -1,0 +1,5 @@
+class AddStartDateToSchemes < ActiveRecord::Migration[5.2]
+  def change
+    add_column :schemes, :start_date, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_20_160534) do
+ActiveRecord::Schema.define(version: 2019_11_22_133859) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -126,6 +126,7 @@ ActiveRecord::Schema.define(version: 2019_11_20_160534) do
     t.string "contractor_email_address"
     t.string "employer_agent_name"
     t.string "employer_agent_email_address"
+    t.date "start_date"
     t.index ["estate_id"], name: "index_schemes_on_estate_id"
   end
 

--- a/spec/features/staff_can_create_a_scheme_spec.rb
+++ b/spec/features/staff_can_create_a_scheme_spec.rb
@@ -21,6 +21,9 @@ RSpec.feature 'Staff can create a scheme' do
       fill_in 'scheme[contractor_email_address]', with: 'email@example.com'
       fill_in 'scheme[employer_agent_name]', with: 'Alex'
       fill_in 'scheme[employer_agent_email_address]', with: 'alex@example.com'
+      fill_in 'start_date[day]', with: '1'
+      fill_in 'start_date[month]', with: '2'
+      fill_in 'start_date[year]', with: '2019'
       click_on(I18n.t('button.create.scheme'))
     end
 
@@ -34,6 +37,7 @@ RSpec.feature 'Staff can create a scheme' do
       click_on(I18n.t('generic.link.show'))
     end
 
+    expect(page).to have_content('1 February 2019')
     expect(page).to have_content(scheme.contractor_email_address)
     expect(page).to have_content(scheme.employer_agent_name)
     expect(page).to have_content(scheme.employer_agent_email_address)

--- a/spec/features/staff_can_view_a_combined_report_spec.rb
+++ b/spec/features/staff_can_view_a_combined_report_spec.rb
@@ -1,27 +1,29 @@
 require 'rails_helper'
 
-RSpec.feature 'Staff can view a report for a scheme' do
+RSpec.feature 'Staff can view a combined report for all schemes' do
   before(:each) do
     stub_authenticated_session
   end
 
-  let(:scheme) { create(:scheme, created_at: 5.days.ago) }
+  let(:scheme) { create(:scheme, created_at: 5.days.ago, start_date: 5.days.ago) }
   let(:priority) { create(:priority, scheme: scheme) }
   let(:property) { create(:property, scheme: scheme) }
   let(:communal_area) { create(:communal_area, scheme: scheme) }
 
-  scenario 'summary information for all defects belonging to the scheme' do
+  let(:second_scheme) { create(:scheme, created_at: 5.days.ago, start_date: 5.days.ago) }
+  let(:second_priority) { create(:priority, scheme: second_scheme) }
+  let(:second_property) { create(:property, scheme: second_scheme) }
+
+  scenario 'summary information for all defects belonging to the schemes' do
     create_list(:property_defect, 1, property: property, priority: priority)
     create_list(:communal_defect, 2, communal_area: communal_area, priority: priority)
 
     visit dashboard_path
 
-    within('.scheme-reports') do
-      click_on(I18n.t('generic.link.show'))
-    end
+    click_on(I18n.t('button.report.view_combined'))
 
-    expect(page).to have_content(I18n.t('page_title.staff.reports.scheme.show', name: scheme.name))
-    expect(page).to have_content("From #{scheme.created_at.to_date} to #{Date.current}")
+    expect(page).to have_content(I18n.t('page_title.staff.reports.index'))
+    expect(page).to have_content("From #{14.months.ago.to_date} to #{Date.current}")
 
     within('.summary') do
       %w[Title Property Communal Total].each do |column_header|
@@ -36,14 +38,14 @@ RSpec.feature 'Staff can view a report for a scheme' do
     end
   end
 
-  scenario 'defect information by status belonging to the scheme' do
+  scenario 'defect information by status' do
     outstanding_property_defects = create_list(:property_defect, 1, property: property, status: :outstanding)
     outstanding_communal_defects = create_list(:communal_defect, 2, communal_area: communal_area, status: :outstanding)
 
     closed_property_defects = create_list(:property_defect, 3, property: property, status: :closed)
     closed_communal_defects = create_list(:communal_defect, 4, communal_area: communal_area, status: :closed)
 
-    visit report_scheme_path(scheme)
+    visit report_path
 
     within('.statuses') do
       %w[Name Property Communal Total].each do |header|
@@ -64,14 +66,14 @@ RSpec.feature 'Staff can view a report for a scheme' do
     end
   end
 
-  scenario 'defect information by trade belonging to the scheme' do
+  scenario 'defect information by trade' do
     electrical_property_defects = create_list(:property_defect, 1, property: property, trade: 'Electrical')
     electrical_communal_defects = create_list(:communal_defect, 2, communal_area: communal_area, trade: 'Electrical')
 
     plumbing_property_defects = create_list(:property_defect, 3, property: property, trade: 'Plumbing')
     plumbing_communal_defects = create_list(:communal_defect, 4, communal_area: communal_area, trade: 'Plumbing')
 
-    visit report_scheme_path(scheme)
+    visit report_path
 
     within('.trades') do
       %w[Name Percentage Total].each do |header|
@@ -90,7 +92,7 @@ RSpec.feature 'Staff can view a report for a scheme' do
     end
   end
 
-  scenario 'defect information by scheme priority' do
+  scenario 'defect information by priority' do
     travel_to Time.zone.parse('2019-05-23')
 
     completed_on_time_priority = create(:property_defect,
@@ -109,16 +111,15 @@ RSpec.feature 'Staff can view a report for a scheme' do
 
     completed_on_time_priority.completed!
 
-    visit report_scheme_path(scheme)
+    visit report_path
 
     within('.priorities') do
-      %w[Code Days Total Due Overdue Completed on time].each do |header|
+      %w[Code Total Due Overdue Completed on time].each do |header|
         expect(page).to have_content(header)
       end
 
       scheme.priorities.each do |priority|
         expect(page).to have_content(priority.name)
-        expect(page).to have_content(priority.days)
       end
 
       expect(page).to have_content('25.0%')
@@ -153,7 +154,7 @@ RSpec.feature 'Staff can view a report for a scheme' do
       completed_later_defect,
     ].each(&:completed!)
 
-    visit report_scheme_path(scheme)
+    visit report_path
 
     within('.priorities') do
       expect(page).to have_content('2')
@@ -162,7 +163,7 @@ RSpec.feature 'Staff can view a report for a scheme' do
     travel_back
   end
 
-  scenario 'filter defects' do
+  scenario 'filter defects by date' do
     travel_to Time.zone.parse('2019-05-25')
 
     create(:property_defect, created_at: Time.utc(2019, 5, 23), property: property)
@@ -170,13 +171,13 @@ RSpec.feature 'Staff can view a report for a scheme' do
     create(:communal_defect, created_at: Time.utc(2019, 5, 24), communal_area: communal_area)
     create(:property_defect, created_at: Time.utc(2019, 5, 25), property: property)
 
-    visit report_scheme_path(scheme)
+    visit report_path
 
     within('.summary') do
       expect(page).to have_content('Total defects 3 1 4')
     end
 
-    within('.date-filter') do
+    within('.report-filter') do
       fill_in 'from_date[day]', with: '23'
       fill_in 'from_date[month]', with: '5'
       fill_in 'from_date[year]', with: '2019'
@@ -185,10 +186,35 @@ RSpec.feature 'Staff can view a report for a scheme' do
       fill_in 'to_date[year]', with: '2019'
     end
 
-    click_button 'Apply dates'
+    click_button 'Apply filters'
 
     within('.summary') do
       expect(page).to have_content('Total defects 2 1 3')
+    end
+
+    travel_back
+  end
+
+  scenario 'filter defects by scheme' do
+    travel_to Time.zone.parse('2019-05-25')
+
+    create(:property_defect, created_at: Time.utc(2019, 5, 23), property: second_property)
+    create(:property_defect, created_at: Time.utc(2019, 5, 23), property: property)
+
+    visit report_path
+
+    within('.summary') do
+      expect(page).to have_content('Total defects 2 0 2')
+    end
+
+    within('.report-filter') do
+      uncheck second_scheme.id
+    end
+
+    click_button 'Apply filters'
+
+    within('.summary') do
+      expect(page).to have_content('Total defects 1 0 1')
     end
 
     travel_back

--- a/spec/features/staff_can_view_a_scheme_report_spec.rb
+++ b/spec/features/staff_can_view_a_scheme_report_spec.rb
@@ -96,7 +96,13 @@ RSpec.feature 'Staff can view a report for a scheme' do
     completed_on_time_priority = create(:property_defect,
                                         property: property,
                                         priority: priority,
-                                        target_completion_date: Date.new(2019, 5, 24))
+                                        target_completion_date: Date.new(2019, 5, 24),
+                                        status: :completed)
+    completed_on_time_priority.activities.create!(key: 'defect.update',
+                                                  parameters: {
+                                                    changes: { status: ['', 'completed'] },
+                                                  })
+
     _due_priority = create(:property_defect,
                            property: property,
                            priority: priority,
@@ -106,8 +112,6 @@ RSpec.feature 'Staff can view a report for a scheme' do
                                       property: property,
                                       priority: priority,
                                       target_completion_date: Date.new(2019, 5, 22))
-
-    completed_on_time_priority.completed!
 
     visit report_scheme_path(scheme)
 

--- a/spec/features/staff_can_view_a_scheme_report_spec.rb
+++ b/spec/features/staff_can_view_a_scheme_report_spec.rb
@@ -93,6 +93,10 @@ RSpec.feature 'Staff can view a report for a scheme' do
   scenario 'defect information by scheme priority' do
     travel_to Time.zone.parse('2019-05-23')
 
+    completed_on_time_priority = create(:property_defect,
+                                        property: property,
+                                        priority: priority,
+                                        target_completion_date: Date.new(2019, 5, 24))
     _due_priority = create(:property_defect,
                            property: property,
                            priority: priority,
@@ -102,6 +106,8 @@ RSpec.feature 'Staff can view a report for a scheme' do
                                       property: property,
                                       priority: priority,
                                       target_completion_date: Date.new(2019, 5, 22))
+
+    completed_on_time_priority.completed!
 
     visit report_scheme_path(scheme)
 
@@ -115,7 +121,7 @@ RSpec.feature 'Staff can view a report for a scheme' do
         expect(page).to have_content(priority.days)
       end
 
-      expect(page).to have_content('100.0%')
+      expect(page).to have_content('25.0%')
       expect(page).to have_content('1')
       expect(page).to have_content('2')
       expect(page).to have_content('3')

--- a/spec/models/scheme_spec.rb
+++ b/spec/models/scheme_spec.rb
@@ -42,4 +42,12 @@ RSpec.describe Scheme, type: :model do
       expect(scheme.valid?).to be_falsey
     end
   end
+
+  describe '.set_start_date' do
+    it 'sets the start_date' do
+      scheme = build(:scheme)
+      scheme.set_start_date({ day: 1, month: 2, year: 2019 })
+      expect(scheme.start_date).to eq(Date.new(2019, 2, 1))
+    end
+  end
 end

--- a/spec/models/scheme_spec.rb
+++ b/spec/models/scheme_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Scheme, type: :model do
   describe '.set_start_date' do
     it 'sets the start_date' do
       scheme = build(:scheme)
-      scheme.set_start_date({ day: 1, month: 2, year: 2019 })
+      scheme.set_start_date(day: 1, month: 2, year: 2019)
       expect(scheme.start_date).to eq(Date.new(2019, 2, 1))
     end
   end

--- a/spec/presenters/combined_report_presenter_spec.rb
+++ b/spec/presenters/combined_report_presenter_spec.rb
@@ -16,7 +16,8 @@ RSpec.describe CombinedReportPresenter do
       it 'returns on defects created within that range' do
         from_date = Date.new(2019, 1, 1)
         to_date = Date.new(2019, 12, 1)
-        report_form = double(from_date: from_date, to_date: to_date)
+        date_range = from_date..to_date
+        report_form = double(from_date: from_date, to_date: to_date, date_range: date_range)
 
         before_range_defect = create(:property_defect, created_at: Time.utc(2018, 1, 1), property: property, priority: priority)
         in_range_defect = create(:property_defect, created_at: Time.utc(2019, 2, 1), property: property, priority: priority)

--- a/spec/presenters/combined_report_presenter_spec.rb
+++ b/spec/presenters/combined_report_presenter_spec.rb
@@ -1,0 +1,334 @@
+require 'rails_helper'
+
+RSpec.describe CombinedReportPresenter do
+  let(:schemes) { create_list(:scheme, 2, start_date: 1.day.ago) }
+  let(:property) { create(:property, scheme: schemes.first) }
+  let(:priority) { create(:priority, scheme: schemes.first) }
+
+  describe '#defects' do
+    it 'returns all defects for the schemes' do
+      defect = create(:property_defect, property: property, priority: priority)
+      result = described_class.new(schemes: schemes).defects
+      expect(result).to include(defect)
+    end
+
+    context 'a ReportForm is injected with a date range' do
+      it 'returns on defects created within that range' do
+        from_date = Date.new(2019, 1, 1)
+        to_date = Date.new(2019, 12, 1)
+        report_form = double(from_date: from_date, to_date: to_date)
+
+        before_range_defect = create(:property_defect, created_at: Time.utc(2018, 1, 1), property: property, priority: priority)
+        in_range_defect = create(:property_defect, created_at: Time.utc(2019, 2, 1), property: property, priority: priority)
+        after_range_defect = create(:property_defect, created_at: Time.utc(2020, 1, 1), property: property, priority: priority)
+
+        result = described_class.new(schemes: schemes, report_form: report_form).defects
+
+        expect(result).to include(in_range_defect)
+        expect(result).not_to include(before_range_defect)
+        expect(result).not_to include(after_range_defect)
+      end
+    end
+  end
+
+  describe '#date_range' do
+    it 'returns a time range for all the data being viewed in a string format' do
+      travel_to Time.zone.parse('2019-07-16')
+
+      from_date = Date.new(2019, 1, 10)
+      to_date = Date.current
+
+      report_form = double(from_date: from_date, to_date: to_date)
+      result = described_class.new(schemes: schemes, report_form: report_form).date_range
+      expect(result).to eq('From 10 January 2019 to 16 July 2019')
+
+      travel_back
+    end
+  end
+
+  describe '#defects_by_status' do
+    it 'returns all defects with the given status' do
+      outstanding_defect = create(:property_defect, property: property, priority: priority, status: :outstanding)
+      closed_defect = create(:property_defect, property: property, priority: priority, status: :closed)
+
+      result = described_class.new(schemes: schemes).defects_by_status(text: 'outstanding')
+      expect(result).to include(outstanding_defect)
+      expect(result).not_to include(closed_defect)
+    end
+
+    context 'when the status is closed' do
+      it 'does not return an inflated number' do
+        create(:property_defect, property: property, priority: priority, status: :outstanding)
+        create(:property_defect, property: property, priority: priority, status: :completed)
+        create(:property_defect, property: property, priority: priority, status: :closed)
+        create(:property_defect, property: property, priority: priority, status: :closed)
+        result = described_class.new(schemes: schemes).defects_by_status(text: 'closed')
+        expect(result.count).to eql(2)
+      end
+    end
+  end
+
+  describe '#defects_by_category' do
+    it 'returns a count for all defects where the trade matches the category' do
+      electrical_defect = create(:property_defect, property: property, trade: 'Electrical')
+      plumbing_defect = create(:property_defect, property: property, trade: 'Drainage')
+
+      result = described_class.new(schemes: schemes).defects_by_category(category: 'Plumbing')
+
+      expect(result).to include(plumbing_defect)
+      expect(result).not_to include(electrical_defect)
+    end
+  end
+
+  describe '#category_percentage' do
+    it 'returns the percentage of defects with this category ' do
+      create(:property_defect, property: property, trade: 'Plumbing')
+      create(:property_defect, property: property, trade: 'Electrical')
+      result = described_class.new(schemes: schemes).category_percentage(category: 'Electrical/Mechanical')
+      expect(result).to eql('50.0%')
+    end
+
+    context 'when there the total defect count is odd' do
+      it 'returns a rounded percentage%' do
+        create(:property_defect, property: property, trade: 'Electrical')
+        create(:property_defect, property: property, trade: 'Plumbing')
+        create(:property_defect, property: property, trade: 'Plumbing')
+        result = described_class.new(schemes: schemes).category_percentage(category: 'Electrical/Mechanical')
+        expect(result).to eql('33.33%')
+      end
+    end
+
+    context 'when there are no defects with that trade' do
+      it 'returns 0.0%' do
+        result = described_class.new(schemes: schemes).category_percentage(category: 'Electrical/Mechanical')
+        expect(result).to eql('0.0%')
+      end
+    end
+  end
+
+  describe '#defects_by_priority' do
+    let(:second_priority) { create(:priority, scheme: schemes.last) }
+
+    it 'returns a count for all defects for the given priority' do
+      first_priority_defect = create(:property_defect, property: property, priority: priority)
+      second_priority_defect = create(:property_defect, property: property, priority: second_priority)
+
+      result = described_class.new(schemes: [schemes.first]).defects_by_priority(priority: priority.name)
+
+      expect(result).to include(first_priority_defect)
+      expect(result).not_to include(second_priority_defect)
+    end
+  end
+
+  describe '#priority_percentage' do
+    it 'returns the percentage of defects completed on time with this priority ' do
+      travel_to Time.zone.parse('2019-05-23')
+
+      completed_on_time_priority = create(:property_defect,
+                                          property: property,
+                                          priority: priority,
+                                          target_completion_date: Date.new(2019, 5, 24),
+                                          status: :completed)
+
+      completed_on_time_priority.activities.create!(key: 'defect.update',
+                                                    parameters: {
+                                                      changes: { status: ['', 'completed'] },
+                                                    })
+
+      create(:property_defect, property: property, priority: priority)
+      result = described_class.new(schemes: schemes).priority_percentage(priority: priority.name)
+      expect(result).to eql('50.0%')
+
+      travel_back
+    end
+
+    context 'when there are no defects with that priority' do
+      it 'returns 0.0%' do
+        result = described_class.new(schemes: schemes).priority_percentage(priority: priority)
+        expect(result).to eql('0.0%')
+      end
+    end
+  end
+
+  describe '#due_defects_by_priority' do
+    it 'returns all defects with a target_completion_date before todays date' do
+      travel_to Time.zone.parse('2019-05-23')
+
+      due_tomorrow_priority_defect = create(:property_defect,
+                                            property: property,
+                                            priority: priority,
+                                            target_completion_date: Date.new(2019, 5, 24))
+      due_today_priority_defect = create(:property_defect,
+                                         property: property,
+                                         priority: priority,
+                                         target_completion_date: Date.new(2019, 5, 23))
+      overdue_priority_defect = create(:property_defect,
+                                       property: property,
+                                       priority: priority,
+                                       target_completion_date: Date.new(2019, 5, 22))
+
+      result = described_class.new(schemes: schemes).due_defects_by_priority(priority: priority.name)
+
+      expect(result).to include(due_tomorrow_priority_defect)
+      expect(result).to include(due_today_priority_defect)
+      expect(result).not_to include(overdue_priority_defect)
+
+      travel_back
+    end
+  end
+
+  describe '#overdue_defects_by_priority' do
+    it 'returns all defects with a target_completion_date before todays date' do
+      travel_to Time.zone.parse('2019-05-23')
+
+      due_tomorrow_priority_defect = create(:property_defect,
+                                            property: property,
+                                            priority: priority,
+                                            target_completion_date: Date.new(2019, 5, 24))
+      due_today_priority_defect = create(:property_defect,
+                                         property: property,
+                                         priority: priority,
+                                         target_completion_date: Date.new(2019, 5, 23))
+      overdue_priority_defect = create(:property_defect,
+                                       property: property,
+                                       priority: priority,
+                                       target_completion_date: Date.new(2019, 5, 22))
+
+      result = described_class.new(schemes: schemes).overdue_defects_by_priority(priority: priority.name)
+
+      expect(result).not_to include(due_tomorrow_priority_defect)
+      expect(result).not_to include(due_today_priority_defect)
+      expect(result).to include(overdue_priority_defect)
+
+      travel_back
+    end
+  end
+
+  describe '#defects_completed_on_time' do
+    it 'returns a count for all defects completed before or on their target date' do
+      travel_to Time.zone.local(2019, 5, 21, 10, 0, 0)
+      completed_early_defect = create(:property_defect,
+                                      status: :completed,
+                                      property: property,
+                                      priority: priority,
+                                      target_completion_date: Date.new(2019, 5, 23))
+      completed_on_time_defect = create(:property_defect,
+                                        status: :completed,
+                                        property: property,
+                                        priority: priority,
+                                        target_completion_date: Date.new(2019, 5, 23))
+      completed_later_defect = create(:property_defect,
+                                      status: :completed,
+                                      property: property,
+                                      priority: priority,
+                                      target_completion_date: Date.new(2019, 5, 23))
+      travel_back
+
+      travel_to Time.zone.local(2019, 5, 22, 10, 10, 10) do
+        completed_early_defect.create_activity(
+          key: 'defect.update',
+          parameters: {
+            changes:
+            {
+              status: %w[outstanding completed],
+            },
+          },
+        )
+      end
+
+      travel_to Time.zone.local(2019, 5, 23, 10, 10, 10) do
+        completed_on_time_defect.create_activity(
+          key: 'defect.update',
+          parameters: {
+            changes:
+            {
+              status: %w[outstanding completed],
+            },
+          }
+        )
+      end
+
+      travel_to Time.zone.local(2019, 5, 24, 10, 10, 10) do
+        completed_on_time_defect.create_activity(
+          key: 'defect.update',
+          parameters: {
+            changes:
+            {
+              status: %w[outstanding completed],
+            },
+          },
+        )
+      end
+
+      travel_to Time.zone.local(2019, 5, 23, 10, 20, 10)
+
+      result = described_class.new(schemes: schemes).defects_completed_on_time(priority: priority.name)
+
+      expect(result).to include(completed_early_defect)
+      expect(result).to include(completed_on_time_defect)
+      expect(result).not_to include(completed_later_defect)
+
+      travel_back
+    end
+
+    it 'returns only completed defects' do
+      travel_to Time.zone.local(2019, 5, 23, 10, 10, 10)
+      rejected_defect = create(:property_defect,
+                               status: :rejected,
+                               property: property,
+                               priority: priority,
+                               target_completion_date: Date.current)
+      rejected_defect.create_activity(
+        key: 'defect.update',
+        parameters: {
+          changes:
+          {
+            status: %w[outstanding rejected],
+          },
+        },
+      )
+      completed_defect = create(:property_defect,
+                                status: :completed,
+                                property: property,
+                                priority: priority,
+                                target_completion_date: Date.current)
+
+      completed_defect.create_activity(
+        key: 'defect.update',
+        parameters: {
+          changes:
+          {
+            status: %w[outstanding completed],
+          },
+        },
+      )
+
+      travel_back
+
+      travel_to Time.zone.local(2019, 5, 23, 10, 20, 10)
+
+      result = described_class.new(schemes: schemes).defects_completed_on_time(priority: priority.name)
+
+      expect(result).to include(completed_defect)
+      expect(result).not_to include(rejected_defect)
+
+      travel_back
+    end
+
+    context 'when the defect has flipped back from completed to in progress' do
+      it 'does not include that defect in the count' do
+        completed_on_time_defect = create(:property_defect,
+                                          property: property,
+                                          priority: priority,
+                                          target_completion_date: Date.new(2019, 5, 23))
+
+        completed_on_time_defect.completed!
+        completed_on_time_defect.outstanding!
+
+        result = described_class.new(schemes: schemes).defects_completed_on_time(priority: priority)
+
+        expect(result).not_to include(completed_on_time_defect)
+      end
+    end
+  end
+end

--- a/spec/presenters/combined_report_presenter_spec.rb
+++ b/spec/presenters/combined_report_presenter_spec.rb
@@ -332,4 +332,19 @@ RSpec.describe CombinedReportPresenter do
       end
     end
   end
+
+  describe '#priorities_with_defects' do
+    context 'when one priority has no defects' do
+      it 'ignores that priority' do
+        p1 = create(:priority, name: 'P1', scheme: property.scheme)
+        p2 = create(:priority, name: 'P2', scheme: property.scheme)
+        _defect = create(:property_defect, property: property, priority: p1)
+
+        result = described_class.new(schemes: schemes).priorities_with_defects
+
+        expect(result).to include(p1.name)
+        expect(result).not_to include(p2.name)
+      end
+    end
+  end
 end

--- a/spec/presenters/scheme_report_presenter_spec.rb
+++ b/spec/presenters/scheme_report_presenter_spec.rb
@@ -16,7 +16,8 @@ RSpec.describe SchemeReportPresenter do
       it 'returns on defects created within that range' do
         from_date = Date.new(2019, 1, 1)
         to_date = Date.new(2019, 12, 1)
-        report_form = double(from_date: from_date, to_date: to_date)
+        date_range = from_date..to_date
+        report_form = double(from_date: from_date, to_date: to_date, date_range: date_range)
 
         before_range_defect = create(:property_defect, created_at: Time.utc(2018, 1, 1), property: property, priority: priority)
         in_range_defect = create(:property_defect, created_at: Time.utc(2019, 2, 1), property: property, priority: priority)
@@ -33,7 +34,8 @@ RSpec.describe SchemeReportPresenter do
     it 'includes defects on an individual day' do
       from_date = Date.new(2019, 1, 1)
       to_date = Date.new(2019, 1, 1)
-      report_form = double(from_date: from_date, to_date: to_date)
+      date_range = from_date..to_date
+      report_form = double(from_date: from_date, to_date: to_date, date_range: date_range)
 
       in_range_defect = create(:property_defect, created_at: Time.utc(2019, 1, 1), property: property, priority: priority)
 

--- a/spec/presenters/scheme_report_presenter_spec.rb
+++ b/spec/presenters/scheme_report_presenter_spec.rb
@@ -133,10 +133,21 @@ RSpec.describe SchemeReportPresenter do
   end
 
   describe '#priority_percentage' do
-    it 'returns the percentage of defects with this priority ' do
+    it 'returns the percentage of defects completed on time with this priority ' do
+      travel_to Time.zone.parse('2019-05-23')
+
+      completed_on_time_priority = create(:property_defect,
+                                          property: property,
+                                          priority: priority,
+                                          target_completion_date: Date.new(2019, 5, 24))
+
+      completed_on_time_priority.completed!
+
       create(:property_defect, property: property, priority: priority)
       result = described_class.new(scheme: scheme).priority_percentage(priority: priority)
-      expect(result).to eql('100.0%')
+      expect(result).to eql('50.0%')
+
+      travel_back
     end
 
     context 'when there are no defects with that priority' do

--- a/spec/presenters/scheme_report_presenter_spec.rb
+++ b/spec/presenters/scheme_report_presenter_spec.rb
@@ -139,9 +139,13 @@ RSpec.describe SchemeReportPresenter do
       completed_on_time_priority = create(:property_defect,
                                           property: property,
                                           priority: priority,
-                                          target_completion_date: Date.new(2019, 5, 24))
+                                          target_completion_date: Date.new(2019, 5, 24),
+                                          status: :completed)
 
-      completed_on_time_priority.completed!
+      completed_on_time_priority.activities.create!(key: 'defect.update',
+                                                    parameters: {
+                                                      changes: { status: ['', 'completed'] },
+                                                    })
 
       create(:property_defect, property: property, priority: priority)
       result = described_class.new(scheme: scheme).priority_percentage(priority: priority)

--- a/spec/services/build_date.rb
+++ b/spec/services/build_date.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe BuildDate do
+  describe '#call' do
+    context 'a complete date is given' do
+      it 'returns a date' do
+        date = BuildDate.new(day: 1, month: 1, year: 1999)
+        expect(date.call).to eq(Date.new(1999, 1, 1))
+      end
+    end
+    context 'part of the date is missing' do
+      it 'returns nil' do
+        date = BuildDate.new(day: 1, year: 1999)
+        expect(date.call).to eq(nil)
+      end
+    end
+  end
+end


### PR DESCRIPTION
[Related Trello ticket](https://trello.com/c/FrgQLC2n/12-3-create-a-combined-view-of-kpis)

## Changes in this PR:

This PR introduces a combined report for KPI's, allowing a manager to filter by Scheme to generate the figures they need to report on.

It builds on the work done to create a single scheme report. From conversations with the main user of this work (Jonnelle) this feels like one of the more volatile parts of the system. For this reason, I've done some cosmetic refactoring but have treated these reports as functionality similar _for the time being_ and liable to change.

As well as creating the new report, this PR introduced the concept of a start date for Schemes. This was required to allow us to pre-select which schemes should be in the report by default. We want Schemes in the last 14 months. Schemes occasionally start before we create them so created_at wouldn't do.

## Screenshots of UI changes:

<details>
<summary>Button to access reports</summary>
<img width="539" alt="Screenshot 2019-11-25 at 14 24 30" src="https://user-images.githubusercontent.com/456902/69548477-4e806a00-0f8f-11ea-8a69-d910d940c796.png">
</details>

<details>
<summary>Filtering within the report (1 and 2 are scheme names)</summary>
<img width="389" alt="Screenshot 2019-11-25 at 14 24 47" src="https://user-images.githubusercontent.com/456902/69548492-59d39580-0f8f-11ea-8c89-c192d79d0133.png">

</details>

<details>
<summary>Priorities table with new percentage view</summary>
<img width="1275" alt="Screenshot 2019-11-25 at 14 25 38" src="https://user-images.githubusercontent.com/456902/69548599-88ea0700-0f8f-11ea-84a2-b817b80c17a9.png">

</details>
