### PR TITLE
Improve accuracy of combined and scheme reports

### DIFF
--- a/app/presenters/report_presenter.rb
+++ b/app/presenters/report_presenter.rb
@@ -35,17 +35,17 @@ class ReportPresenter
 
   def overdue_defects_by_priority(priority:)
     (
-      defects_completed_late(priority: priority) +
+      defects_closed_late(priority: priority) +
       defects_still_open_and_overdue(priority: priority) +
-      completed_defects_with_no_completion_date(priority: priority)
+      closed_defects_with_no_completion_date(priority: priority)
     ).uniq
   end
 
   def defects_completed_on_time(priority:)
-    completed_defects(priority: priority).select do |completed_defect|
-      next if completed_defect.actual_completion_date.nil?
+    closed_defects(priority: priority).select do |closed_defect|
+      next if closed_defect.actual_completion_date.nil?
 
-      completed_defect.actual_completion_date <= completed_defect.target_completion_date
+      closed_defect.actual_completion_date <= closed_defect.target_completion_date
     end
   end
 
@@ -57,22 +57,22 @@ class ReportPresenter
     "#{percentage.round(2)}%"
   end
 
-  def completed_defects(priority:)
-    defects_by_priority(priority: priority).completed
+  def closed_defects(priority:)
+    defects_by_priority(priority: priority).closed
   end
 
-  def defects_completed_late(priority:)
+  def defects_closed_late(priority:)
     defects = defects_by_priority(priority: priority)
-    defects.completed.where('target_completion_date < actual_completion_date')
+    defects.closed.where('target_completion_date < actual_completion_date')
   end
 
   # This is a catch-all, as some defects may not have a completion date due to
   # the hacky way in which they are marked as closed - we have no way of telling whether
   # they were completed on time, so this should make any data inconsistencies obvious
   # for the team to fix
-  def completed_defects_with_no_completion_date(priority:)
+  def closed_defects_with_no_completion_date(priority:)
     defects = defects_by_priority(priority: priority)
-    defects.completed.where(actual_completion_date: nil)
+    defects.closed.where(actual_completion_date: nil)
   end
 
   def defects_still_open_and_overdue(priority:)

--- a/app/presenters/report_presenter.rb
+++ b/app/presenters/report_presenter.rb
@@ -43,17 +43,9 @@ class ReportPresenter
 
   def defects_completed_on_time(priority:)
     completed_defects(priority: priority).select do |completed_defect|
-      completed_defect_activities = completed_defect.activities.where(key: 'defect.update')
-      activities_on_time = completed_defect_activities.select do |activity|
-        activity.created_at.to_date <= completed_defect.target_completion_date
-      end
+      next if completed_defect.actual_completion_date.nil?
 
-      # TODO: Query parameter JSON at database level rather than in Ruby
-      true if activities_on_time.detect do |update_activity|
-        update_activity.parameters &&
-        update_activity.parameters[:changes] &&
-        update_activity.parameters[:changes][:status]&.last == 'completed'
-      end
+      completed_defect.actual_completion_date <= completed_defect.target_completion_date
     end
   end
 

--- a/app/presenters/report_presenter.rb
+++ b/app/presenters/report_presenter.rb
@@ -30,7 +30,7 @@ class ReportPresenter
 
   def due_defects_by_priority(priority:)
     defects = defects_by_priority(priority: priority)
-    defects.where('target_completion_date >= ?', Date.current)
+    defects.open.where('target_completion_date >= ?', Date.current)
   end
 
   def overdue_defects_by_priority(priority:)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -61,3 +61,25 @@ FactoryBot.create_list(
   communal_area: communal_area,
   priority: [priority1, priority2, priority3, priority4].sample
 )
+
+user = FactoryBot.create(:user)
+
+# Create a `defect.update` activity to simulate a change of status - updating
+# the activity more realistically (i.e. creating them as "outstanding" and
+# _then_ updating their status) is tricky, as it doesn't assign an `owner` to
+# the activity, so we're essentially lying about their status here, but it's
+# slightly closer to what actually happens.
+Defect.all.each do |defect|
+  next if defect.status.downcase == 'outstanding'
+
+  completed_statuses = %w[completed closed raised_in_error rejected]
+  if completed_statuses.include?(defect.status.downcase)
+    defect.update(actual_completion_date: Faker::Date.between(4.days.ago, 4.days.from_now))
+  end
+
+  defect.create_activity(
+    key: 'defect.update',
+    params: { changes: { status: ['outstanding', defect.status] } },
+    owner: user
+  )
+end

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -25,6 +25,9 @@ services:
     container_name: report-a-defect_test_db_1
     volumes:
       - pg_test_data:/var/lib/postgresql/data/:cached
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_HOST_AUTH_METHOD=trust
     networks:
       - test
     restart: on-failure

--- a/spec/features/staff_can_view_a_combined_report_spec.rb
+++ b/spec/features/staff_can_view_a_combined_report_spec.rb
@@ -92,7 +92,7 @@ RSpec.feature 'Staff can view a combined report for all schemes' do
     end
   end
 
