### PR TITLE
[FIX] Improve calculations in Combined Report view

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ group :development, :test do
   gem 'pry'
   gem 'dxw-utils', git: 'https://github.com/dxw/dxw-utils'
   gem 'bullet'
+  gem 'dotenv-rails'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,6 +95,10 @@ GEM
     crass (1.0.5)
     database_cleaner (1.7.0)
     diff-lcs (1.3)
+    dotenv (2.7.6)
+    dotenv-rails (2.7.6)
+      dotenv (= 2.7.6)
+      railties (>= 3.2)
     erubi (1.9.0)
     erubis (2.7.0)
     excon (0.68.0)
@@ -389,6 +393,7 @@ DEPENDENCIES
   carrierwave (~> 2.0)
   coffee-rails (~> 4.2)
   database_cleaner
+  dotenv-rails
   dxw-utils!
   factory_bot_rails
   faker
@@ -435,4 +440,4 @@ RUBY VERSION
    ruby 2.6.1p33
 
 BUNDLED WITH
-   2.0.2
+   2.1.4

--- a/app/presenters/report_presenter.rb
+++ b/app/presenters/report_presenter.rb
@@ -35,7 +35,10 @@ class ReportPresenter
 
   def overdue_defects_by_priority(priority:)
     defects = defects_by_priority(priority: priority)
-    defects.where('target_completion_date < ?', Date.current)
+    defects_completed_late = defects.where('target_completion_date < actual_completion_date')
+    defects_still_open_and_overdue = defects.open.where('target_completion_date < ?', Date.current)
+
+    (defects_completed_late + defects_still_open_and_overdue).uniq
   end
 
   def defects_completed_on_time(priority:)

--- a/app/presenters/report_presenter.rb
+++ b/app/presenters/report_presenter.rb
@@ -30,7 +30,7 @@ class ReportPresenter
 
   def due_defects_by_priority(priority:)
     defects = defects_by_priority(priority: priority)
-    defects.where('target_completion_date >= ?', Date.current)
+    defects.open.where('target_completion_date >= ?', Date.current)
   end
 
   def overdue_defects_by_priority(priority:)

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -25,6 +25,9 @@ services:
     container_name: report-a-defect_test_db_1
     volumes:
       - pg_test_data:/var/lib/postgresql/data/:cached
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_HOST_AUTH_METHOD=trust
     networks:
       - test
     restart: on-failure

--- a/spec/factories/defects.rb
+++ b/spec/factories/defects.rb
@@ -1,4 +1,5 @@
 FactoryBot.define do
+  old_date = "2019-01-01"
   factory :defect do
     title { Faker::Lorem.paragraph_by_chars(50) }
     description { Faker::Lorem.paragraph_by_chars(750) }
@@ -7,7 +8,9 @@ FactoryBot.define do
     contact_email_address { Faker::Internet.email }
     contact_phone_number { Faker::Base.numerify('###########') }
     trade { Defect::TRADES.sample }
-    target_completion_date { Faker::Date.between(1.day.from_now, 5.days.from_now) }
+    target_completion_date { Faker::Date.between(old_date, 5.days.from_now) }
+    created_at { Faker::Date.between(old_date, Date.today) }
+
     status { Defect.statuses.keys.sample }
 
     association :priority, factory: :priority

--- a/spec/features/staff_can_view_a_combined_report_spec.rb
+++ b/spec/features/staff_can_view_a_combined_report_spec.rb
@@ -6,17 +6,20 @@ RSpec.feature 'Staff can view a combined report for all schemes' do
   end
 
   let(:scheme) { create(:scheme, created_at: 5.days.ago, start_date: 5.days.ago) }
-  let(:priority) { create(:priority, scheme: scheme) }
+  let(:priority) { create(:priority, scheme: scheme, name: 'P1') }
   let(:property) { create(:property, scheme: scheme) }
   let(:communal_area) { create(:communal_area, scheme: scheme) }
 
   let(:second_scheme) { create(:scheme, created_at: 5.days.ago, start_date: 5.days.ago) }
-  let(:second_priority) { create(:priority, scheme: second_scheme) }
+  let(:second_priority) { create(:priority, scheme: second_scheme, name: 'P2') }
   let(:second_property) { create(:property, scheme: second_scheme) }
 
   scenario 'summary information for all defects belonging to the schemes' do
-    create_list(:property_defect, 1, property: property, priority: priority)
-    create_list(:communal_defect, 2, communal_area: communal_area, priority: priority)
+    property_defects_count = 1
+    communal_defects_count = 2
+    total = property_defects_count + communal_defects_count
+    create_list(:property_defect, property_defects_count, property: property, priority: priority)
+    create_list(:communal_defect, communal_defects_count, communal_area: communal_area, priority: priority)
 
     visit dashboard_path
 
