### PR TITLE
Feature/add project manager

### DIFF
--- a/app/controllers/staff/schemes_controller.rb
+++ b/app/controllers/staff/schemes_controller.rb
@@ -61,7 +61,9 @@ class Staff::SchemesController < Staff::BaseController
       :contractor_name,
       :contractor_email_address,
       :employer_agent_name,
-      :employer_agent_email_address
+      :employer_agent_email_address,
+      :project_manager_name,
+      :project_manager_email_address
     )
   end
 end

--- a/app/controllers/staff/schemes_controller.rb
+++ b/app/controllers/staff/schemes_controller.rb
@@ -62,6 +62,7 @@ class Staff::SchemesController < Staff::BaseController
       :contractor_email_address,
       :employer_agent_name,
       :employer_agent_email_address,
+      :employer_agent_phone_number,
       :project_manager_name,
       :project_manager_email_address
     )

--- a/app/views/shared/schemes/_information.html.haml
+++ b/app/views/shared/schemes/_information.html.haml
@@ -17,6 +17,9 @@
     %div.govuk-summary-list__row
       %dt.govuk-summary-list__key Employer agent email address
       %dd.govuk-summary-list__value= scheme.employer_agent_email_address
+    %div.govuk-summary-list__row
+      %dt.govuk-summary-list__key Employer agent phone number
+      %dd.govuk-summary-list__value= scheme.employer_agent_phone_number
 
 .govuk-grid-column-one-half
   %h3.govuk-heading-s Project manager details

--- a/app/views/shared/schemes/_information.html.haml
+++ b/app/views/shared/schemes/_information.html.haml
@@ -17,3 +17,13 @@
     %div.govuk-summary-list__row
       %dt.govuk-summary-list__key Employer agent email address
       %dd.govuk-summary-list__value= scheme.employer_agent_email_address
+
+.govuk-grid-column-one-half
+  %h3.govuk-heading-s Project manager details
+  %dl.govuk-summary-list.govuk-summary-list--no-border.no-actions.scheme_information.scheme_project_manager
+    %div.govuk-summary-list__row
+      %dt.govuk-summary-list__key Project manager name
+      %dd.govuk-summary-list__value= scheme.project_manager_name
+    %div.govuk-summary-list__row
+      %dt.govuk-summary-list__key Project manager email address
+      %dd.govuk-summary-list__value= scheme.project_manager_email_address

--- a/app/views/staff/schemes/edit.html.haml
+++ b/app/views/staff/schemes/edit.html.haml
@@ -13,6 +13,7 @@
         = f.input :contractor_email_address
         = f.input :employer_agent_name
         = f.input :employer_agent_email_address
+        = f.input :employer_agent_phone_number
         = f.input :project_manager_name
         = f.input :project_manager_email_address
         .govuk-form-group

--- a/app/views/staff/schemes/edit.html.haml
+++ b/app/views/staff/schemes/edit.html.haml
@@ -13,6 +13,8 @@
         = f.input :contractor_email_address
         = f.input :employer_agent_name
         = f.input :employer_agent_email_address
+        = f.input :project_manager_name
+        = f.input :project_manager_email_address
         .govuk-form-group
           %label.govuk-label.govuk-label{for: 'start_date_day'}
             Start date

--- a/app/views/staff/schemes/new.html.haml
+++ b/app/views/staff/schemes/new.html.haml
@@ -17,6 +17,8 @@
         = f.input :contractor_email_address
         = f.input :employer_agent_name
         = f.input :employer_agent_email_address
+        = f.input :project_manager_name
+        = f.input :project_manager_email_address
         .govuk-form-group
           %label.govuk-label.govuk-label{for: 'start_date_day'}
             Start date

--- a/app/views/staff/schemes/new.html.haml
+++ b/app/views/staff/schemes/new.html.haml
@@ -17,6 +17,7 @@
         = f.input :contractor_email_address
         = f.input :employer_agent_name
         = f.input :employer_agent_email_address
+        = f.input :employer_agent_phone_number
         = f.input :project_manager_name
         = f.input :project_manager_email_address
         .govuk-form-group

--- a/db/migrate/20191204143808_add_project_manager_to_schemes.rb
+++ b/db/migrate/20191204143808_add_project_manager_to_schemes.rb
@@ -1,0 +1,6 @@
+class AddProjectManagerToSchemes < ActiveRecord::Migration[5.2]
+  def change
+    add_column :schemes, :project_manager_name, :string
+    add_column :schemes, :project_manager_email_address, :string
+  end
+end

--- a/db/migrate/20191204150141_add_employer_agent_phone_number_to_schemes.rb
+++ b/db/migrate/20191204150141_add_employer_agent_phone_number_to_schemes.rb
@@ -1,0 +1,5 @@
+class AddEmployerAgentPhoneNumberToSchemes < ActiveRecord::Migration[5.2]
+  def change
+    add_column :schemes, :employer_agent_phone_number, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_22_133859) do
+ActiveRecord::Schema.define(version: 2019_12_04_143808) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -127,6 +127,8 @@ ActiveRecord::Schema.define(version: 2019_11_22_133859) do
     t.string "employer_agent_name"
     t.string "employer_agent_email_address"
     t.date "start_date"