-  scenario 'defects completed on or before their target date' do
+  scenario 'defects closed on or before their target date' do
     travel_to Time.zone.parse('2019-05-23')
 
     _completed_early_defect = create(:property_defect,
@@ -101,18 +101,35 @@ RSpec.feature 'Staff can view a combined report for all schemes' do
                                      status: :completed,
                                      target_completion_date: Date.new(2019, 5, 22),
                                      actual_completion_date: Date.new(2019, 5, 21))
-    _completed_on_time_defect = create(:property_defect,
-                                       property: property,
-                                       priority: priority,
-                                       status: :completed,
-                                       target_completion_date: Date.new(2019, 5, 23),
-                                       actual_completion_date: Date.new(2019, 5, 23))
+    _closed_on_time_defect = create(:property_defect,
+                                    property: property,
+                                    priority: priority,
+                                    status: :closed,
+                                    target_completion_date: Date.new(2019, 5, 23),
+                                    actual_completion_date: Date.new(2019, 5, 23))
+    _rejected_on_time_defect = create(:property_defect,
+                                      property: property,
+                                      priority: priority,
+                                      status: :rejected,
+                                      target_completion_date: Date.new(2019, 5, 23),
+                                      actual_completion_date: Date.new(2019, 5, 23))
     _completed_late_defect = create(:property_defect,
                                     property: property,
                                     priority: priority,
                                     status: :completed,
                                     target_completion_date: Date.new(2019, 5, 24),
                                     actual_completion_date: Date.new(2019, 5, 25))
