### PR TITLE
Add `bundle exec` to Dockerfile CMD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,4 +53,4 @@ RUN RAILS_ENV=production SECRET_KEY_BASE=`rake secret` bin/rails DATABASE_URL=po
 
 EXPOSE 3000
 
-CMD ["rails", "server"]
+CMD ["bundle", "exec", "rails", "server"]


### PR DESCRIPTION
The app is currently unable to start up during deployment, as it's not being run with `bundle` and can't find the `rails` command. This should hopefully fix that.