@@ -30,10 +33,7 @@ RSpec.feature 'Staff can view a combined report for all schemes' do
         expect(page).to have_content(column_header)
       end
       within('tbody tr') do
-        expect(page).to have_content('Total defects')
-        expect(page).to have_content('1')
-        expect(page).to have_content('2')
-        expect(page).to have_content('3')
+        expect(page).to have_content("Total defects #{property_defects_count} #{communal_defects_count} #{total}")
       end
     end
   end
@@ -92,36 +92,63 @@ RSpec.feature 'Staff can view a combined report for all schemes' do
     end
   end
 
-  scenario 'defects completed on or before their target date' do
+  scenario 'defects closed on or before their target date' do
     travel_to Time.zone.parse('2019-05-23')
 
-    completed_early_defect = create(:property_defect,
+    _completed_early_defect = create(:property_defect,
+                                     property: property,
+                                     priority: priority,
+                                     status: 'completed',
+                                     target_completion_date: Date.new(2019, 5, 22),
+                                     actual_completion_date: Date.new(2019, 5, 21))
+    _completed_on_time_defect = create(:property_defect,
+                                       property: property,
+                                       priority: priority,
+                                       status: 'completed',
+                                       target_completion_date: Date.new(2019, 5, 23),
+                                       actual_completion_date: Date.new(2019, 5, 23))
+    _closed_on_time_defect = create(:property_defect,
                                     property: property,
                                     priority: priority,
-                                    target_completion_date: Date.new(2019, 5, 22),
-                                    actual_completion_date: Date.new(2019, 5, 21))
-    completed_on_time_defect = create(:property_defect,
+                                    status: 'closed',
+                                    target_completion_date: Date.new(2019, 5, 23),
+                                    actual_completion_date: Date.new(2019, 5, 23))
+    _rejected_on_time_defect = create(:property_defect,
                                       property: property,
                                       priority: priority,
+                                      status: 'rejected',
                                       target_completion_date: Date.new(2019, 5, 23),
                                       actual_completion_date: Date.new(2019, 5, 23))
-    completed_later_defect = create(:property_defect,
+    _completed_late_defect = create(:property_defect,
                                     property: property,
                                     priority: priority,
+                                    status: 'completed',
                                     target_completion_date: Date.new(2019, 5, 24),
                                     actual_completion_date: Date.new(2019, 5, 25))
-
-    # Update the records status so that PublicActivity creates the required defect.update events
-    [
-      completed_early_defect,
-      completed_on_time_defect,
-      completed_later_defect,
-    ].each(&:completed!)
+    _raised_in_error_late_defect = create(:property_defect,
+                                          property: property,
+                                          priority: priority,
+                                          status: 'raised_in_error',
+                                          target_completion_date: Date.new(2019, 5, 24),
+                                          actual_completion_date: Date.new(2019, 5, 25))
+    _overdue_open_defect = create(:property_defect,
+                                  property: property,
+                                  priority: priority,
+                                  status: 'outstanding',
+                                  target_completion_date: Date.new(2019, 5, 22))
+    _old_defect_with_no_actual_completion_date = create(:property_defect,
+                                                                  property: property,
+                                                                  priority: priority,
+                                                                  status: 'completed',
+                                                                  target_completion_date: Date.new(2019, 5, 24))
 
     visit report_path
 
     within('.priorities') do
-      expect(page).to have_content('2')
+      expect(page).to have_content(
+        'Code Due Overdue Total Completed on time Percentage completed on time'
+      )
+      expect(page).to have_content('P1 0 4 8 4 50.0%')
     end
 
     travel_back

--- a/spec/features/staff_can_view_a_combined_report_spec.rb
+++ b/spec/features/staff_can_view_a_combined_report_spec.rb
@@ -98,15 +98,18 @@ RSpec.feature 'Staff can view a combined report for all schemes' do
     completed_early_defect = create(:property_defect,
                                     property: property,
                                     priority: priority,
-                                    target_completion_date: Date.new(2019, 5, 22))
+                                    target_completion_date: Date.new(2019, 5, 22),
+                                    actual_completion_date: Date.new(2019, 5, 21))
     completed_on_time_defect = create(:property_defect,
                                       property: property,
                                       priority: priority,
-                                      target_completion_date: Date.new(2019, 5, 23))
+                                      target_completion_date: Date.new(2019, 5, 23),
+                                      actual_completion_date: Date.new(2019, 5, 23))
     completed_later_defect = create(:property_defect,
                                     property: property,
                                     priority: priority,
-                                    target_completion_date: Date.new(2019, 5, 24))
+                                    target_completion_date: Date.new(2019, 5, 24),
+                                    actual_completion_date: Date.new(2019, 5, 25))
 
     # Update the records status so that PublicActivity creates the required defect.update events
     [

--- a/spec/features/staff_can_view_a_scheme_report_spec.rb
+++ b/spec/features/staff_can_view_a_scheme_report_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature 'Staff can view a report for a scheme' do
   end
 
   let(:scheme) { create(:scheme, created_at: 5.days.ago) }
-  let(:priority) { create(:priority, scheme: scheme) }
+  let(:priority) { create(:priority, scheme: scheme, name: 'P1', days: 10) }
   let(:property) { create(:property, scheme: scheme) }
   let(:communal_area) { create(:communal_area, scheme: scheme) }
 
@@ -93,42 +93,32 @@ RSpec.feature 'Staff can view a report for a scheme' do
   scenario 'defect information by scheme priority' do
     travel_to Time.zone.parse('2019-05-23')
 
-    completed_on_time_priority = create(:property_defect,
-                                        property: property,
-                                        priority: priority,
-                                        target_completion_date: Date.new(2019, 5, 24),
-                                        status: :completed)
-    completed_on_time_priority.activities.create!(key: 'defect.update',
-                                                  parameters: {
-                                                    changes: { status: ['', 'completed'] },
-                                                  })
-
+    _completed_on_time_priority = create(:property_defect,
+                                         property: property,
+                                         priority: priority,
+                                         target_completion_date: Date.new(2019, 5, 24),
+                                         actual_completion_date: Date.new(2019, 5, 24),
+                                         status: :completed)
     _due_priority = create(:property_defect,
                            property: property,
                            priority: priority,
+                           status: 'outstanding',
                            target_completion_date: Date.new(2019, 5, 24))
     _overdue_priorities = create_list(:property_defect,
                                       2,
                                       property: property,
                                       priority: priority,
+                                      status: 'outstanding',
                                       target_completion_date: Date.new(2019, 5, 22))
 
     visit report_scheme_path(scheme)
 
     within('.priorities') do
-      %w[Code Days Total Due Overdue Completed on time].each do |header|
-        expect(page).to have_content(header)
-      end
+      expect(page).to have_content(
+        'Code Days Due Overdue Total Completed on time Percentage completed on time'
+      )
 
-      scheme.priorities.each do |priority|
-        expect(page).to have_content(priority.name)
-        expect(page).to have_content(priority.days)
-      end
-
-      expect(page).to have_content('25.0%')
-      expect(page).to have_content('1')
-      expect(page).to have_content('2')
-      expect(page).to have_content('4')
+      expect(page).to have_content('P1 10 1 2 4 1 33.33%')
     end
 
     travel_back
@@ -137,33 +127,39 @@ RSpec.feature 'Staff can view a report for a scheme' do
   scenario 'defects completed on or before their target date' do
     travel_to Time.zone.parse('2019-05-23')
 
-    completed_early_defect = create(:property_defect,
-                                    property: property,
-                                    priority: priority,
-                                    target_completion_date: Date.new(2019, 5, 22))
-    completed_on_time_defect = create(:property_defect,
-                                      property: property,
-                                      priority: priority,
-                                      target_completion_date: Date.new(2019, 5, 23))
-    completed_later_defect = create(:property_defect,
-                                    property: property,
-                                    priority: priority,
-                                    target_completion_date: Date.new(2019, 5, 24))
+    _completed_early_defect = create(:property_defect,
+                                     property: property,
+                                     priority: priority,
+                                     status: 'completed',
+                                     target_completion_date: Date.new(2019, 5, 22),
+                                     actual_completion_date: Date.new(2019, 5, 21))
+    _completed_on_time_defect = create(:property_defect,
+                                       property: property,
+                                       priority: priority,
+                                       status: 'completed',
+                                       target_completion_date: Date.new(2019, 5, 23),
+                                       actual_completion_date: Date.new(2019, 5, 23))
+    _completed_later_defect = create(:property_defect,
+                                     property: property,
+                                     priority: priority,
+                                     status: 'completed',
+                                     target_completion_date: Date.new(2019, 5, 24),
+                                     actual_completion_date: Date.new(2019, 5, 25))
+    _old_defect_with_no_actual_completion_date = create(:property_defect,
+                                                        property: property,
+                                                        priority: priority,
+                                                        status: 'completed',
+                                                        target_completion_date: Date.new(2019, 5, 24))
 
-    # Update the records status so that PublicActivity creates the required defect.update events
-    [
-      completed_early_defect,
-      completed_on_time_defect,
-      completed_later_defect,
-    ].each(&:completed!)
-
+    travel_back
     visit report_scheme_path(scheme)
 
     within('.priorities') do
-      expect(page).to have_content('2')
+      expect(page).to have_content(
+        'Code Days Due Overdue Total Completed on time Percentage completed on time'
+      )
+      expect(page).to have_content('P1 10 0 1 4 2 66.67%')
     end
-
-    travel_back
   end
 
   scenario 'filter defects' do

--- a/spec/presenters/combined_report_presenter_spec.rb
+++ b/spec/presenters/combined_report_presenter_spec.rb
@@ -188,27 +188,44 @@ RSpec.describe CombinedReportPresenter do
   end
 
   describe '#overdue_defects_by_priority' do
-    it 'returns all defects with a target_completion_date before todays date' do
+    it 'returns all defects completed late, or with a target_completion_date before todays date' do
       travel_to Time.zone.parse('2019-05-23')
 
       due_tomorrow_priority_defect = create(:property_defect,
                                             property: property,
                                             priority: priority,
+                                            status: 'outstanding',
                                             target_completion_date: Date.new(2019, 5, 24))
       due_today_priority_defect = create(:property_defect,
                                          property: property,
                                          priority: priority,
+                                         status: 'outstanding',
                                          target_completion_date: Date.new(2019, 5, 23))
+      priority_defect_completed_on_time = create(:property_defect,
+                                                 property: property,
+                                                 priority: priority,
+                                                 status: 'completed',
+                                                 target_completion_date: Date.new(2019, 5, 22),
+                                                 actual_completion_date: Date.new(2019, 5, 21))
       overdue_priority_defect = create(:property_defect,
                                        property: property,
                                        priority: priority,
+                                       status: 'outstanding',
                                        target_completion_date: Date.new(2019, 5, 22))
+      late_completed_priority_defect = create(:property_defect,
+                                              property: property,
+                                              priority: priority,
+                                              status: 'outstanding',
+                                              target_completion_date: Date.new(2019, 5, 22),
+                                              actual_completion_date: Date.new(2019, 5, 23))
 
       result = described_class.new(schemes: schemes).overdue_defects_by_priority(priority: priority.name)
 
       expect(result).not_to include(due_tomorrow_priority_defect)
       expect(result).not_to include(due_today_priority_defect)
+      expect(result).not_to include(priority_defect_completed_on_time)
       expect(result).to include(overdue_priority_defect)
+      expect(result).to include(late_completed_priority_defect)
 
       travel_back
     end

--- a/spec/presenters/combined_report_presenter_spec.rb
+++ b/spec/presenters/combined_report_presenter_spec.rb
@@ -152,26 +152,35 @@ RSpec.describe CombinedReportPresenter do
   end
 
   describe '#due_defects_by_priority' do
-    it 'returns all defects with a target_completion_date before todays date' do
+    it 'returns all open defects with a target_completion_date before todays date' do
       travel_to Time.zone.parse('2019-05-23')
 
       due_tomorrow_priority_defect = create(:property_defect,
                                             property: property,
                                             priority: priority,
+                                            status: 'outstanding',
                                             target_completion_date: Date.new(2019, 5, 24))
       due_today_priority_defect = create(:property_defect,
                                          property: property,
                                          priority: priority,
+                                         status: 'outstanding',
                                          target_completion_date: Date.new(2019, 5, 23))
+      completed_priority_defect = create(:property_defect,
+                                         property: property,
+                                         priority: priority,
+                                         status: 'completed',
+                                         target_completion_date: Date.new(2019, 5, 24))
       overdue_priority_defect = create(:property_defect,
                                        property: property,
                                        priority: priority,
+                                       status: 'outstanding',
                                        target_completion_date: Date.new(2019, 5, 22))
 
       result = described_class.new(schemes: schemes).due_defects_by_priority(priority: priority.name)
 
       expect(result).to include(due_tomorrow_priority_defect)
       expect(result).to include(due_today_priority_defect)
+      expect(result).not_to include(completed_priority_defect)
       expect(result).not_to include(overdue_priority_defect)
 
       travel_back

--- a/spec/presenters/combined_report_presenter_spec.rb
+++ b/spec/presenters/combined_report_presenter_spec.rb
@@ -122,21 +122,40 @@ RSpec.describe CombinedReportPresenter do
   end
 
   describe '#priority_percentage' do
-    it 'returns the percentage of defects completed on time with this priority ' do
+    it 'returns the percentage of defects closed on time with this priority' do
       travel_to Time.zone.parse('2019-05-23')
 
-      completed_on_time_priority = create(:property_defect,
-                                          property: property,
-                                          priority: priority,
-                                          target_completion_date: Date.new(2019, 5, 24),
-                                          status: :completed)
+      _completed_on_time_priority = create(:property_defect,
+                                           property: property,
+                                           priority: priority,
+                                           target_completion_date: Date.new(2019, 5, 24),
+                                           actual_completion_date: Date.new(2019, 5, 23),
+                                           status: :completed)
 
-      completed_on_time_priority.activities.create!(key: 'defect.update',
-                                                    parameters: {
-                                                      changes: { status: ['', 'completed'] },
-                                                    })
+      _closed_on_time_priority = create(:property_defect,
+                                        property: property,
+                                        priority: priority,
+                                        target_completion_date: Date.new(2019, 5, 24),
+                                        actual_completion_date: Date.new(2019, 5, 23),
+                                        status: :closed)
 
-      create(:property_defect, property: property, priority: priority)
+      _completed_late_priority = create(
+        :property_defect,
+        property: property,
+        priority: priority,
+        target_completion_date: Date.new(2019, 5, 24),
+        actual_completion_date: Date.new(2019, 5, 25),
+        status: :completed
+      )
+
+      _still_overdue_priority = create(
+        :property_defect,
+        property: property,
+        priority: priority,
+        target_completion_date: Date.new(2019, 5, 22),
+        status: :outstanding
+      )
+
       result = described_class.new(schemes: schemes).priority_percentage(priority: priority.name)
       expect(result).to eql('50.0%')
 
@@ -238,54 +257,26 @@ RSpec.describe CombinedReportPresenter do
                                       status: :completed,
                                       property: property,
                                       priority: priority,
-                                      target_completion_date: Date.new(2019, 5, 23))
+                                      target_completion_date: Date.new(2019, 5, 23),
+                                      actual_completion_date: Date.new(2019, 5, 22))
       completed_on_time_defect = create(:property_defect,
                                         status: :completed,
                                         property: property,
                                         priority: priority,
-                                        target_completion_date: Date.new(2019, 5, 23))
+                                        target_completion_date: Date.new(2019, 5, 23),
+                                        actual_completion_date: Date.new(2019, 5, 23))
       completed_later_defect = create(:property_defect,
                                       status: :completed,
                                       property: property,
                                       priority: priority,
-                                      target_completion_date: Date.new(2019, 5, 23))
-      travel_back
+                                      target_completion_date: Date.new(2019, 5, 23),
+                                      actual_completion_date: Date.new(2019, 5, 24))
 