+    _raised_in_error_late_defect = create(:property_defect,
+                                          property: property,
+                                          priority: priority,
+                                          status: 'raised_in_error',
+                                          target_completion_date: Date.new(2019, 5, 24),
+                                          actual_completion_date: Date.new(2019, 5, 25))
+    _overdue_open_defect = create(:property_defect,
+                                  property: property,
+                                  priority: priority,
+                                  status: 'outstanding',
+                                  target_completion_date: Date.new(2019, 5, 22))
     _old_defect_with_no_actual_completion_date = create(:property_defect,
                                                         property: property,
                                                         priority: priority,
@@ -125,7 +142,7 @@ RSpec.feature 'Staff can view a combined report for all schemes' do
       expect(page).to have_content(
         'Code Due Overdue Total Completed on time Percentage completed on time'
       )
-      expect(page).to have_content("#{priority.name} 0 2 4 2 50.0%")
+      expect(page).to have_content("#{priority.name} 0 4 7 3 42.86%")
     end
 
     travel_back

--- a/spec/features/staff_can_view_a_combined_report_spec.rb
+++ b/spec/features/staff_can_view_a_combined_report_spec.rb
@@ -98,15 +98,18 @@ RSpec.feature 'Staff can view a combined report for all schemes' do
     completed_early_defect = create(:property_defect,
                                     property: property,
                                     priority: priority,
-                                    target_completion_date: Date.new(2019, 5, 22))
+                                    target_completion_date: Date.new(2019, 5, 22),
+                                    actual_completion_date: Date.new(2019, 5, 21))
     completed_on_time_defect = create(:property_defect,
                                       property: property,
                                       priority: priority,
-                                      target_completion_date: Date.new(2019, 5, 23))
+                                      target_completion_date: Date.new(2019, 5, 23),
+                                      actual_completion_date: Date.new(2019, 5, 23))
     completed_later_defect = create(:property_defect,
                                     property: property,
                                     priority: priority,
-                                    target_completion_date: Date.new(2019, 5, 24))
+                                    target_completion_date: Date.new(2019, 5, 24),
+                                    actual_completion_date: Date.new(2019, 5, 25))
 
     # Update the records status so that PublicActivity creates the required defect.update events
     [

--- a/spec/features/staff_can_view_a_combined_report_spec.rb
+++ b/spec/features/staff_can_view_a_combined_report_spec.rb
@@ -15,8 +15,11 @@ RSpec.feature 'Staff can view a combined report for all schemes' do
   let(:second_property) { create(:property, scheme: second_scheme) }
 
   scenario 'summary information for all defects belonging to the schemes' do
-    create_list(:property_defect, 1, property: property, priority: priority)
-    create_list(:communal_defect, 2, communal_area: communal_area, priority: priority)
+    property_defects_count = 1
+    communal_defects_count = 2
+    total = property_defects_count + communal_defects_count
+    create_list(:property_defect, property_defects_count, property: property, priority: priority)
+    create_list(:communal_defect, communal_defects_count, communal_area: communal_area, priority: priority)
 
     visit dashboard_path
 
@@ -30,10 +33,7 @@ RSpec.feature 'Staff can view a combined report for all schemes' do
         expect(page).to have_content(column_header)
       end
       within('tbody tr') do
-        expect(page).to have_content('Total defects')
-        expect(page).to have_content('1')
-        expect(page).to have_content('2')
-        expect(page).to have_content('3')
+        expect(page).to have_content("Total defects #{property_defects_count} #{communal_defects_count} #{total}")
       end
     end
   end

--- a/spec/features/staff_can_view_a_combined_report_spec.rb
+++ b/spec/features/staff_can_view_a_combined_report_spec.rb
@@ -95,33 +95,37 @@ RSpec.feature 'Staff can view a combined report for all schemes' do
   scenario 'defects completed on or before their target date' do
     travel_to Time.zone.parse('2019-05-23')
 
-    completed_early_defect = create(:property_defect,
+    _completed_early_defect = create(:property_defect,
+                                     property: property,
+                                     priority: priority,
+                                     status: :completed,
+                                     target_completion_date: Date.new(2019, 5, 22),
+                                     actual_completion_date: Date.new(2019, 5, 21))
+    _completed_on_time_defect = create(:property_defect,
+                                       property: property,
+                                       priority: priority,
+                                       status: :completed,
+                                       target_completion_date: Date.new(2019, 5, 23),
+                                       actual_completion_date: Date.new(2019, 5, 23))
+    _completed_late_defect = create(:property_defect,
                                     property: property,
                                     priority: priority,
-                                    target_completion_date: Date.new(2019, 5, 22),
-                                    actual_completion_date: Date.new(2019, 5, 21))
-    completed_on_time_defect = create(:property_defect,
-                                      property: property,
-                                      priority: priority,
-                                      target_completion_date: Date.new(2019, 5, 23),
-                                      actual_completion_date: Date.new(2019, 5, 23))
-    completed_later_defect = create(:property_defect,
-                                    property: property,
-                                    priority: priority,
+                                    status: :completed,
                                     target_completion_date: Date.new(2019, 5, 24),
                                     actual_completion_date: Date.new(2019, 5, 25))
-
-    # Update the records status so that PublicActivity creates the required defect.update events
-    [
-      completed_early_defect,
-      completed_on_time_defect,
-      completed_later_defect,
-    ].each(&:completed!)
+    _old_defect_with_no_actual_completion_date = create(:property_defect,
+                                                        property: property,
+                                                        priority: priority,
+                                                        status: :completed,
+                                                        target_completion_date: Date.new(2019, 5, 24))
 
     visit report_path
 
     within('.priorities') do
-      expect(page).to have_content('2')
+      expect(page).to have_content(
+        'Code Due Overdue Total Completed on time Percentage completed on time'
+      )
+      expect(page).to have_content("#{priority.name} 0 2 4 2 50.0%")
     end
 
     travel_back

--- a/spec/features/staff_can_view_a_scheme_report_spec.rb
+++ b/spec/features/staff_can_view_a_scheme_report_spec.rb
@@ -140,7 +140,7 @@ RSpec.feature 'Staff can view a report for a scheme' do
     travel_back
   end
 
-  scenario 'defects completed on or before their target date' do
+  scenario 'defects closed on or before their target date' do
     travel_to Time.zone.parse('2019-05-23')
 
     _completed_early_defect = create(:property_defect,
@@ -149,18 +149,35 @@ RSpec.feature 'Staff can view a report for a scheme' do
                                      status: :completed,
                                      target_completion_date: Date.new(2019, 5, 22),
                                      actual_completion_date: Date.new(2019, 5, 21))
-    _completed_on_time_defect = create(:property_defect,
-                                       property: property,
-                                       priority: priority,
-                                       status: :completed,
-                                       target_completion_date: Date.new(2019, 5, 23),
-                                       actual_completion_date: Date.new(2019, 5, 23))
+    _closed_on_time_defect = create(:property_defect,
+                                    property: property,
+                                    priority: priority,
+                                    status: :closed,
+                                    target_completion_date: Date.new(2019, 5, 23),
+                                    actual_completion_date: Date.new(2019, 5, 23))
+    _rejected_on_time_defect = create(:property_defect,
+                                      property: property,
+                                      priority: priority,
+                                      status: :rejected,
+                                      target_completion_date: Date.new(2019, 5, 23),
+                                      actual_completion_date: Date.new(2019, 5, 23))
     _completed_late_defect = create(:property_defect,
                                     property: property,
                                     priority: priority,
                                     status: :completed,
                                     target_completion_date: Date.new(2019, 5, 24),
                                     actual_completion_date: Date.new(2019, 5, 25))
+    _raised_in_error_late_defect = create(:property_defect,
+                                          property: property,
+                                          priority: priority,
+                                          status: 'raised_in_error',
+                                          target_completion_date: Date.new(2019, 5, 24),
+                                          actual_completion_date: Date.new(2019, 5, 25))
+    _overdue_open_defect = create(:property_defect,
+                                  property: property,
+                                  priority: priority,
+                                  status: 'outstanding',
+                                  target_completion_date: Date.new(2019, 5, 22))
     _old_defect_with_no_actual_completion_date = create(:property_defect,
                                                         property: property,
                                                         priority: priority,
@@ -173,7 +190,7 @@ RSpec.feature 'Staff can view a report for a scheme' do
       expect(page).to have_content(
         'Code Days Due Overdue Total Completed on time Percentage completed on time'
       )
-      expect(page).to have_content('2 4 2 50.0%')
+      expect(page).to have_content('0 4 7 3 42.86%')
     end
 
     travel_back

--- a/spec/features/staff_can_view_a_scheme_report_spec.rb
+++ b/spec/features/staff_can_view_a_scheme_report_spec.rb
@@ -11,8 +11,11 @@ RSpec.feature 'Staff can view a report for a scheme' do
   let(:communal_area) { create(:communal_area, scheme: scheme) }
 
   scenario 'summary information for all defects belonging to the scheme' do
-    create_list(:property_defect, 1, property: property, priority: priority)
-    create_list(:communal_defect, 2, communal_area: communal_area, priority: priority)
+    property_defects_count = 1
+    communal_defects_count = 2
+    total = property_defects_count + communal_defects_count
+    create_list(:property_defect, property_defects_count, property: property, priority: priority)
+    create_list(:communal_defect, communal_defects_count, communal_area: communal_area, priority: priority)
 
     visit dashboard_path
 
@@ -28,10 +31,7 @@ RSpec.feature 'Staff can view a report for a scheme' do
         expect(page).to have_content(column_header)
       end
       within('tbody tr') do
-        expect(page).to have_content('Total defects')
-        expect(page).to have_content('1')
-        expect(page).to have_content('2')
-        expect(page).to have_content('3')
+        expect(page).to have_content("Total defects #{property_defects_count} #{communal_defects_count} #{total}")
       end
     end
   end

--- a/spec/presenters/combined_report_presenter_spec.rb
+++ b/spec/presenters/combined_report_presenter_spec.rb
@@ -250,7 +250,7 @@ RSpec.describe CombinedReportPresenter do
   end
 
   describe '#defects_completed_on_time' do
-    it 'returns a count for all defects completed before or on their target date' do
+    it 'returns a count for all defects closed before or on their target date' do
       travel_to Time.zone.local(2019, 5, 21, 10, 0, 0)
       completed_early_defect = create(:property_defect,
                                       status: :completed,
@@ -258,58 +258,39 @@ RSpec.describe CombinedReportPresenter do
                                       priority: priority,
                                       target_completion_date: Date.new(2019, 5, 23),
                                       actual_completion_date: Date.new(2019, 5, 22))
-      completed_on_time_defect = create(:property_defect,
-                                        status: :completed,
-                                        property: property,
-                                        priority: priority,
-                                        target_completion_date: Date.new(2019, 5, 23),
-                                        actual_completion_date: Date.new(2019, 5, 23))
+      closed_on_time_defect = create(:property_defect,
+                                     status: :closed,
+                                     property: property,
+                                     priority: priority,
+                                     target_completion_date: Date.new(2019, 5, 23),
+                                     actual_completion_date: Date.new(2019, 5, 23))
+      rejected_on_time_defect = create(:property_defect,
+                                       status: :rejected,
+                                       property: property,
+                                       priority: priority,
+                                       target_completion_date: Date.new(2019, 5, 23),
+                                       actual_completion_date: Date.new(2019, 5, 23))
       completed_later_defect = create(:property_defect,
                                       status: :completed,
                                       property: property,
                                       priority: priority,
                                       target_completion_date: Date.new(2019, 5, 23),
-                                      actual_completion_date: Date.new(2019, 5, 24))
-
-      completed_defect_no_actual_completion_date = create(:property_defect,
-                                                          status: :completed,
-                                                          property: property,
-                                                          priority: priority,
-                                                          target_completion_date: Date.new(2019, 5, 23))
+                                      actual_completion_date: Date.new(2019, 5, 25)),
+                               completed_defect_no_actual_completion_date = create(:property_defect,
+                                                                                   status: :completed,
+                                                                                   property: property,
+                                                                                   priority: priority,
+                                                                                   target_completion_date: Date.new(2019, 5, 23))
 
       travel_to Time.zone.local(2019, 5, 23, 10, 20, 10)
 
       result = described_class.new(schemes: schemes).defects_completed_on_time(priority: priority.name)
 
       expect(result).to include(completed_early_defect)
-      expect(result).to include(completed_on_time_defect)
+      expect(result).to include(closed_on_time_defect)
+      expect(result).to include(rejected_on_time_defect)
       expect(result).not_to include(completed_later_defect)
       expect(result).not_to include(completed_defect_no_actual_completion_date)
-
-      travel_back
-    end
-
-    it 'returns only completed defects' do
-      travel_to Time.zone.local(2019, 5, 23, 10, 10, 10)
-      rejected_defect = create(:property_defect,
-                               status: :rejected,
-                               property: property,
-                               priority: priority,
-                               target_completion_date: Date.new(2019, 5, 23))
-
-      completed_early_defect = create(:property_defect,
-                                      status: :completed,
-                                      property: property,
-                                      priority: priority,
-                                      target_completion_date: Date.new(2019, 5, 23),
-                                      actual_completion_date: Date.new(2019, 5, 22))
-
-      travel_to Time.zone.local(2019, 5, 23, 10, 20, 10)
-
-      result = described_class.new(schemes: schemes).defects_completed_on_time(priority: priority.name)
-
-      expect(result).to include(completed_early_defect)
-      expect(result).not_to include(rejected_defect)
 
       travel_back
     end

--- a/spec/presenters/combined_report_presenter_spec.rb
+++ b/spec/presenters/combined_report_presenter_spec.rb
@@ -152,26 +152,35 @@ RSpec.describe CombinedReportPresenter do
   end
 
   describe '#due_defects_by_priority' do
-    it 'returns all defects with a target_completion_date before todays date' do
+    it 'returns all open defects with a target_completion_date before todays date' do
       travel_to Time.zone.parse('2019-05-23')
 
       due_tomorrow_priority_defect = create(:property_defect,
                                             property: property,
                                             priority: priority,
+                                            status: 'outstanding',
                                             target_completion_date: Date.new(2019, 5, 24))
       due_today_priority_defect = create(:property_defect,
                                          property: property,
                                          priority: priority,
+                                         status: 'outstanding',
                                          target_completion_date: Date.new(2019, 5, 23))
+      completed_priority_defect = create(:property_defect,
+                                         property: property,
+                                         priority: priority,
+                                         status: 'completed',
+                                         target_completion_date: Date.new(2019, 5, 24))
       overdue_priority_defect = create(:property_defect,
                                        property: property,
                                        priority: priority,
+                                       status: 'outstanding',
                                        target_completion_date: Date.new(2019, 5, 22))
 
       result = described_class.new(schemes: schemes).due_defects_by_priority(priority: priority.name)
 
       expect(result).to include(due_tomorrow_priority_defect)
       expect(result).to include(due_today_priority_defect)
+      expect(result).not_to include(completed_priority_defect)
       expect(result).not_to include(overdue_priority_defect)
 
       travel_back

--- a/spec/presenters/combined_report_presenter_spec.rb
+++ b/spec/presenters/combined_report_presenter_spec.rb
@@ -188,27 +188,50 @@ RSpec.describe CombinedReportPresenter do
   end
 
   describe '#overdue_defects_by_priority' do
-    it 'returns all defects with a target_completion_date before todays date' do
+    it 'returns all defects completed late, or with a target_completion_date before today\'s date, or completed with no actual_completion_date' do
       travel_to Time.zone.parse('2019-05-23')
 
       due_tomorrow_priority_defect = create(:property_defect,
                                             property: property,
                                             priority: priority,
+                                            status: 'outstanding',
                                             target_completion_date: Date.new(2019, 5, 24))
       due_today_priority_defect = create(:property_defect,
                                          property: property,
                                          priority: priority,
+                                         status: 'outstanding',
                                          target_completion_date: Date.new(2019, 5, 23))
+      priority_defect_completed_on_time = create(:property_defect,
+                                                 property: property,
+                                                 priority: priority,
+                                                 status: 'completed',
+                                                 target_completion_date: Date.new(2019, 5, 22),
+                                                 actual_completion_date: Date.new(2019, 5, 21))
       overdue_priority_defect = create(:property_defect,
                                        property: property,
                                        priority: priority,
+                                       status: 'outstanding',
                                        target_completion_date: Date.new(2019, 5, 22))
+      late_completed_priority_defect = create(:property_defect,
+                                              property: property,
+                                              priority: priority,
+                                              status: 'outstanding',
+                                              target_completion_date: Date.new(2019, 5, 22),
+                                              actual_completion_date: Date.new(2019, 5, 23))
+      completed_with_no_actual_completion_date_defect = create(:property_defect,
+                                                               property: property,
+                                                               priority: priority,
+                                                               status: 'completed',
+                                                               target_completion_date: Date.new(2019, 5, 22))
 
       result = described_class.new(schemes: schemes).overdue_defects_by_priority(priority: priority.name)
 
       expect(result).not_to include(due_tomorrow_priority_defect)
       expect(result).not_to include(due_today_priority_defect)
+      expect(result).not_to include(priority_defect_completed_on_time)
       expect(result).to include(overdue_priority_defect)
+      expect(result).to include(late_completed_priority_defect)
+      expect(result).to include(completed_with_no_actual_completion_date_defect)
 
       travel_back
     end

--- a/spec/presenters/scheme_report_presenter_spec.rb
+++ b/spec/presenters/scheme_report_presenter_spec.rb
@@ -171,20 +171,29 @@ RSpec.describe SchemeReportPresenter do
       due_tomorrow_priority_defect = create(:property_defect,
                                             property: property,
                                             priority: priority,
+                                            status: 'outstanding',
                                             target_completion_date: Date.new(2019, 5, 24))
       due_today_priority_defect = create(:property_defect,
                                          property: property,
                                          priority: priority,
+                                         status: 'outstanding',
                                          target_completion_date: Date.new(2019, 5, 23))
+      completed_priority_defect = create(:property_defect,
+                                         property: property,
+                                         priority: priority,
+                                         status: 'completed',
+                                         target_completion_date: Date.new(2019, 5, 24))
       overdue_priority_defect = create(:property_defect,
                                        property: property,
                                        priority: priority,
+                                       status: 'outstanding',
                                        target_completion_date: Date.new(2019, 5, 22))
 
       result = described_class.new(scheme: scheme).due_defects_by_priority(priority: priority)
 
       expect(result).to include(due_tomorrow_priority_defect)
       expect(result).to include(due_today_priority_defect)
+      expect(result).not_to include(completed_priority_defect)
       expect(result).not_to include(overdue_priority_defect)
 
       travel_back

--- a/spec/presenters/scheme_report_presenter_spec.rb
+++ b/spec/presenters/scheme_report_presenter_spec.rb
@@ -138,20 +138,32 @@ RSpec.describe SchemeReportPresenter do
     it 'returns the percentage of defects completed on time with this priority ' do
       travel_to Time.zone.parse('2019-05-23')
 
-      completed_on_time_priority = create(:property_defect,
-                                          property: property,
-                                          priority: priority,
-                                          target_completion_date: Date.new(2019, 5, 24),
-                                          status: :completed)
+      _completed_on_time_priority = create(:property_defect,
+                                           property: property,
+                                           priority: priority,
+                                           target_completion_date: Date.new(2019, 5, 24),
+                                           actual_completion_date: Date.new(2019, 5, 23),
+                                           status: :completed)
 
-      completed_on_time_priority.activities.create!(key: 'defect.update',
-                                                    parameters: {
-                                                      changes: { status: ['', 'completed'] },
-                                                    })
+      _completed_late_priority = create(
+        :property_defect,
+        property: property,
+        priority: priority,
+        target_completion_date: Date.new(2019, 5, 24),
+        actual_completion_date: Date.new(2019, 5, 25),
+        status: :completed
+      )
 
-      create(:property_defect, property: property, priority: priority)
+      _still_overdue_priority = create(
+        :property_defect,
+        property: property,
+        priority: priority,
+        target_completion_date: Date.new(2019, 5, 22),
+        status: :outstanding
+      )
+
       result = described_class.new(scheme: scheme).priority_percentage(priority: priority)
-      expect(result).to eql('50.0%')
+      expect(result).to eql('33.33%')
 
       travel_back
     end
@@ -197,6 +209,8 @@ RSpec.describe SchemeReportPresenter do
       expect(result).not_to include(overdue_priority_defect)
 
       travel_back
+
+      travel_back
     end
   end
 
@@ -214,6 +228,12 @@ RSpec.describe SchemeReportPresenter do
                                          priority: priority,
                                          status: 'outstanding',
                                          target_completion_date: Date.new(2019, 5, 23))
+      priority_defect_completed_on_time = create(:property_defect,
+                                                 property: property,
+                                                 priority: priority,
+                                                 status: 'completed',
+                                                 target_completion_date: Date.new(2019, 5, 22),
+                                                 actual_completion_date: Date.new(2019, 5, 21))
       overdue_priority_defect = create(:property_defect,
                                        property: property,
                                        priority: priority,
@@ -235,6 +255,7 @@ RSpec.describe SchemeReportPresenter do
 
       expect(result).not_to include(due_tomorrow_priority_defect)
       expect(result).not_to include(due_today_priority_defect)
+      expect(result).not_to include(priority_defect_completed_on_time)
       expect(result).to include(overdue_priority_defect)
       expect(result).to include(late_completed_priority_defect)
       expect(result).to include(completed_with_no_actual_completion_date_defect)
@@ -250,54 +271,26 @@ RSpec.describe SchemeReportPresenter do
                                       status: :completed,
                                       property: property,
                                       priority: priority,
-                                      target_completion_date: Date.new(2019, 5, 23))
+                                      target_completion_date: Date.new(2019, 5, 23),
+                                      actual_completion_date: Date.new(2019, 5, 22))
       completed_on_time_defect = create(:property_defect,
                                         status: :completed,
                                         property: property,
                                         priority: priority,
-                                        target_completion_date: Date.new(2019, 5, 23))
+                                        target_completion_date: Date.new(2019, 5, 23),
+                                        actual_completion_date: Date.new(2019, 5, 23))
       completed_later_defect = create(:property_defect,
                                       status: :completed,
                                       property: property,
                                       priority: priority,
-                                      target_completion_date: Date.new(2019, 5, 23))
-      travel_back
+                                      target_completion_date: Date.new(2019, 5, 23),
+                                      actual_completion_date: Date.new(2019, 5, 24))
 
