### PR TITLE
Heroku release fixed after Rails 6 update

### DIFF
--- a/heroku.yml
+++ b/heroku.yml
@@ -4,7 +4,7 @@ build:
 release:
   image: web
   command:
-    - rake db:migrate
+    - bundle exec rake db:migrate
 run:
   web: bundle exec puma -C config/puma.rb
   worker:


### PR DESCRIPTION
Different dependencies are using different versions of rake so the release was failing. Use bundle exec in remaining line to allow Bundler to resolve version issues.