-      travel_to Time.zone.local(2019, 5, 22, 10, 10, 10) do
-        completed_early_defect.create_activity(
-          key: 'defect.update',
-          parameters: {
-            changes:
-            {
-              status: %w[outstanding completed],
-            },
-          },
-        )
-      end
-
-      travel_to Time.zone.local(2019, 5, 23, 10, 10, 10) do
-        completed_on_time_defect.create_activity(
-          key: 'defect.update',
-          parameters: {
-            changes:
-            {
-              status: %w[outstanding completed],
-            },
-          }
-        )
-      end
-
-      travel_to Time.zone.local(2019, 5, 24, 10, 10, 10) do
-        completed_on_time_defect.create_activity(
-          key: 'defect.update',
-          parameters: {
-            changes:
-            {
-              status: %w[outstanding completed],
-            },
-          },
-        )
-      end
+      completed_defect_no_actual_completion_date = create(:property_defect,
+                                                          status: :completed,
+                                                          property: property,
+                                                          priority: priority,
+                                                          target_completion_date: Date.new(2019, 5, 23))
 
       travel_to Time.zone.local(2019, 5, 23, 10, 20, 10)
 
@@ -294,49 +285,33 @@ RSpec.describe CombinedReportPresenter do
       expect(result).to include(completed_early_defect)
       expect(result).to include(completed_on_time_defect)
       expect(result).not_to include(completed_later_defect)