-      travel_to Time.zone.local(2019, 5, 22, 10, 10, 10) do
-        completed_early_defect.create_activity(
-          key: 'defect.update',
-          parameters: {
-            changes:
-            {
-              status: %w[outstanding completed],
-            },
-          },
-        )
-      end
-
-      travel_to Time.zone.local(2019, 5, 23, 10, 10, 10) do
-        completed_on_time_defect.create_activity(
-          key: 'defect.update',
-          parameters: {
-            changes:
-            {
-              status: %w[outstanding completed],
-            },
-          }
-        )
-      end
-
-      travel_to Time.zone.local(2019, 5, 24, 10, 10, 10) do
-        completed_on_time_defect.create_activity(
-          key: 'defect.update',
-          parameters: {
-            changes:
-            {
-              status: %w[outstanding completed],
-            },
-          },
-        )
-      end
+      completed_defect_no_actual_completion_date = create(:property_defect,
+                                                          status: :completed,
+                                                          property: property,
+                                                          priority: priority,
+                                                          target_completion_date: Date.new(2019, 5, 23))
 
       travel_to Time.zone.local(2019, 5, 23, 10, 20, 10)
 
@@ -306,6 +299,7 @@ RSpec.describe SchemeReportPresenter do
       expect(result).to include(completed_early_defect)
       expect(result).to include(completed_on_time_defect)
       expect(result).not_to include(completed_later_defect)
