### PR TITLE
Allows staff to add one piece of evidence when creating defects

### DIFF
--- a/app/controllers/staff/communal_defects_controller.rb
+++ b/app/controllers/staff/communal_defects_controller.rb
@@ -2,6 +2,7 @@ class Staff::CommunalDefectsController < Staff::BaseController
   def new
     @communal_area = CommunalArea.find(communal_area_id)
     @defect = Defect.new
+    @defect.evidences.build
   end
 
   def create
@@ -11,6 +12,7 @@ class Staff::CommunalDefectsController < Staff::BaseController
       communal_area_id: communal_area_id,
       priority_id: priority_id,
       created_at: created_at,
+      user: current_user,
     }
     @defect = BuildDefect.new(defect_params: defect_params, options: options).call
 
@@ -95,7 +97,8 @@ class Staff::CommunalDefectsController < Staff::BaseController
       :contact_email_address,
       :contact_phone_number,
       :trade,
-      :status
+      :status,
+      evidences_attributes: %i[supporting_file description]
     )
   end
 

--- a/app/controllers/staff/property_defects_controller.rb
+++ b/app/controllers/staff/property_defects_controller.rb
@@ -2,6 +2,7 @@ class Staff::PropertyDefectsController < Staff::BaseController
   def new
     @property = Property.find(property_id)
     @defect = Defect.new
+    @defect.evidences.build
   end
 
   def create
@@ -11,6 +12,7 @@ class Staff::PropertyDefectsController < Staff::BaseController
       property_id: property_id,
       priority_id: priority_id,
       created_at: created_at,
+      user: current_user,
     }
     @defect = BuildDefect.new(defect_params: defect_params, options: options).call
 
@@ -94,7 +96,8 @@ class Staff::PropertyDefectsController < Staff::BaseController
       :contact_email_address,
       :contact_phone_number,
       :trade,
-      :status
+      :status,
+      evidences_attributes: %i[supporting_file description]
     )
   end
 

--- a/app/models/defect.rb
+++ b/app/models/defect.rb
@@ -58,6 +58,8 @@ class Defect < ApplicationRecord
   has_many :comments, dependent: :destroy
   has_many :evidences, dependent: :destroy
 
+  accepts_nested_attributes_for :evidences, reject_if: :all_blank
+
   def scheme
     return communal_area&.scheme if communal_area
     return property&.scheme if property

--- a/app/services/build_defect.rb
+++ b/app/services/build_defect.rb
@@ -1,6 +1,7 @@
 class BuildDefect < DefectBuilder
   attr_accessor :communal_area_id,
-                :property_id
+                :property_id,
+                :user
 
   def initialize(defect_params:, options: {})
     self.defect_params = defect_params
@@ -8,6 +9,7 @@ class BuildDefect < DefectBuilder
     self.communal_area_id = options[:communal_area_id]
     self.priority_id = options[:priority_id]
     self.created_at = options[:created_at]
+    self.user = options[:user]
   end
 
   def call
@@ -18,7 +20,14 @@ class BuildDefect < DefectBuilder
     defect.set_target_completion_date
 
     set_created_at if created_at.present?
+    set_evidence_user
 
     defect
+  end
+
+  private
+
+  def set_evidence_user
+    defect.evidences.first.user = user if defect.evidences.present?
   end
 end

--- a/app/views/staff/communal_defects/new.html.haml
+++ b/app/views/staff/communal_defects/new.html.haml
@@ -58,6 +58,18 @@
 
         %span.govuk-label.govuk-label
           %label.required
+            Evidence
+            = f.fields_for :evidences do |evidence_form|
+              = evidence_form.input :supporting_file,
+                                    as: :file
+
+              = evidence_form.input :description,
+                        wrapper: 'textarea',
+                        as: :text,
+                        input_html: { rows: 1 }
+
+        %span.govuk-label.govuk-label
+          %label.required
             Forwarding
         = f.input :send_contractor_email,
                   as: :boolean,

--- a/app/views/staff/property_defects/new.html.haml
+++ b/app/views/staff/property_defects/new.html.haml
@@ -53,6 +53,18 @@
 
         %span.govuk-label.govuk-label
           %label.required