+      expect(result).not_to include(completed_defect_no_actual_completion_date)
 
       travel_back
     end
 
     it 'returns only completed defects' do
       travel_to Time.zone.local(2019, 5, 23, 10, 10, 10)
+
+      completed_early_defect = create(:property_defect,
+                                      status: :completed,
+                                      property: property,
+                                      priority: priority,
+                                      target_completion_date: Date.new(2019, 5, 23),
+                                      actual_completion_date: Date.new(2019, 5, 22))
+
       rejected_defect = create(:property_defect,
                                status: :rejected,
                                property: property,
                                priority: priority,
                                target_completion_date: Date.current)
-      rejected_defect.create_activity(
-        key: 'defect.update',
-        parameters: {
-          changes:
-          {
-            status: %w[outstanding rejected],
-          },
-        },
-      )
-      completed_defect = create(:property_defect,
-                                status: :completed,
-                                property: property,
-                                priority: priority,
-                                target_completion_date: Date.current)
-
-      completed_defect.create_activity(
-        key: 'defect.update',
-        parameters: {
-          changes:
-          {
-            status: %w[outstanding completed],
-          },
-        },
-      )
-
       travel_back
 
       travel_to Time.zone.local(2019, 5, 23, 10, 20, 10)
 
       result = described_class.new(schemes: schemes).defects_completed_on_time(priority: priority.name)
 