+      expect(result).not_to include(completed_defect_no_actual_completion_date)
 
       travel_back
     end
@@ -316,39 +310,20 @@ RSpec.describe SchemeReportPresenter do
                                status: :rejected,
                                property: property,
                                priority: priority,
-                               target_completion_date: Date.current)
-      rejected_defect.create_activity(
-        key: 'defect.update',
-        parameters: {
-          changes:
-          {
-            status: %w[outstanding rejected],
-          },
-        },
-      )
-      completed_defect = create(:property_defect,
-                                status: :completed,
-                                property: property,
-                                priority: priority,
-                                target_completion_date: Date.current)
+                               target_completion_date: Date.new(2019, 5, 23))
 
-      completed_defect.create_activity(
-        key: 'defect.update',
-        parameters: {
-          changes:
-          {
-            status: %w[outstanding completed],
-          },
-        },
-      )
-
-      travel_back
+      completed_early_defect = create(:property_defect,
+                                      status: :completed,
+                                      property: property,
+                                      priority: priority,
+                                      target_completion_date: Date.new(2019, 5, 23),
+                                      actual_completion_date: Date.new(2019, 5, 22))
 
       travel_to Time.zone.local(2019, 5, 23, 10, 20, 10)
 
       result = described_class.new(scheme: scheme).defects_completed_on_time(priority: priority)
 
