### PR TITLE
Report accuracy improved by using 'added_at' rather than 'created_at'

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,9 +1,59 @@
-inherit_gem:
-  dxw-utils:
-    - dxw-rubocop.yml
+AllCops:
+  TargetRubyVersion: 2.6
+  Exclude:
+    - 'db/migrate/**/*'
+    - 'db/schema.rb'
+    - 'bin/**/*'
+    - 'lib/tasks/*'
+    - 'vendor/bundle/**/*'
+
+Bundler/OrderedGems:
+    Enabled: false
+
+Style/Alias:
+    Enabled: false
+
+Style/FrozenStringLiteralComment:
+    Enabled: false
+
+Style/NumericLiterals:
+    Enabled: false
+
+Style/TrailingCommaInArrayLiteral:
+    EnforcedStyleForMultiline: comma
+
+Style/TrailingCommaInHashLiteral:
+    EnforcedStyleForMultiline: comma
+
+Style/TrailingCommaInArguments:
+    Enabled: false
+
+Style/Documentation:
+    Enabled: false
+
+Style/FormatStringToken:
+    Enabled: false
+
+Layout/EmptyLineAfterGuardClause:
+    Enabled: false
+
+Layout/LineLength:
+    Max: 100
+    Exclude:
+      - 'spec/**/*'
+      - 'features/**/*'
+      - 'config/initializers/judge_role_types.rb'
+      - 'config/initializers/secure_headers.rb'
+      # Also list here third party config eg:
+      # - 'config/initializers/rollbar.rb'
+
+Metrics/MethodLength:
+    Max: 25
+    Exclude:
+      - 'spec/**/*'
 
 Metrics/AbcSize:
-  Max: 25
+  Max: 30
   Exclude:
     - 'spec/**/*'
 
@@ -14,11 +64,11 @@ Metrics/BlockLength:
     - 'config/environments/*'
     - 'config/initializers/devise.rb'
 
-Metrics/MethodLength:
-  Max: 25
-
 Naming/AccessorMethodName:
   Enabled: false
 
 Style/ClassAndModuleChildren:
   Enabled: false
+
+Metrics/CyclomaticComplexity:
+  Max: 8

--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,6 @@ group :development, :test do
   gem 'capybara', '~> 2.13'
   gem 'selenium-webdriver'
   gem 'pry'
-  gem 'dxw-utils', git: 'https://github.com/dxw/dxw-utils'
   gem 'bullet'
 end
 
@@ -63,5 +62,6 @@ group :test do
   gem 'launchy'
   gem 'shoulda'
   gem 'rack_session_access'
+  gem 'rubocop'
   gem 'webmock', '~> 3.5'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,3 @@
-GIT
-  remote: https://github.com/dxw/dxw-utils
-  revision: f3e4941c7c2bc5a2dfd1cab35531932373334158
-  specs:
-    dxw-utils (0.1.1)
-      rubocop (~> 0.58)
-      rubocop-rspec (~> 1.29)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -53,7 +45,7 @@ GEM
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
     arel (9.0.0)
-    ast (2.4.0)
+    ast (2.4.1)
     better_errors (2.5.1)
       coderay (>= 1.0.0)
       erubi (>= 1.0.0)
@@ -153,7 +145,6 @@ GEM
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.13, < 3)
     ipaddress (0.8.3)
