### PR TITLE
Filter defects by `added_at` date

### DIFF
--- a/app/presenters/combined_report_presenter.rb
+++ b/app/presenters/combined_report_presenter.rb
@@ -8,7 +8,7 @@ class CombinedReportPresenter < ReportPresenter
 
   def defects
     @defects ||= Defect.for_scheme(schemes.pluck(:id))
-                       .where(created_at: report_form.date_range)
+                       .where(added_at: report_form.date_range)
   end
 
   def defects_by_priority(priority:)

--- a/app/presenters/scheme_report_presenter.rb
+++ b/app/presenters/scheme_report_presenter.rb
@@ -10,7 +10,7 @@ class SchemeReportPresenter < ReportPresenter
 
   def defects
     @defects ||= Defect.for_scheme([scheme.id])
-                       .where(created_at: report_form.date_range)
+                       .where(added_at: report_form.date_range)
   end
 
   def defects_by_priority(priority:)

--- a/spec/features/staff_can_view_a_combined_report_spec.rb
+++ b/spec/features/staff_can_view_a_combined_report_spec.rb
@@ -151,10 +151,10 @@ RSpec.feature 'Staff can view a combined report for all schemes' do
   scenario 'filter defects by date' do
     travel_to Time.zone.parse('2019-05-25')
 
-    create(:property_defect, created_at: Time.utc(2019, 5, 23), property: property)
-    create(:property_defect, created_at: Time.utc(2019, 5, 24), property: property)
-    create(:communal_defect, created_at: Time.utc(2019, 5, 24), communal_area: communal_area)
-    create(:property_defect, created_at: Time.utc(2019, 5, 25), property: property)
+    create(:property_defect, added_at: Time.utc(2019, 5, 23), property: property)
+    create(:property_defect, added_at: Time.utc(2019, 5, 24), property: property)
+    create(:communal_defect, added_at: Time.utc(2019, 5, 24), communal_area: communal_area)
+    create(:property_defect, added_at: Time.utc(2019, 5, 25), property: property)
 
     visit report_path
 

--- a/spec/features/staff_can_view_a_scheme_report_spec.rb
+++ b/spec/features/staff_can_view_a_scheme_report_spec.rb
@@ -199,10 +199,10 @@ RSpec.feature 'Staff can view a report for a scheme' do
   scenario 'filter defects' do
     travel_to Time.zone.parse('2019-05-25')
 
-    create(:property_defect, created_at: Time.utc(2019, 5, 23), property: property)
-    create(:property_defect, created_at: Time.utc(2019, 5, 24), property: property)
-    create(:communal_defect, created_at: Time.utc(2019, 5, 24), communal_area: communal_area)
-    create(:property_defect, created_at: Time.utc(2019, 5, 25), property: property)
+    create(:property_defect, added_at: Time.utc(2019, 5, 23), property: property)
+    create(:property_defect, added_at: Time.utc(2019, 5, 24), property: property)
+    create(:communal_defect, added_at: Time.utc(2019, 5, 24), communal_area: communal_area)
+    create(:property_defect, added_at: Time.utc(2019, 5, 25), property: property)
 
     visit report_scheme_path(scheme)
 

--- a/spec/presenters/combined_report_presenter_spec.rb
+++ b/spec/presenters/combined_report_presenter_spec.rb
@@ -19,9 +19,9 @@ RSpec.describe CombinedReportPresenter do
         date_range = from_date..to_date
         report_form = double(from_date: from_date, to_date: to_date, date_range: date_range)
 
-        before_range_defect = create(:property_defect, created_at: Time.utc(2018, 1, 1), property: property, priority: priority)
-        in_range_defect = create(:property_defect, created_at: Time.utc(2019, 2, 1), property: property, priority: priority)
-        after_range_defect = create(:property_defect, created_at: Time.utc(2020, 1, 1), property: property, priority: priority)
+        before_range_defect = create(:property_defect, added_at: Time.utc(2018, 1, 1), property: property, priority: priority)
+        in_range_defect = create(:property_defect, added_at: Time.utc(2019, 2, 1), property: property, priority: priority)
+        after_range_defect = create(:property_defect, added_at: Time.utc(2020, 1, 1), property: property, priority: priority)
 
         result = described_class.new(schemes: schemes, report_form: report_form).defects
 

--- a/spec/presenters/scheme_report_presenter_spec.rb
+++ b/spec/presenters/scheme_report_presenter_spec.rb
@@ -19,9 +19,9 @@ RSpec.describe SchemeReportPresenter do
         date_range = from_date..to_date
         report_form = double(from_date: from_date, to_date: to_date, date_range: date_range)
 
-        before_range_defect = create(:property_defect, created_at: Time.utc(2018, 1, 1), property: property, priority: priority)
-        in_range_defect = create(:property_defect, created_at: Time.utc(2019, 2, 1), property: property, priority: priority)
-        after_range_defect = create(:property_defect, created_at: Time.utc(2020, 1, 1), property: property, priority: priority)
+        before_range_defect = create(:property_defect, added_at: Time.utc(2018, 1, 1), property: property, priority: priority)
+        in_range_defect = create(:property_defect, added_at: Time.utc(2019, 2, 1), property: property, priority: priority)
+        after_range_defect = create(:property_defect, added_at: Time.utc(2020, 1, 1), property: property, priority: priority)
 
         result = described_class.new(scheme: scheme, report_form: report_form).defects
 
@@ -37,7 +37,7 @@ RSpec.describe SchemeReportPresenter do
       date_range = from_date..to_date
       report_form = double(from_date: from_date, to_date: to_date, date_range: date_range)
 
-      in_range_defect = create(:property_defect, created_at: Time.utc(2019, 1, 1), property: property, priority: priority)
+      in_range_defect = create(:property_defect, added_at: Time.utc(2019, 1, 1), property: property, priority: priority)
 
       result = described_class.new(scheme: scheme, report_form: report_form).defects
 


### PR DESCRIPTION
The Hackney team are filtering on the `added_at` date in their internal
reports, so this closer matches the user need.

Given that `added_at` starts as a copy of created_at but can be
overwritten it's hard to see when `created_at` is ever relevant to users.