-      expect(result).to include(completed_defect)
+      expect(result).to include(completed_early_defect)
       expect(result).not_to include(rejected_defect)
 
       travel_back

--- a/spec/presenters/scheme_report_presenter_spec.rb
+++ b/spec/presenters/scheme_report_presenter_spec.rb
@@ -201,27 +201,43 @@ RSpec.describe SchemeReportPresenter do
   end
 
   describe '#overdue_defects_by_priority' do
-    it 'returns all defects with a target_completion_date before todays date' do
+    it 'returns all defects completed late, with a target_completion_date before today\'s date, or completed with no actual_completion_date' do
       travel_to Time.zone.parse('2019-05-23')
 
       due_tomorrow_priority_defect = create(:property_defect,
                                             property: property,
                                             priority: priority,
+                                            status: 'outstanding',
                                             target_completion_date: Date.new(2019, 5, 24))
       due_today_priority_defect = create(:property_defect,
                                          property: property,
                                          priority: priority,
+                                         status: 'outstanding',
                                          target_completion_date: Date.new(2019, 5, 23))
       overdue_priority_defect = create(:property_defect,
                                        property: property,
                                        priority: priority,
+                                       status: 'outstanding',
                                        target_completion_date: Date.new(2019, 5, 22))
+      late_completed_priority_defect = create(:property_defect,
+                                              property: property,
+                                              priority: priority,
+                                              status: 'completed',
+                                              target_completion_date: Date.new(2019, 5, 22),
+                                              actual_completion_date: Date.new(2019, 5, 23))
+      completed_with_no_actual_completion_date_defect = create(:property_defect,
+                                                               property: property,
+                                                               priority: priority,
+                                                               status: 'completed',
+                                                               target_completion_date: Date.new(2019, 5, 22))
 
       result = described_class.new(scheme: scheme).overdue_defects_by_priority(priority: priority)
 
       expect(result).not_to include(due_tomorrow_priority_defect)
       expect(result).not_to include(due_today_priority_defect)
       expect(result).to include(overdue_priority_defect)