-      expect(result).to include(completed_defect)
+      expect(result).to include(completed_early_defect)
       expect(result).not_to include(rejected_defect)
 
       travel_back
@@ -347,9 +322,10 @@ RSpec.describe CombinedReportPresenter do
         completed_on_time_defect = create(:property_defect,
                                           property: property,
                                           priority: priority,
-                                          target_completion_date: Date.new(2019, 5, 23))
+                                          status: :completed,
+                                          target_completion_date: Date.new(2019, 5, 23),
+                                          actual_completion_date: Date.new(2019, 5, 23))
 
-        completed_on_time_defect.completed!
         completed_on_time_defect.outstanding!
 
         result = described_class.new(schemes: schemes).defects_completed_on_time(priority: priority)

--- a/spec/presenters/scheme_report_presenter_spec.rb
+++ b/spec/presenters/scheme_report_presenter_spec.rb
@@ -171,20 +171,29 @@ RSpec.describe SchemeReportPresenter do
       due_tomorrow_priority_defect = create(:property_defect,
                                             property: property,
                                             priority: priority,
+                                            status: 'outstanding',
                                             target_completion_date: Date.new(2019, 5, 24))
       due_today_priority_defect = create(:property_defect,
                                          property: property,
                                          priority: priority,
+                                         status: 'outstanding',
                                          target_completion_date: Date.new(2019, 5, 23))
