### PR TITLE
Fix local development server

### DIFF
--- a/bin/drails
+++ b/bin/drails
@@ -1,3 +1,3 @@
 #!/bin/sh
 set +e
-docker-compose run --rm web rails $@
+docker-compose run --rm web bundle exec rails $@

--- a/bin/dtest-server
+++ b/bin/dtest-server
@@ -4,7 +4,7 @@ set -e
 
 run_with_pretty_print()
 {
-  echo "\n\033[36m===> $1\033[0m\n"
+  echo "===> $1"
   eval $1
 }
 

--- a/bin/dtest-server
+++ b/bin/dtest-server
@@ -39,5 +39,10 @@ then
   # Circle CI cannot mount volumes which are very useful for quick file reloading
   # in dev and test. Therefore we require an almost identical docker-compose.yml
   # file for CI only.
+
+  # INFO: When running CI mode locally to verify changes, we need to clear up
+  # any old state
+  run_with_pretty_print 'docker-compose --file docker-compose.ci.yml down -v'
+
   start_test_server 'docker-compose.ci.yml'
 fi

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -12,7 +12,7 @@ services:
     env_file:
       - docker-compose.env.example
     volumes:
-      - node_modules:/srv/report-a-defect/node_modules:cached
+      - ci_node_modules:/srv/report-a-defect/node_modules:cached
     depends_on:
       - db-test
     command: ["bundle", "exec", "./bin/dsetup && spring server"]
@@ -24,7 +24,7 @@ services:
     image: postgres:10.21
     container_name: report-a-defect_test_db_1
     volumes:
-      - pg_test_data:/var/lib/postgresql/data/:cached
+      - ci_pg_test_data:/var/lib/postgresql/data/:cached
     environment:
       - POSTGRES_DB=report-a-defect
       - POSTGRES_USER=postgres
@@ -38,5 +38,5 @@ networks:
   ci:
 
 volumes:
-  pg_test_data: {}
-  node_modules:
+  ci_pg_test_data: {}
+  ci_node_modules:

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -7,7 +7,7 @@ services:
         RAILS_ENV: "test"
     environment:
       RAILS_ENV: "test"
-      DATABASE_URL: "postgres://postgres@db-test:5432/report-a-defect?template=template0&pool=5&encoding=unicode"
+      DATABASE_URL: "postgres://postgres:password@db-test:5432/report-a-defect?template=template0&pool=5&encoding=unicode"
     container_name: report-a-defect_test_web_1
     env_file:
       - docker-compose.env.example

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -18,7 +18,7 @@ services:
     command: ["bundle", "exec", "./bin/dsetup && spring server"]
     restart: on-failure
     networks:
-      - test
+      - ci
 
   db-test:
     image: postgres:10.21
@@ -31,11 +31,11 @@ services:
       - POSTGRES_PASSWORD=password
       - POSTGRES_HOST_AUTH_METHOD=trust
     networks:
-      - test
+      - ci
     restart: on-failure
 
 networks:
-  test:
+  ci:
 
 volumes:
   pg_test_data: {}

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -20,14 +20,6 @@ services:
     restart: on-failure
     networks:
       - tests
-    deploy:
-      resources:
-        limits:
-          cpus: '0.25'
-          memory: 25M
-        reservations:
-          cpus: '0.50'
-          memory: 50M
 
   db-test:
     image: postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     volumes:
       - .:/srv/report-a-defect:cached
       - node_modules:/srv/report-a-defect/node_modules
-    command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s"
+    command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
 
   db:
     image: postgres


### PR DESCRIPTION
## Changes in this PR:

Before this proposal, booting the server locally with `docker-compose up` rendered a connection could not be established error. This is primarily fixed through binding the server start to 0.0.0.0. 

- get the server running locally via Docker
- minor docker configuration improvements
- ensure postgres is running as the same version as in prod