+      expect(result).to include(late_completed_priority_defect)
+      expect(result).to include(completed_with_no_actual_completion_date_defect)
 
       travel_back
     end

--- a/spec/presenters/scheme_report_presenter_spec.rb
+++ b/spec/presenters/scheme_report_presenter_spec.rb
@@ -265,7 +265,7 @@ RSpec.describe SchemeReportPresenter do
   end
 
   describe '#defects_completed_on_time' do
-    it 'returns a count for all defects completed before or on their target date' do
+    it 'returns a count for all defects closed before or on their target date' do
       travel_to Time.zone.local(2019, 5, 21, 10, 0, 0)
       completed_early_defect = create(:property_defect,
                                       status: :completed,
@@ -273,12 +273,18 @@ RSpec.describe SchemeReportPresenter do
                                       priority: priority,
                                       target_completion_date: Date.new(2019, 5, 23),
                                       actual_completion_date: Date.new(2019, 5, 22))
-      completed_on_time_defect = create(:property_defect,
-                                        status: :completed,
-                                        property: property,
-                                        priority: priority,
-                                        target_completion_date: Date.new(2019, 5, 23),
-                                        actual_completion_date: Date.new(2019, 5, 23))
+      closed_on_time_defect = create(:property_defect,
+                                     status: :closed,
+                                     property: property,
+                                     priority: priority,
+                                     target_completion_date: Date.new(2019, 5, 23),
+                                     actual_completion_date: Date.new(2019, 5, 23))
+      rejected_on_time_defect = create(:property_defect,
+                                       status: :rejected,
+                                       property: property,
+                                       priority: priority,
+                                       target_completion_date: Date.new(2019, 5, 23),
+                                       actual_completion_date: Date.new(2019, 5, 23))
       completed_later_defect = create(:property_defect,
                                       status: :completed,
                                       property: property,
@@ -297,34 +303,10 @@ RSpec.describe SchemeReportPresenter do
       result = described_class.new(scheme: scheme).defects_completed_on_time(priority: priority)
 
       expect(result).to include(completed_early_defect)
-      expect(result).to include(completed_on_time_defect)
+      expect(result).to include(closed_on_time_defect)
+      expect(result).to include(rejected_on_time_defect)
       expect(result).not_to include(completed_later_defect)
       expect(result).not_to include(completed_defect_no_actual_completion_date)
-
-      travel_back
-    end
-
-    it 'returns only completed defects' do
-      travel_to Time.zone.local(2019, 5, 23, 10, 10, 10)
-      rejected_defect = create(:property_defect,
-                               status: :rejected,
-                               property: property,
-                               priority: priority,
-                               target_completion_date: Date.new(2019, 5, 23))
-
-      completed_early_defect = create(:property_defect,
-                                      status: :completed,
-                                      property: property,
-                                      priority: priority,
-                                      target_completion_date: Date.new(2019, 5, 23),
-                                      actual_completion_date: Date.new(2019, 5, 22))
-
-      travel_to Time.zone.local(2019, 5, 23, 10, 20, 10)
-
-      result = described_class.new(scheme: scheme).defects_completed_on_time(priority: priority)
-
-      expect(result).to include(completed_early_defect)
-      expect(result).not_to include(rejected_defect)
 
       travel_back
     end


### PR DESCRIPTION
## The problem:

This task came out of the following note from the Hackney team:

> There appears to be a discrepancy between the full download of defects data (available to download as a csv and how the data in the P1 table has been calculated. According to the full download 28/38 P1 incidents were resolved within or on there target completion date. The remaining were completed either just after the target completion date or not at all and the case was closed. There is no guidance to explain how the 'View Combined Report' (https://lbh-report-a-defect-production.herokuapp.com/report) calculates the number completed on time but I suspect there is a problem with the logic in the code for this calculation. 
> 
> In addition, in the 'Priorities' table, the denominator for the 'percentage completed on time' column does not appear to be correct - it's currently calculating number completed on time / total but the total column is just a copy of the 'overdue' column which is messing up the calculation.

## Changes in this PR:
**Issues discovered with the Combined Report view:**
1. All defects were being marked as "overdue" as the code was checking a defect's `target_completion_date` against the current date(i.e. the date the user is viewing the report, meaning everything from before today was "overdue"), even if the defect was marked as closed or completed. 
**An overdue defect is now one where its actual completed date is before its  target completion date , or where it's still open and its target completion date is in the past.**

2. The "due" column doesn't really make sense - if you're viewing a report from last year, should anything still be marked as "due"? I guess it makes sense if you're viewing the current month and looking for things that are still outstanding, but it's a little confusing. Similar to the above issue, it was including all "closed" defects as still "due". 
**All "closed" defects are now excluded from this list, but it's still a bit confusing for past defects, does it add any value? Would it be better to have something like "all defects that were opened/due during this time period" (would require a bit more work)?**

3. The "percent completed on time" data discrepancy is the main issue they've asked us to fix. In the code, we were checking against the "last" "activity" on the defect (e.g. if it was updated by someone), and comparing it to whether the status had changed to "completed". This is a bit hacky and unreliable, as the order of activities on a defect seems a bit random and not always chronological, also if a case is "re-opened", it's hard to know what to do. There was also an overlap in the number of overdue defects and those completed on time, which didn't make sense.
**We now compare a defect's target completion date against its actual completed date like we do with "overdue" defects. However, some "completed" defects, particularly those from last year don't have an actual completed date, possibly due to how the code was written before this feature, so I am classing them as "overdue" to encourage staff to manually add in this date if it doesn't match up with what they expected.**

4. We're now classing any kind of "closed" defect e.g. rejected, raised in error, closed, completed as "completed" for the purposes of this report, as this is how Hackney have been using their CSV export, and is one of the main reasons numbers didn't add up properly.

**Note**: this is a tidy up of [my previous pull request](https://github.com/LBHackney-IT/report-a-defect/pull/163), and addresses its comments.
