### PR TITLE
Filter defects by escalations

### DIFF
--- a/app/controllers/staff/defects_controller.rb
+++ b/app/controllers/staff/defects_controller.rb
@@ -1,9 +1,18 @@
 class Staff::DefectsController < Staff::BaseController
+  helper_method :open_status?,
+                :closed_status?,
+                :type_property?,
+                :type_communal?,
+                :escalated_manually?,
+                :escalated_overdue?,
+                :escalated_due_soon?,
+                :selected_scheme?
   def index
     @defect_filter = DefectFilter.new(
       statuses: statuses,
       types: types,
       schemes: scheme_ids,
+      escalations: escalations,
     )
     @defects = DefectFinder.new(order: :target_completion_date, filter: @defect_filter)
                            .call
@@ -17,15 +26,15 @@ class Staff::DefectsController < Staff::BaseController
           .map { |status| status.parameterize.underscore.to_sym }
   end
 
-  helper_method :open_status?
   def open_status?
     return false if statuses.blank?
+
     statuses.include?(:open)
   end
 
-  helper_method :closed_status?
   def closed_status?
     return false if statuses.blank?
+
     statuses.include?(:closed)
   end
 
@@ -39,33 +48,33 @@ class Staff::DefectsController < Staff::BaseController
           .map { |escalation| escalation.parameterize.underscore.to_sym }
   end
 
-  helper_method :type_property?
   def type_property?
     return false if types.blank?
+
     types.include?(:property)
   end
 
-  helper_method :type_communal?
   def type_communal?
     return false if types.blank?
+
     types.include?(:communal)
   end
 
-  helper_method :escalated_escalated?
-  def escalated_escalated?
+  def escalated_manually?
     return false if escalations.blank?
-    escalations.include?(:escalated)
+
+    escalations.include?(:manually_escalated)
   end
 
-  helper_method :escalated_overdue?
   def escalated_overdue?
     return false if escalations.blank?
+
     escalations.include?(:overdue)
   end
 
-  helper_method :escalated_due_soon?
   def escalated_due_soon?
     return false if escalations.blank?
+
     escalations.include?(:due_soon)
   end
 
@@ -73,9 +82,9 @@ class Staff::DefectsController < Staff::BaseController
     params.fetch(:scheme_ids, [])
   end
 
-  helper_method :selected_scheme?
   def selected_scheme?(scheme_id)
     return false if scheme_id.blank?
+
     scheme_ids.include?(scheme_id)
   end
 end

--- a/app/controllers/staff/defects_controller.rb
+++ b/app/controllers/staff/defects_controller.rb
@@ -34,6 +34,11 @@ class Staff::DefectsController < Staff::BaseController
           .map { |type| type.parameterize.underscore.to_sym }
   end
 
+  def escalations
+    params.fetch(:escalations, [])
+          .map { |escalation| escalation.parameterize.underscore.to_sym }
+  end
+
   helper_method :type_property?
   def type_property?
     return false if types.blank?
@@ -44,6 +49,24 @@ class Staff::DefectsController < Staff::BaseController
   def type_communal?
     return false if types.blank?
     types.include?(:communal)
+  end
+
+  helper_method :escalated_escalated?
+  def escalated_escalated?
+    return false if escalations.blank?
+    escalations.include?(:escalated)
+  end
+
+  helper_method :escalated_overdue?
+  def escalated_overdue?
+    return false if escalations.blank?
+    escalations.include?(:overdue)
+  end
+
+  helper_method :escalated_due_soon?
+  def escalated_due_soon?
+    return false if escalations.blank?
+    escalations.include?(:due_soon)
   end
 
   def scheme_ids

--- a/app/models/defect.rb
+++ b/app/models/defect.rb
@@ -52,6 +52,13 @@ class Defect < ApplicationRecord
 
   scope :for_trades, (->(trade_names) { where(trade: trade_names) })
 