+      completed_priority_defect = create(:property_defect,
+                                         property: property,
+                                         priority: priority,
+                                         status: 'completed',
+                                         target_completion_date: Date.new(2019, 5, 24))
       overdue_priority_defect = create(:property_defect,
                                        property: property,
                                        priority: priority,
+                                       status: 'outstanding',
                                        target_completion_date: Date.new(2019, 5, 22))
 
       result = described_class.new(scheme: scheme).due_defects_by_priority(priority: priority)
 
       expect(result).to include(due_tomorrow_priority_defect)
       expect(result).to include(due_today_priority_defect)
+      expect(result).not_to include(completed_priority_defect)
       expect(result).not_to include(overdue_priority_defect)
 
       travel_back

--- a/spec/presenters/scheme_report_presenter_spec.rb
+++ b/spec/presenters/scheme_report_presenter_spec.rb
@@ -138,20 +138,40 @@ RSpec.describe SchemeReportPresenter do
     it 'returns the percentage of defects completed on time with this priority ' do
       travel_to Time.zone.parse('2019-05-23')
 
-      completed_on_time_priority = create(:property_defect,
-                                          property: property,
-                                          priority: priority,
-                                          target_completion_date: Date.new(2019, 5, 24),
-                                          status: :completed)
+      _completed_on_time_priority = create(:property_defect,
+                                           property: property,
+                                           priority: priority,
+                                           target_completion_date: Date.new(2019, 5, 24),
+                                           actual_completion_date: Date.new(2019, 5, 23),
+                                           status: :completed)
 
-      completed_on_time_priority.activities.create!(key: 'defect.update',
-                                                    parameters: {
-                                                      changes: { status: ['', 'completed'] },
-                                                    })
+      _completed_late_priority = create(
+        :property_defect,
+        property: property,
+        priority: priority,
+        target_completion_date: Date.new(2019, 5, 24),
+        actual_completion_date: Date.new(2019, 5, 25),
+        status: :completed
+      )
 
-      create(:property_defect, property: property, priority: priority)
+      _still_overdue_priority = create(
+        :property_defect,
+        property: property,
+        priority: priority,
+        target_completion_date: Date.new(2019, 5, 22),
+        status: :outstanding
+      )
+
+      _completed_with_no_actual_completion_date = create(
+        :property_defect,
+        property: property,
+        priority: priority,
+        target_completion_date: Date.new(2019, 5, 24),
+        status: :completed
+      )
+
       result = described_class.new(scheme: scheme).priority_percentage(priority: priority)
-      expect(result).to eql('50.0%')
+      expect(result).to eql('33.33%')
 
       travel_back
     end
@@ -214,6 +234,12 @@ RSpec.describe SchemeReportPresenter do
                                          priority: priority,
                                          status: 'outstanding',
                                          target_completion_date: Date.new(2019, 5, 23))
