### PR TITLE
[FIX] Run app with `bundle exec` and fix local Docker environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,9 @@ services:
     container_name: report-a-defect_dev_db_1
     volumes:
       - pg_data:/var/lib/postgresql/data/:cached
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_HOST_AUTH_METHOD=trust
     restart: on-failure
 
   redis_queue:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     volumes:
       - .:/srv/report-a-defect:cached
       - node_modules:/srv/report-a-defect/node_modules
-    command: bash -c "rm -f tmp/pids/server.pid && rails s"
+    command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s"
 
   db:
     image: postgres


### PR DESCRIPTION
## Changes in this PR:
- When deploying to staging, we encountered the following when trying to start the application (staging is currently down for this reason):

```
heroku[web.1]: Starting process with command `rails server`
app[web.1]: /bin/sh: 1: rails: not found
heroku[web.1]: Process exited with status 127
```

Adding `bundle exec` to this command should hopefully fix that issue (it now starts the app sucessfully locally).

- When trying to run the application locally with Docker, I encountered issues starting Postgres, as Postgres images now require you to set a user and password. For the testdatabase, we can explicitly set it to trust us. See: https://www.postgresql.org/docs/current/auth-trust.html for a more details explanation.