+  scope :flagged, (-> { where(flagged: true) })
+  scope :overdue, (-> { open.where('target_completion_date < ?', Date.current) })
+  scope :due_soon, (-> { open.where('target_completion_date < ?', 3.days.since) })
+  scope :flagged_and_overdue, (-> { flagged.or(overdue) })
+  scope :overdue_and_due_soon, (-> { overdue.or(due_soon) })
+  scope :flagged_and_due_soon, (-> { flagged.or(due_soon) })
+
   belongs_to :property, optional: true
   belongs_to :communal_area, optional: true
   belongs_to :priority

--- a/app/services/defect_filter.rb
+++ b/app/services/defect_filter.rb
@@ -37,17 +37,27 @@ class DefectFilter
   end
 
   def escalation_scope
-    return escalated_permutations if manually_escalated?
-    return :overdue_and_due_soon if due_soon? && overdue?
-    return :overdue if overdue?
-    return :due_soon if due_soon?
+    if manually_escalated?
+      escalated_permutations
+    elsif due_soon? && overdue?
+      :overdue_and_due_soon
+    elsif overdue?
+      :overdue
+    elsif due_soon?
+      :due_soon
+    end
   end
 
   def escalated_permutations
     return if overdue? && due_soon?
-    return :flagged_and_overdue if overdue?
-    return :flagged_and_due_soon if due_soon?
-    :flagged
+
+    if overdue?
+      :flagged_and_overdue
+    elsif due_soon?
+      :flagged_and_due_soon
+    else
+      :flagged
+    end
   end
 
   def none?

--- a/app/views/staff/communal_defects/show.html.haml
+++ b/app/views/staff/communal_defects/show.html.haml
@@ -1,6 +1,12 @@
 - content_for :page_title_prefix, I18n.t('page_title.staff.defects.show', reference_number: @defect.reference_number)
 
-= link_to "Back to #{I18n.t('page_title.staff.communal_areas.show', name: @defect.communal_area.name)}", communal_area_path(@defect.communal_area), class: 'govuk-back-link'
+.govuk-breadcrumbs
+  %ol.govuk-breadcrumbs__list
+    = breadcrumb_link_to('Home', dashboard_path)
+    = breadcrumb_link_to(I18n.t('page_title.staff.estates.show', name: @defect.communal_area.scheme.estate.name), estate_path(@defect.communal_area.scheme.estate))
+    = breadcrumb_link_to(I18n.t('page_title.staff.schemes.show', name: @defect.communal_area.scheme.name), estate_scheme_path(@defect.communal_area.scheme.estate, @defect.communal_area.scheme))
+    = breadcrumb_link_to(I18n.t('page_title.staff.communal_areas.show', name: @defect.communal_area.name), communal_area_path(@defect.communal_area))
+    = breadcrumb_current(@defect.reference_number)
 
 .govuk-grid-row
   .govuk-grid-column-full

--- a/app/views/staff/defects/index.html.haml
+++ b/app/views/staff/defects/index.html.haml
@@ -39,6 +39,19 @@
                 .govuk-checkboxes__item
                   = check_box_tag 'scheme_ids[]', scheme.id, selected_scheme?(scheme.id), id: scheme.id, class: 'govuk-checkboxes__input'
                   = label_tag 'scheme_ids[]', scheme.name, for: scheme.id, class: 'govuk-label govuk-checkboxes__label'