-    jaro_winkler (1.5.2)
     jbuilder (2.8.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
@@ -213,9 +204,9 @@ GEM
     omniauth-rails_csrf_protection (0.1.2)
       actionpack (>= 4.2)
       omniauth (>= 1.3.1)
-    parallel (1.17.0)
-    parser (2.6.3.0)
-      ast (~> 2.4.0)
+    parallel (1.19.2)
+    parser (2.7.1.4)
+      ast (~> 2.4.1)
     pg (0.21.0)
     pg_search (2.2.0)
       activerecord (>= 4.2)
@@ -271,6 +262,8 @@ GEM
     redis (4.1.2)
     redis-namespace (1.6.0)
       redis (>= 3.0.4)
+    regexp_parser (1.7.1)
+    rexml (3.2.4)
     rspec-core (3.8.0)
       rspec-support (~> 3.8.0)
     rspec-expectations (3.8.2)
@@ -288,16 +281,18 @@ GEM
       rspec-mocks (~> 3.8.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
-    rubocop (0.68.1)
-      jaro_winkler (~> 1.5.1)
+    rubocop (0.91.0)
       parallel (~> 1.10)
-      parser (>= 2.5, != 2.5.1.1)
+      parser (>= 2.7.1.1)
       rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.7)
+      rexml
+      rubocop-ast (>= 0.4.0, < 1.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 1.6)
-    rubocop-rspec (1.32.0)
-      rubocop (>= 0.60.0)
-    ruby-progressbar (1.10.0)
+      unicode-display_width (>= 1.4.0, < 2.0)
+    rubocop-ast (0.4.0)
+      parser (>= 2.7.1.4)
+    ruby-progressbar (1.10.1)
     ruby-vips (2.0.16)
       ffi (~> 1.9)
     ruby_dep (1.5.0)
@@ -361,7 +356,7 @@ GEM
       thread_safe (~> 0.1)
     uglifier (4.1.20)
       execjs (>= 0.3.0, < 3)
-    unicode-display_width (1.5.0)
+    unicode-display_width (1.7.0)
     uniform_notifier (1.12.1)
     web-console (3.7.0)
       actionview (>= 5.0)
@@ -389,7 +384,6 @@ DEPENDENCIES
   carrierwave (~> 2.0)
   coffee-rails (~> 4.2)
   database_cleaner
-  dxw-utils!
   factory_bot_rails
   faker
   figaro
@@ -416,6 +410,7 @@ DEPENDENCIES
   redis
   redis-namespace
   rspec-rails
+  rubocop
   sass-rails (~> 5.0)
   selenium-webdriver
   sentry-raven

--- a/Rakefile
+++ b/Rakefile
@@ -6,4 +6,4 @@ require_relative 'config/application'
 Rails.application.load_tasks
 
 desc 'Run all the specs'
-task default: %i[spec]
+task default: %i[rubocop spec]

--- a/app/helpers/breadcrumb_helper.rb
+++ b/app/helpers/breadcrumb_helper.rb
@@ -1,12 +1,10 @@
 module BreadcrumbHelper
   def breadcrumb_link_to(title, url, *args)
-    # rubocop:disable Rails/OutputSafety
     content_tag(:li,
                 title,
                 class: 'govuk-breadcrumbs__list-item') do
       link_to(title, url, *args, class: 'govuk-breadcrumbs__link')
     end.html_safe
-    # rubocop:enable Rails/OutputSafety
   end
 
   def breadcrumb_current(title = nil, &blk)

--- a/app/presenters/combined_report_presenter.rb
+++ b/app/presenters/combined_report_presenter.rb
@@ -8,7 +8,7 @@ class CombinedReportPresenter < ReportPresenter
 
   def defects
     @defects ||= Defect.for_scheme(schemes.pluck(:id))
-                       .where(created_at: report_form.date_range)
+                       .where(added_at: report_form.date_range)
   end
 
   def defects_by_priority(priority:)

--- a/app/presenters/defect_event_presenter.rb
+++ b/app/presenters/defect_event_presenter.rb
@@ -5,21 +5,21 @@ class DefectEventPresenter
 
   def description # rubocop:disable Metrics/CyclomaticComplexity
     case @event.key
-    when 'defect.create' then
+    when 'defect.create'
       description_for_create
-    when 'defect.update' then
+    when 'defect.update'
       description_for_update
-    when 'defect.forwarded_to_contractor' then
+    when 'defect.forwarded_to_contractor'
       descrition_for_forwarded_to_contractor
-    when 'defect.forwarded_to_employer_agent' then
+    when 'defect.forwarded_to_employer_agent'
       description_for_forwarded_to_employer_agent
-    when 'defect.accepted' then
+    when 'defect.accepted'
       description_for_accepted
-    when 'defect.notification.contact.sent_to_contractor' then
+    when 'defect.notification.contact.sent_to_contractor'
       description_for_sent_on_to_contact
-    when 'defect.notification.contact.accepted_by_contractor' then
+    when 'defect.notification.contact.accepted_by_contractor'
       description_for_accepted_by_to_contact
-    when 'defect.notification.contact.completed' then
+    when 'defect.notification.contact.completed'
       description_for_completed
     else
       @event.key

--- a/app/presenters/scheme_report_presenter.rb
+++ b/app/presenters/scheme_report_presenter.rb
@@ -10,7 +10,7 @@ class SchemeReportPresenter < ReportPresenter
 
   def defects
     @defects ||= Defect.for_scheme([scheme.id])
-                       .where(created_at: report_form.date_range)
+                       .where(added_at: report_form.date_range)
   end
 
   def defects_by_priority(priority:)

--- a/bin/dspec
+++ b/bin/dspec
@@ -3,9 +3,9 @@ set -e
 
 if [ $# -eq 0 ]
 then
-  echo "No arguments supplied. Defaults to 'rake default'"
-  docker exec -it report-a-defect_test_web_1 rake default $@
+  echo "No arguments supplied. Defaults to 'bundle exec rake default'"
+  docker exec -it report-a-defect_test_web_1 bundle exec rake default $@
 else
   echo "Testing: $@"
-  docker exec -it report-a-defect_test_web_1 rspec --order random "$@"
+  docker exec -it report-a-defect_test_web_1 bundle exec rspec --order random "$@"
 fi

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -91,13 +91,13 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 end
 
-# rubocop:disable Metrics/LineLength
+# rubocop:disable Layout/LineLength
 OmniAuth.config.on_failure = proc { |env|
   message_key = env['omniauth.error.type']
   error_description = Rack::Utils.escape(env['omniauth.error'].error_reason)
   new_path = "#{env['SCRIPT_NAME']}#{OmniAuth.config.path_prefix}/failure?message=#{message_key}&error_description=#{error_description}"
   Rack::Response.new(['302 Moved'], 302, 'Location' => new_path).finish
 }
-# rubocop:enable Metrics/LineLength
+# rubocop:enable Layout/LineLength
 
 OmniAuth.config.full_host = 'https://lbh-report-a-defect-production.herokuapp.com'

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -10,7 +10,7 @@
 # Use this setup block to configure all options available in SimpleForm.
 
 # rubocop:disable Metrics/BlockLength
-# rubocop:disable Metrics/LineLength
+# rubocop:disable Layout/LineLength
 SimpleForm.setup do |config|
   # Wrappers are used by the form builder to generate a
   # complete input. You can remove any component from the
@@ -242,4 +242,4 @@ SimpleForm.setup do |config|
   end
 end
 # rubocop:enable Metrics/BlockLength
-# rubocop:enable Metrics/LineLength
+# rubocop:enable Layout/LineLength

--- a/lib/tasks/rubocop.rake
+++ b/lib/tasks/rubocop.rake
@@ -1,13 +1,5 @@
-if Rails.env.development? || Rails.env.test?
-  require 'rubocop/rake_task'
+require 'rubocop/rake_task'
 
-  desc 'Run rubocop - configure in .rubocop.yml'
-  task :rubocop do
-    RuboCop::RakeTask.new(:rubocop) do |t|
-      t.options = ['--display-cop-names']
-    end
-  end
-
-  task(:default).clear.enhance(%i[rubocop spec])
-  task(:default).comment = 'Run rubocop checks'
+RuboCop::RakeTask.new(:rubocop) do |t|
+  t.options = ['--display-cop-names']
 end

--- a/spec/factories/defects.rb
+++ b/spec/factories/defects.rb
@@ -9,6 +9,7 @@ FactoryBot.define do
     trade { Defect::TRADES.sample }
     target_completion_date { Faker::Date.between(1.day.from_now, 5.days.from_now) }
     status { Defect.statuses.keys.sample }
+    added_at { Time.now.utc }
 
     association :priority, factory: :priority
 

--- a/spec/features/staff_can_view_a_combined_report_spec.rb
+++ b/spec/features/staff_can_view_a_combined_report_spec.rb
@@ -151,10 +151,10 @@ RSpec.feature 'Staff can view a combined report for all schemes' do
   scenario 'filter defects by date' do
     travel_to Time.zone.parse('2019-05-25')
 
-    create(:property_defect, created_at: Time.utc(2019, 5, 23), property: property)
-    create(:property_defect, created_at: Time.utc(2019, 5, 24), property: property)
-    create(:communal_defect, created_at: Time.utc(2019, 5, 24), communal_area: communal_area)
-    create(:property_defect, created_at: Time.utc(2019, 5, 25), property: property)
+    create(:property_defect, added_at: Time.utc(2019, 5, 23), property: property)
+    create(:property_defect, added_at: Time.utc(2019, 5, 24), property: property)
+    create(:communal_defect, added_at: Time.utc(2019, 5, 24), communal_area: communal_area)
+    create(:property_defect, added_at: Time.utc(2019, 5, 25), property: property)
 
     visit report_path
 
@@ -183,8 +183,8 @@ RSpec.feature 'Staff can view a combined report for all schemes' do
   scenario 'filter defects by scheme' do
     travel_to Time.zone.parse('2019-05-25')
 
-    create(:property_defect, created_at: Time.utc(2019, 5, 23), property: second_property)
-    create(:property_defect, created_at: Time.utc(2019, 5, 23), property: property)
+    create(:property_defect, added_at: Time.utc(2019, 5, 23), property: second_property)
+    create(:property_defect, added_at: Time.utc(2019, 5, 23), property: property)
 
     visit report_path
 

--- a/spec/features/staff_can_view_a_scheme_report_spec.rb
+++ b/spec/features/staff_can_view_a_scheme_report_spec.rb
@@ -199,10 +199,10 @@ RSpec.feature 'Staff can view a report for a scheme' do
   scenario 'filter defects' do
     travel_to Time.zone.parse('2019-05-25')
 
-    create(:property_defect, created_at: Time.utc(2019, 5, 23), property: property)
-    create(:property_defect, created_at: Time.utc(2019, 5, 24), property: property)
-    create(:communal_defect, created_at: Time.utc(2019, 5, 24), communal_area: communal_area)
-    create(:property_defect, created_at: Time.utc(2019, 5, 25), property: property)
+    create(:property_defect, added_at: Time.utc(2019, 5, 23), property: property)
+    create(:property_defect, added_at: Time.utc(2019, 5, 24), property: property)
+    create(:communal_defect, added_at: Time.utc(2019, 5, 24), communal_area: communal_area)
+    create(:property_defect, added_at: Time.utc(2019, 5, 25), property: property)
 
     visit report_scheme_path(scheme)
 

--- a/spec/presenters/combined_report_presenter_spec.rb
+++ b/spec/presenters/combined_report_presenter_spec.rb
@@ -19,9 +19,9 @@ RSpec.describe CombinedReportPresenter do
         date_range = from_date..to_date
         report_form = double(from_date: from_date, to_date: to_date, date_range: date_range)
 
-        before_range_defect = create(:property_defect, created_at: Time.utc(2018, 1, 1), property: property, priority: priority)
-        in_range_defect = create(:property_defect, created_at: Time.utc(2019, 2, 1), property: property, priority: priority)
-        after_range_defect = create(:property_defect, created_at: Time.utc(2020, 1, 1), property: property, priority: priority)
+        before_range_defect = create(:property_defect, added_at: Time.utc(2018, 1, 1), property: property, priority: priority)
+        in_range_defect = create(:property_defect, added_at: Time.utc(2019, 2, 1), property: property, priority: priority)
+        after_range_defect = create(:property_defect, added_at: Time.utc(2020, 1, 1), property: property, priority: priority)
 
         result = described_class.new(schemes: schemes, report_form: report_form).defects
 

--- a/spec/presenters/scheme_report_presenter_spec.rb
+++ b/spec/presenters/scheme_report_presenter_spec.rb
@@ -19,9 +19,9 @@ RSpec.describe SchemeReportPresenter do
         date_range = from_date..to_date
         report_form = double(from_date: from_date, to_date: to_date, date_range: date_range)
 
-        before_range_defect = create(:property_defect, created_at: Time.utc(2018, 1, 1), property: property, priority: priority)
-        in_range_defect = create(:property_defect, created_at: Time.utc(2019, 2, 1), property: property, priority: priority)
-        after_range_defect = create(:property_defect, created_at: Time.utc(2020, 1, 1), property: property, priority: priority)
+        before_range_defect = create(:property_defect, added_at: Time.utc(2018, 1, 1), property: property, priority: priority)
+        in_range_defect = create(:property_defect, added_at: Time.utc(2019, 2, 1), property: property, priority: priority)
+        after_range_defect = create(:property_defect, added_at: Time.utc(2020, 1, 1), property: property, priority: priority)
 
         result = described_class.new(scheme: scheme, report_form: report_form).defects
 
@@ -37,7 +37,7 @@ RSpec.describe SchemeReportPresenter do
       date_range = from_date..to_date
       report_form = double(from_date: from_date, to_date: to_date, date_range: date_range)
 
-      in_range_defect = create(:property_defect, created_at: Time.utc(2019, 1, 1), property: property, priority: priority)
+      in_range_defect = create(:property_defect, added_at: Time.utc(2019, 1, 1), property: property, priority: priority)
 
       result = described_class.new(scheme: scheme, report_form: report_form).defects
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,7 +20,7 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
+Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.

--- a/spec/support/carrierwave.rb
+++ b/spec/support/carrierwave.rb
@@ -4,7 +4,7 @@ RSpec.configure do |config|
   end
 end
 
-Dir[Rails.root.join('app', 'uploaders', '*.rb')].each { |file| require file }
+Dir[Rails.root.join('app', 'uploaders', '*.rb')].sort.each { |file| require file }
 
 if defined?(CarrierWave)
   CarrierWave::Uploader::Base.descendants.each do |klass|


### PR DESCRIPTION
## Changes in this PR:

Scheme and combined reports respect the more recent `added_at` field which can be edited by users, rather than the older `created_at` time which cannot. 

The `created_at` can be thought of as the time the defect was added to the service. The `added_at` is the time it was reported to Hackney. If there is a delay in getting the detect entered into the service for any reason it can push the defect in or out of any report filtering done by date.