+      priority_defect_completed_on_time = create(:property_defect,
+                                                 property: property,
+                                                 priority: priority,
+                                                 status: 'completed',
+                                                 target_completion_date: Date.new(2019, 5, 22),
+                                                 actual_completion_date: Date.new(2019, 5, 21))
       overdue_priority_defect = create(:property_defect,
                                        property: property,
                                        priority: priority,
@@ -230,6 +256,7 @@ RSpec.describe SchemeReportPresenter do
 
       expect(result).not_to include(due_tomorrow_priority_defect)
       expect(result).not_to include(due_today_priority_defect)
+      expect(result).not_to include(priority_defect_completed_on_time)
       expect(result).to include(overdue_priority_defect)
       expect(result).to include(late_completed_priority_defect)
 
@@ -240,58 +267,31 @@ RSpec.describe SchemeReportPresenter do
   describe '#defects_completed_on_time' do
     it 'returns a count for all defects completed before or on their target date' do
       travel_to Time.zone.local(2019, 5, 21, 10, 0, 0)
+      travel_to Time.zone.local(2019, 5, 21, 10, 0, 0)
       completed_early_defect = create(:property_defect,
                                       status: :completed,
                                       property: property,
                                       priority: priority,
-                                      target_completion_date: Date.new(2019, 5, 23))
+                                      target_completion_date: Date.new(2019, 5, 23),
+                                      actual_completion_date: Date.new(2019, 5, 22))
       completed_on_time_defect = create(:property_defect,
                                         status: :completed,
                                         property: property,
                                         priority: priority,
-                                        target_completion_date: Date.new(2019, 5, 23))
+                                        target_completion_date: Date.new(2019, 5, 23),
+                                        actual_completion_date: Date.new(2019, 5, 23))
       completed_later_defect = create(:property_defect,
                                       status: :completed,
                                       property: property,
                                       priority: priority,
-                                      target_completion_date: Date.new(2019, 5, 23))
-      travel_back
+                                      target_completion_date: Date.new(2019, 5, 23),
+                                      actual_completion_date: Date.new(2019, 5, 24))
 
-      travel_to Time.zone.local(2019, 5, 22, 10, 10, 10) do
-        completed_early_defect.create_activity(
-          key: 'defect.update',
-          parameters: {
-            changes:
-            {
-              status: %w[outstanding completed],
-            },
-          },
-        )
-      end
-
-      travel_to Time.zone.local(2019, 5, 23, 10, 10, 10) do
-        completed_on_time_defect.create_activity(
-          key: 'defect.update',
-          parameters: {
-            changes:
-            {
-              status: %w[outstanding completed],
-            },
-          }
-        )
-      end
-
-      travel_to Time.zone.local(2019, 5, 24, 10, 10, 10) do
-        completed_on_time_defect.create_activity(
-          key: 'defect.update',
-          parameters: {
-            changes:
-            {
-              status: %w[outstanding completed],
-            },
-          },
-        )
-      end
+      completed_defect_no_actual_completion_date = create(:property_defect,
+                                                          status: :completed,
+                                                          property: property,
+                                                          priority: priority,
+                                                          target_completion_date: Date.new(2019, 5, 23))
 
       travel_to Time.zone.local(2019, 5, 23, 10, 20, 10)
 
@@ -300,41 +300,26 @@ RSpec.describe SchemeReportPresenter do
       expect(result).to include(completed_early_defect)
       expect(result).to include(completed_on_time_defect)
       expect(result).not_to include(completed_later_defect)
+      expect(result).not_to include(completed_defect_no_actual_completion_date)
 
       travel_back
     end
 
     it 'returns only completed defects' do
       travel_to Time.zone.local(2019, 5, 23, 10, 10, 10)
+
       rejected_defect = create(:property_defect,
                                status: :rejected,
                                property: property,
                                priority: priority,
                                target_completion_date: Date.current)
-      rejected_defect.create_activity(
-        key: 'defect.update',
-        parameters: {
-          changes:
-          {
-            status: %w[outstanding rejected],
-          },
-        },
-      )
+
       completed_defect = create(:property_defect,
                                 status: :completed,
                                 property: property,
                                 priority: priority,
-                                target_completion_date: Date.current)
-
-      completed_defect.create_activity(
-        key: 'defect.update',
-        parameters: {
-          changes:
-          {
-            status: %w[outstanding completed],
-          },
-        },
-      )
+                                target_completion_date: Date.new(2019, 5, 22),
+                                actual_completion_date: Date.new(2019, 5, 22))
 
       travel_back
 