+          %fieldset.govuk-fieldset.lbh-fieldset
+            = label_tag 'escalations', 'Escalations', class: 'govuk-label govuk-!-font-weight-bold'
+            .govuk-checkboxes.checkbox-group.govuk-checkboxes--small
+              .govuk-checkboxes__item
+                = check_box_tag 'escalations[]', 'Escalated', escalated_escalated?, id: 'escalations_escalated', class: 'govuk-checkboxes__input'
+                = label_tag 'escalations[]', 'Escalated', for: 'escalations_escalated', class: 'govuk-label govuk-checkboxes__label'
+              .govuk-checkboxes__item
+                = check_box_tag 'escalations[]', 'Overdue', escalated_overdue?, id: 'escalations_overdue', class: 'govuk-checkboxes__input'
+                = label_tag 'escalations[]', 'Overdue', for: 'escalations_overdue', class: 'govuk-label govuk-checkboxes__label'
+              .govuk-checkboxes__item
+                = check_box_tag 'escalations[]', 'Due Soon', escalated_due_soon?, id: 'escalations_due_soon', class: 'govuk-checkboxes__input'
+                = label_tag 'escalations[]', 'Due Soon', for: 'escalations_due_soon', class: 'govuk-label govuk-checkboxes__label'
+
         = submit_tag I18n.t('generic.button.filter'), class: 'govuk-button mb0'
 
   %article{role: 'main'}

--- a/app/views/staff/defects/index.html.haml
+++ b/app/views/staff/defects/index.html.haml
@@ -43,14 +43,14 @@
             = label_tag 'escalations', 'Escalations', class: 'govuk-label govuk-!-font-weight-bold'
             .govuk-checkboxes.checkbox-group.govuk-checkboxes--small
               .govuk-checkboxes__item
-                = check_box_tag 'escalations[]', 'Escalated', escalated_escalated?, id: 'escalations_escalated', class: 'govuk-checkboxes__input'
-                = label_tag 'escalations[]', 'Escalated', for: 'escalations_escalated', class: 'govuk-label govuk-checkboxes__label'
+                = check_box_tag 'escalations[]', 'Manually escalated', escalated_manually?, id: 'escalations_escalated', class: 'govuk-checkboxes__input'
+                = label_tag 'escalations[]', 'Manually escalated', for: 'escalations_escalated', class: 'govuk-label govuk-checkboxes__label'
               .govuk-checkboxes__item
                 = check_box_tag 'escalations[]', 'Overdue', escalated_overdue?, id: 'escalations_overdue', class: 'govuk-checkboxes__input'
                 = label_tag 'escalations[]', 'Overdue', for: 'escalations_overdue', class: 'govuk-label govuk-checkboxes__label'
               .govuk-checkboxes__item
-                = check_box_tag 'escalations[]', 'Due Soon', escalated_due_soon?, id: 'escalations_due_soon', class: 'govuk-checkboxes__input'
-                = label_tag 'escalations[]', 'Due Soon', for: 'escalations_due_soon', class: 'govuk-label govuk-checkboxes__label'
+                = check_box_tag 'escalations[]', 'Due soon', escalated_due_soon?, id: 'escalations_due_soon', class: 'govuk-checkboxes__input'
+                = label_tag 'escalations[]', 'Due soon', for: 'escalations_due_soon', class: 'govuk-label govuk-checkboxes__label'
 
         = submit_tag I18n.t('generic.button.filter'), class: 'govuk-button mb0'
 

--- a/app/views/staff/property_defects/show.html.haml
+++ b/app/views/staff/property_defects/show.html.haml
@@ -1,6 +1,12 @@
 - content_for :page_title_prefix, I18n.t('page_title.staff.defects.show', reference_number: @defect.reference_number)
 
-= link_to "Back to #{I18n.t('page_title.staff.properties.show', name: @defect.property.address)}", property_path(@defect.property), class: 'govuk-back-link'
+.govuk-breadcrumbs
+  %ol.govuk-breadcrumbs__list
+    = breadcrumb_link_to('Home', dashboard_path)
+    = breadcrumb_link_to(I18n.t('page_title.staff.estates.show', name: @defect.property.scheme.estate.name), estate_path(@defect.property.scheme.estate))
+    = breadcrumb_link_to(I18n.t('page_title.staff.schemes.show', name: @defect.property.scheme.name), estate_scheme_path(@defect.property.scheme.estate, @defect.property.scheme))
+    = breadcrumb_link_to(I18n.t('page_title.staff.properties.show', name: @defect.property.address), property_path(@defect.property))
+    = breadcrumb_current(@defect.reference_number)
 
 .govuk-grid-row
   .govuk-grid-column-full

