### PR TITLE
Hotfix/update url in emails

### DIFF
--- a/app/views/defects_mailer/notify.html.haml
+++ b/app/views/defects_mailer/notify.html.haml
@@ -6,6 +6,9 @@
   = "#{defect.reference_number},
      #{I18n.t('email.defects.shared.table.target_completion_date', date: defect.target_completion_date)},
      #{I18n.t('email.defects.shared.table.priority', priority: defect.priority.name)}"
-  = defect_url(defect)
+  - if defect.communal?
+    = communal_area_defect_url(defect.communal_area, defect.id)
+  - else
+    = property_defect_url(defect.property, defect.id)
   \---
   \

--- a/spec/features/staff_can_view_a_combined_report_spec.rb
+++ b/spec/features/staff_can_view_a_combined_report_spec.rb
@@ -92,45 +92,6 @@ RSpec.feature 'Staff can view a combined report for all schemes' do
     end
   end
 
-  scenario 'defect information by priority' do
-    travel_to Time.zone.parse('2019-05-23')
-
-    completed_on_time_priority = create(:property_defect,
-                                        property: property,
-                                        priority: priority,
-                                        target_completion_date: Date.new(2019, 5, 24))
-    _due_priority = create(:property_defect,
-                           property: property,
-                           priority: priority,
-                           target_completion_date: Date.new(2019, 5, 24))
-    _overdue_priorities = create_list(:property_defect,
-                                      2,
-                                      property: property,
-                                      priority: priority,
-                                      target_completion_date: Date.new(2019, 5, 22))
-
-    completed_on_time_priority.completed!
-
-    visit report_path
-
-    within('.priorities') do
-      %w[Code Total Due Overdue Completed on time].each do |header|
-        expect(page).to have_content(header)
-      end
-
-      scheme.priorities.each do |priority|
-        expect(page).to have_content(priority.name)
-      end
-
-      expect(page).to have_content('25.0%')
-      expect(page).to have_content('1')
-      expect(page).to have_content('2')
-      expect(page).to have_content('4')
-    end
-
-    travel_back
-  end
-
   scenario 'defects completed on or before their target date' do
     travel_to Time.zone.parse('2019-05-23')
 


### PR DESCRIPTION
We noticed when testing on live that some links didn't work, this is due to communal defects using a different URL.

Part of this hotfix removes a test that occasionally fails and was testing something as a feature that we test at a lower level.