+    t.string "project_manager_name"
+    t.string "project_manager_email_address"
     t.index ["estate_id"], name: "index_schemes_on_estate_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_04_143808) do
+ActiveRecord::Schema.define(version: 2019_12_04_150141) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -129,6 +129,7 @@ ActiveRecord::Schema.define(version: 2019_12_04_143808) do
     t.date "start_date"
     t.string "project_manager_name"
     t.string "project_manager_email_address"
+    t.string "employer_agent_phone_number"
     t.index ["estate_id"], name: "index_schemes_on_estate_id"
   end
 

--- a/spec/features/staff_can_create_a_scheme_spec.rb
+++ b/spec/features/staff_can_create_a_scheme_spec.rb
@@ -21,6 +21,8 @@ RSpec.feature 'Staff can create a scheme' do
       fill_in 'scheme[contractor_email_address]', with: 'email@example.com'
       fill_in 'scheme[employer_agent_name]', with: 'Alex'
       fill_in 'scheme[employer_agent_email_address]', with: 'alex@example.com'
+      fill_in 'scheme[project_manager_name]', with: 'Sara'
+      fill_in 'scheme[project_manager_email_address]', with: 'sara@example.com'
       fill_in 'start_date[day]', with: '1'
       fill_in 'start_date[month]', with: '2'
       fill_in 'start_date[year]', with: '2019'
@@ -41,6 +43,8 @@ RSpec.feature 'Staff can create a scheme' do
     expect(page).to have_content(scheme.contractor_email_address)
     expect(page).to have_content(scheme.employer_agent_name)
     expect(page).to have_content(scheme.employer_agent_email_address)
+    expect(page).to have_content(scheme.project_manager_name)
+    expect(page).to have_content(scheme.project_manager_email_address)
   end
 
   scenario 'an invalid scheme cannot be submitted' do

--- a/spec/features/staff_can_create_a_scheme_spec.rb
+++ b/spec/features/staff_can_create_a_scheme_spec.rb
@@ -21,6 +21,7 @@ RSpec.feature 'Staff can create a scheme' do
       fill_in 'scheme[contractor_email_address]', with: 'email@example.com'
       fill_in 'scheme[employer_agent_name]', with: 'Alex'
       fill_in 'scheme[employer_agent_email_address]', with: 'alex@example.com'
+      fill_in 'scheme[employer_agent_phone_number]', with: '07712345678'
       fill_in 'scheme[project_manager_name]', with: 'Sara'
       fill_in 'scheme[project_manager_email_address]', with: 'sara@example.com'
       fill_in 'start_date[day]', with: '1'
@@ -43,6 +44,7 @@ RSpec.feature 'Staff can create a scheme' do
     expect(page).to have_content(scheme.contractor_email_address)
     expect(page).to have_content(scheme.employer_agent_name)
     expect(page).to have_content(scheme.employer_agent_email_address)
+    expect(page).to have_content(scheme.employer_agent_phone_number)
     expect(page).to have_content(scheme.project_manager_name)
     expect(page).to have_content(scheme.project_manager_email_address)
   end

--- a/spec/features/staff_can_update_a_scheme_spec.rb
+++ b/spec/features/staff_can_update_a_scheme_spec.rb
@@ -25,6 +25,8 @@ RSpec.feature 'Staff can update a scheme' do
       fill_in 'scheme[contractor_email_address]', with: 'new@email.com'
       fill_in 'scheme[employer_agent_name]', with: 'Alex'
       fill_in 'scheme[employer_agent_email_address]', with: 'alex@example.com'
+      fill_in 'scheme[project_manager_name]', with: 'Sara'
+      fill_in 'scheme[project_manager_email_address]', with: 'sara@example.com'
       click_on(I18n.t('button.update.scheme'))
     end
   end

--- a/spec/features/staff_can_update_a_scheme_spec.rb
+++ b/spec/features/staff_can_update_a_scheme_spec.rb
@@ -25,6 +25,7 @@ RSpec.feature 'Staff can update a scheme' do
       fill_in 'scheme[contractor_email_address]', with: 'new@email.com'
       fill_in 'scheme[employer_agent_name]', with: 'Alex'
       fill_in 'scheme[employer_agent_email_address]', with: 'alex@example.com'
+      fill_in 'scheme[employer_agent_phone_number]', with: '07712345678'
       fill_in 'scheme[project_manager_name]', with: 'Sara'
       fill_in 'scheme[project_manager_email_address]', with: 'sara@example.com'
       click_on(I18n.t('button.update.scheme'))


### PR DESCRIPTION
## Changes in this PR:

This PR adds three new fields into the Scheme object;

- Project Manager Name
- Project Manager Email Address
- Employer Agent Phone Number

All fields just need to be available on create and edit and be displayed when viewing the scheme.

## Screenshots of UI changes:

<img width="830" alt="Screenshot 2019-12-04 at 15 12 29" src="https://user-images.githubusercontent.com/456902/70154515-86cb2b00-16a8-11ea-8ce7-8a38fac42d1c.png">