--- a/spec/features/staff_can_view_a_defect_spec.rb
+++ b/spec/features/staff_can_view_a_defect_spec.rb
@@ -118,7 +118,7 @@ RSpec.feature 'Staff can view a defect' do
 
     visit property_defect_path(defect.property, defect)
 
-    expect(page).to have_link("Back to #{defect.property.address}", href: property_path(defect.property))
+    expect(page).to have_link(defect.property.address, href: property_path(defect.property))
   end
 
   scenario 'can use breadcrumbs to navigate back to a communal_area' do
@@ -126,7 +126,7 @@ RSpec.feature 'Staff can view a defect' do
 
     visit communal_area_defect_path(defect.communal_area, defect)
 
-    expect(page).to have_link("Back to #{defect.communal_area.name}", href: communal_area_path(defect.communal_area))
+    expect(page).to have_link(defect.communal_area.name, href: communal_area_path(defect.communal_area))
   end
 
   scenario 'can see comments' do

--- a/spec/services/defect_filter_spec.rb
+++ b/spec/services/defect_filter_spec.rb
@@ -92,5 +92,70 @@ RSpec.describe DefectFilter do
         end
       end
     end
+
+    describe 'escalations' do
+      context 'when the escalation is manual' do
+        it 'returns an array with :flagged' do
+          result = described_class.new(escalations: %i[manually_escalated])
+          expect(result.scopes).to eq([:flagged])
+        end
+      end
+
+      context 'when the escalation is overdue' do
+        it 'returns an array with :overdue' do
+          result = described_class.new(escalations: %i[overdue])
+          expect(result.scopes).to eq([:overdue])
+        end
+      end
+
+      context 'when the escalation is due soon' do
+        it 'returns an array with :due_soon' do
+          result = described_class.new(escalations: %i[due_soon])
+          expect(result.scopes).to eq([:due_soon])
+        end
+      end
+
+      context 'when the escalation is overdue and manual' do
+        it 'returns an array with :flagged_and_overdue' do
+          result = described_class.new(escalations: %i[overdue manually_escalated])
+          expect(result.scopes).to include(:flagged_and_overdue)
+        end
+      end
+
+      context 'when the escalation is overdue and due soon' do
+        it 'returns an array with :overdue_and_due_soon' do
+          result = described_class.new(escalations: %i[overdue due_soon])
+          expect(result.scopes).to include(:overdue_and_due_soon)
+        end
+      end
+
+      context 'when the escalation is manual and due soon' do
+        it 'returns an array with :overdue_and_due_soon' do
+          result = described_class.new(escalations: %i[manually_escalated due_soon])
+          expect(result.scopes).to include(:flagged_and_due_soon)
+        end
+      end
+
+      context 'when the escalation is manual, due soon, and overdue' do
+        it 'returns an array with :all' do
+          result = described_class.new(escalations: %i[manually_escalated due_soon overdue])
+          expect(result.scopes).to include(:all)
+        end
+      end
+
+      context 'when the escalation is unknown' do
+        it 'returns an array with :all' do
+          result = described_class.new(escalations: %i[foo])
+          expect(result.scopes).to eq([:all])
+        end
+      end
+
+      context 'when there are no escalations' do
+        it 'returns an array with :all' do
+          result = described_class.new(escalations: %i[])
+          expect(result.scopes).to eq([:all])
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Allows staff to filter Defects by three types of escalation

- Manual escalation
- Overdue
- Due soon

[Related Trello Ticket](https://trello.com/c/94i9dmaB/40-4-create-ability-to-filter-for-both-escalated-defects-and-out-of-time-defects)

## Changes in this PR

Extends `DefectFilter` to allow these escalation filters to be included, and adds the required scopes in the Defect model.

## Screenshots of UI changes:

<img width="318" alt="Screenshot 2019-11-26 at 12 47 53" src="https://user-images.githubusercontent.com/456902/69634824-f9a22980-104a-11ea-9d5c-84bf77255a02.png">