@@ -353,9 +338,10 @@ RSpec.describe SchemeReportPresenter do
         completed_on_time_defect = create(:property_defect,
                                           property: property,
                                           priority: priority,
-                                          target_completion_date: Date.new(2019, 5, 23))
+                                          status: :completed,
+                                          target_completion_date: Date.new(2019, 5, 23),
+                                          actual_completion_date: Date.new(2019, 5, 23))
 
-        completed_on_time_defect.completed!
         completed_on_time_defect.outstanding!
 
         result = described_class.new(scheme: scheme).defects_completed_on_time(priority: priority)

--- a/spec/presenters/scheme_report_presenter_spec.rb
+++ b/spec/presenters/scheme_report_presenter_spec.rb
@@ -201,27 +201,37 @@ RSpec.describe SchemeReportPresenter do
   end
 
   describe '#overdue_defects_by_priority' do
-    it 'returns all defects with a target_completion_date before todays date' do
+    it 'returns all defects completed late, or with a target_completion_date before todays date' do
       travel_to Time.zone.parse('2019-05-23')
 
       due_tomorrow_priority_defect = create(:property_defect,
                                             property: property,
                                             priority: priority,
+                                            status: 'outstanding',
                                             target_completion_date: Date.new(2019, 5, 24))
       due_today_priority_defect = create(:property_defect,
                                          property: property,
                                          priority: priority,
+                                         status: 'outstanding',
                                          target_completion_date: Date.new(2019, 5, 23))
       overdue_priority_defect = create(:property_defect,
                                        property: property,
                                        priority: priority,
+                                       status: 'outstanding',
                                        target_completion_date: Date.new(2019, 5, 22))
+      late_completed_priority_defect = create(:property_defect,
+                                              property: property,
+                                              priority: priority,
+                                              status: 'outstanding',
+                                              target_completion_date: Date.new(2019, 5, 22),
+                                              actual_completion_date: Date.new(2019, 5, 23))
 
       result = described_class.new(scheme: scheme).overdue_defects_by_priority(priority: priority)
 
       expect(result).not_to include(due_tomorrow_priority_defect)
       expect(result).not_to include(due_today_priority_defect)
       expect(result).to include(overdue_priority_defect)
+      expect(result).to include(late_completed_priority_defect)
 
       travel_back
     end


### PR DESCRIPTION
## The problem:

This task came out of the following note from the Hackney team:

> There appears to be a discrepancy between the full download of defects data (available to download as a csv and how the data in the P1 table has been calculated. According to the full download 28/38 P1 incidents were resolved within or on there target completion date. The remaining were completed either just after the target completion date or not at all and the case was closed. There is no guidance to explain how the 'View Combined Report' (https://lbh-report-a-defect-production.herokuapp.com/report) calculates the number completed on time but I suspect there is a problem with the logic in the code for this calculation. 
> 
> In addition, in the 'Priorities' table, the denominator for the 'percentage completed on time' column does not appear to be correct - it's currently calculating number completed on time / total but the total column is just a copy of the 'overdue' column which is messing up the calculation.

## Changes in this PR:
**Issues discovered with the Combined Report view:**
1. All defects were being marked as "overdue" as the code was checking a defect's `target_completion_date` against the current date(i.e. the date the user is viewing the report, meaning everything from before today was "overdue"), even if the defect was marked as closed or completed. 
**An overdue defect is now one where its actual completed date is before its  target completion date , or where it's still open and its target completion date is in the past.**

2. The "due" column doesn't really make sense - if you're viewing a report from last year, should anything still be marked as "due"? I guess it makes sense if you're viewing the current month and looking for things that are still outstanding, but it's a little confusing. Similar to the above issue, it was including all "closed" defects as still "due". 
**All "closed" defects are now excluded from this list, but it's still a bit confusing for past defects, does it add any value? Would it be better to have something like "all defects that were opened/due during this time period" (would require a bit more work)?**

3. The "percent completed on time" data discrepancy is the main issue they've asked us to fix. In the code, we were checking against the "last" "activity" on the defect (e.g. if it was updated by someone), and comparing it to whether the status had changed to "completed". This is a bit hacky and unreliable, as the order of activities on a defect seems a bit random and not always chronological, also if a case is "re-opened", it's hard to know what to do. There was also an overlap in the number of overdue defects and those completed on time, which didn't make sense.
**We should compare a defect's target completion date against its actual completed date like we do with "overdue" defects. However, some "completed" defects, particularly those from last year don't have an actual completed date, possibly due to how the code was written before this feature, so I have excluded them from the percent completed on time (and the total number of completed defects used in the calculation) - this will need running past the Hackney team.**

This fix will need testing with the Hackney team on staging, and verifying some assumptions I've made so far.