+            Evidence
+            = f.fields_for :evidences do |evidence_form|
+              = evidence_form.input :supporting_file,
+                                    as: :file
+
+              = evidence_form.input :description,
+                        wrapper: 'textarea',
+                        as: :text,
+                        input_html: { rows: 1 }
+
+        %span.govuk-label.govuk-label
+          %label.required
             Forwarding
         = f.input :send_contractor_email,
                   as: :boolean,

--- a/spec/features/staff_can_create_a_communal_defect_spec.rb
+++ b/spec/features/staff_can_create_a_communal_defect_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Staff can create a defect for a communal_area' do
+RSpec.feature 'Staff can create a defect for a communal_area', :carrierwave do
   before(:each) do
     stub_authenticated_session
   end
@@ -42,6 +42,8 @@ RSpec.feature 'Staff can create a defect for a communal_area' do
       fill_in 'defect[contact_email_address]', with: 'email@example.com'
       fill_in 'defect[contact_phone_number]', with: '07123456789'
       select 'Electrical', from: 'defect[trade]'
+      attach_file 'defect[evidences_attributes][0][supporting_file]', Rails.root.join('spec', 'fixtures', 'evidence.png')
+      fill_in 'defect[evidences_attributes][0][description]', with: 'Some uploaded evidence'
       choose priority.name
       click_on(I18n.t('button.create.communal_defect'))
     end
@@ -64,6 +66,12 @@ RSpec.feature 'Staff can create a defect for a communal_area' do
     within('.communal-location') do
       expect(page).to have_content('Communal Area')
       expect(page).to have_content('33-50 Hackney Street, communal entrance')
+    end
+
+    within('.evidence') do
+      evidence = Evidence.first
+      expect(page).to have_content('Some uploaded evidence')
+      expect(page).to have_selector(:css, "a[href='#{evidence.supporting_file.url}']")
     end
   end
 

--- a/spec/features/staff_can_create_a_property_defect_spec.rb
+++ b/spec/features/staff_can_create_a_property_defect_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature 'Staff can create a defect for a property' do
     stub_authenticated_session
   end
 
-  scenario 'a property can be found and defect can be created' do
+  scenario 'a property can be found and defect can be created', :carrierwave do
     property = create(:property, address: '1 Hackney Street')
     priority = create(:priority, scheme: property.scheme, name: 'P1', days: 1)
 
@@ -43,6 +43,8 @@ RSpec.feature 'Staff can create a defect for a property' do
       fill_in 'defect[contact_phone_number]', with: '07123456789'
       select 'Electrical', from: 'defect[trade]'
       choose priority.name
+      attach_file 'defect[evidences_attributes][0][supporting_file]', Rails.root.join('spec', 'fixtures', 'evidence.png')
+      fill_in 'defect[evidences_attributes][0][description]', with: 'Some uploaded evidence'
       click_on(I18n.t('button.create.property_defect'))
     end
 
@@ -64,6 +66,12 @@ RSpec.feature 'Staff can create a defect for a property' do
     within('.property-location') do
       expect(page).to have_content('Property')
       expect(page).to have_content(property.address)
+    end
+
+    within('.evidence') do
+      evidence = Evidence.first
+      expect(page).to have_content('Some uploaded evidence')
+      expect(page).to have_selector(:css, "a[href='#{evidence.supporting_file.url}']")
     end
   end
 

--- a/spec/features/staff_can_create_evidence_spec.rb
+++ b/spec/features/staff_can_create_evidence_spec.rb
@@ -35,6 +35,7 @@ RSpec.feature 'Staff can create evidence' do
       within('.evidence') do
         evidence = Evidence.first
         expect(page).to have_content(evidence.description)
+        expect(page).to have_selector(:css, "a[href='#{evidence.supporting_file.url}']")
       end
     end
 


### PR DESCRIPTION
[Related Trello ticket](https://trello.com/c/lr6Kam4o/4-2-create-ability-to-attach-files-to-defect-records-which-can-then-be-shared-among-nbt)

We want to allow people to upload evidence when they are creating defects.

The majority of evidence will be added after the fact, but this allows for quick entry

## Changes in this PR:

Adds the notion of nested attributes for evidence from defects.

Adds form elements to communal/property defect form to allow for quick upload.

## Screenshots of UI changes:
<img width="759" alt="Screenshot 2019-11-25 at 15 21 27" src="https://user-images.githubusercontent.com/456902/69552987-47f5f080-0f97-11ea-9b6d-f6457932e2f3.png">

