### PR TITLE
Chore: Fix URL Redirects

### DIFF
--- a/app/controllers/auth0_controller.rb
+++ b/app/controllers/auth0_controller.rb
@@ -7,7 +7,7 @@ class Auth0Controller < ApplicationController
     Rails.logger.info "Session after assignment: #{request.session.inspect}"
 
     # Redirect to the URL you want after successful auth
-    redirect_to dashboard_path
+    redirect_to dashboard_url
   end
 
   def failure

--- a/app/controllers/staff/communal_areas_controller.rb
+++ b/app/controllers/staff/communal_areas_controller.rb
@@ -16,7 +16,7 @@ class Staff::CommunalAreasController < Staff::BaseController
     if @communal_area.valid?
       @communal_area.save
       flash[:success] = I18n.t('generic.notice.create.success', resource: 'Communal Area')
-      redirect_to estate_scheme_path(@scheme.estate, @scheme)
+      redirect_to estate_scheme_url(@scheme.estate, @scheme)
     else
       render :new
     end
@@ -35,7 +35,7 @@ class Staff::CommunalAreasController < Staff::BaseController
     if @communal_area.valid?
       @communal_area.save
       flash[:success] = I18n.t('generic.notice.update.success', resource: 'Communal Area')
-      redirect_to estate_scheme_path(@scheme.estate, @scheme)
+      redirect_to estate_scheme_url(@scheme.estate, @scheme)
     else
       render :edit
     end

--- a/app/controllers/staff/communal_defects_controller.rb
+++ b/app/controllers/staff/communal_defects_controller.rb
@@ -23,7 +23,7 @@ class Staff::CommunalDefectsController < Staff::BaseController
         send_email_to_employer_agent: send_email_to_employer_agent
       ).call
       flash[:success] = I18n.t('generic.notice.create.success', resource: 'defect')
-      redirect_to communal_area_path(@communal_area)
+      redirect_to communal_area_url(@communal_area)
     else
       render :new
     end
@@ -47,10 +47,10 @@ class Staff::CommunalDefectsController < Staff::BaseController
     UpdateDefect.new(defect: @defect).call
 
     if @defect.saved_change_to_status? && @defect.completed?
-      redirect_to new_defect_completion_path(@defect)
+      redirect_to new_defect_completion_url(@defect)
     else
       flash[:success] = I18n.t('generic.notice.update.success', resource: 'defect')
-      redirect_to communal_area_defect_path(@defect.communal_area, @defect)
+      redirect_to communal_area_defect_url(@defect.communal_area, @defect)
     end
   end
 

--- a/app/controllers/staff/estates_controller.rb
+++ b/app/controllers/staff/estates_controller.rb
@@ -9,7 +9,7 @@ class Staff::EstatesController < Staff::BaseController
     if @estate.valid?
       @estate.save
       flash[:success] = I18n.t('generic.notice.create.success', resource: 'estate')
-      redirect_to dashboard_path
+      redirect_to dashboard_url
     else
       render :new
     end

--- a/app/controllers/staff/priorities_controller.rb
+++ b/app/controllers/staff/priorities_controller.rb
@@ -12,7 +12,7 @@ class Staff::PrioritiesController < Staff::BaseController
     if @priority.valid?
       @priority.save
       flash[:success] = I18n.t('generic.notice.create.success', resource: 'priority')
-      redirect_to estate_scheme_path(@scheme.estate, @scheme)
+      redirect_to estate_scheme_url(@scheme.estate, @scheme)
     else
       render :new
     end

--- a/app/controllers/staff/properties_controller.rb
+++ b/app/controllers/staff/properties_controller.rb
@@ -16,7 +16,7 @@ class Staff::PropertiesController < Staff::BaseController
     if @property.valid?
       @property.save
       flash[:success] = I18n.t('generic.notice.create.success', resource: 'property')
-      redirect_to estate_scheme_path(@scheme.estate, @scheme)
+      redirect_to estate_scheme_url(@scheme.estate, @scheme)
     else
       render :new
     end
@@ -35,7 +35,7 @@ class Staff::PropertiesController < Staff::BaseController
     if @property.valid?
       @property.save
       flash[:success] = I18n.t('generic.notice.update.success', resource: 'property')
-      redirect_to estate_scheme_path(@scheme.estate, @scheme)
+      redirect_to estate_scheme_url(@scheme.estate, @scheme)
     else
       render :edit
     end

--- a/app/controllers/staff/property_defects_controller.rb
+++ b/app/controllers/staff/property_defects_controller.rb
@@ -23,7 +23,7 @@ class Staff::PropertyDefectsController < Staff::BaseController
         send_email_to_employer_agent: send_email_to_employer_agent
       ).call
       flash[:success] = I18n.t('generic.notice.create.success', resource: 'defect')
-      redirect_to property_path(@property)
+      redirect_to property_url(@property)
     else
       render :new
     end
@@ -55,10 +55,10 @@ class Staff::PropertyDefectsController < Staff::BaseController
     UpdateDefect.new(defect: @defect).call
 
     if @defect.saved_change_to_status? && @defect.completed?
-      redirect_to new_defect_completion_path(@defect)
+      redirect_to new_defect_completion_url(@defect)
     else
       flash[:success] = I18n.t('generic.notice.update.success', resource: 'defect')
-      redirect_to property_defect_path(@defect.property, @defect)
+      redirect_to property_defect_url(@defect.property, @defect)
     end
   end
 

--- a/app/controllers/staff/schemes_controller.rb
+++ b/app/controllers/staff/schemes_controller.rb
@@ -13,7 +13,7 @@ class Staff::SchemesController < Staff::BaseController
     if @scheme.valid?
       @scheme.save
       flash[:success] = I18n.t('generic.notice.create.success', resource: 'scheme')
-      redirect_to estate_path(@estate)
+      redirect_to estate_url(@estate)
     else
       render :new
     end
@@ -35,7 +35,7 @@ class Staff::SchemesController < Staff::BaseController
     if @scheme.valid?
       @scheme.save
       flash[:success] = I18n.t('generic.notice.update.success', resource: 'scheme')
-      redirect_to estate_scheme_path(@scheme.estate, @scheme)
+      redirect_to estate_scheme_url(@scheme.estate, @scheme)
     else
       render :edit
     end

--- a/app/controllers/staff/searches_controller.rb
+++ b/app/controllers/staff/searches_controller.rb
@@ -22,7 +22,7 @@ class Staff::SearchesController < Staff::BaseController
       redirect_to helpers.defect_path_for(defect: defect)
     else
       flash[:notice] = I18n.t('page_content.defect.not_found', reference_number: query)
-      redirect_to dashboard_path
+      redirect_to dashboard_url
     end
   end
 end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,1 +1,4 @@
 Capybara.asset_host = 'http://localhost:3000'
+Capybara.server_host = 'localhost'
+Capybara.app_host = 'http://localhost:3000'
+Capybara.always_include_port = true

--- a/terraform/app_infra_module/compute.tf
+++ b/terraform/app_infra_module/compute.tf
@@ -56,6 +56,11 @@ resource "aws_ecs_service" "app_service" {
     container_name   = "report-a-defect-app"
     container_port   = local.app_port
   }
+
+  tags = {
+    WeekendShutdown    = "true"
+    OutOfHoursShutdown = "true"
+  }
 }
 resource "aws_ecs_service" "worker_service" {
   name            = "report-a-defect-worker-service"
@@ -68,6 +73,11 @@ resource "aws_ecs_service" "worker_service" {
     subnets          = data.aws_subnets.public_subnets.ids
     security_groups  = [aws_security_group.ecs_task_sg.id]
     assign_public_ip = false
+  }
+
+  tags = {
+    WeekendShutdown    = "true"
+    OutOfHoursShutdown = "true"
   }
 }
 

--- a/terraform/app_infra_module/data_stores.tf
+++ b/terraform/app_infra_module/data_stores.tf
@@ -64,6 +64,9 @@ resource "aws_db_instance" "lbh-db" {
   deletion_protection   = false
   skip_final_snapshot   = true
   copy_tags_to_snapshot = false
+  tags = {
+    Confidentiality = "Internal"
+  }
 }
 
 # Redis Instance

--- a/terraform/app_infra_module/locals.tf
+++ b/terraform/app_infra_module/locals.tf
@@ -6,18 +6,18 @@ locals {
   redis_port    = 6379
   secret_names = [
     "auth0-client-secret",
-    "database-url-string",
-    "notify-key",
-    "papertrail-api-token",
-    "secret-key-base",
     "aws-access-key-id",
     "aws-secret-access-key",
+    "database-url-string",
+    "notify-key",
+    "secret-key-base",
   ]
   ssm_params = [
     "auth0_client_id",
     "auth0_domain",
     "aws_bucket",
     "aws_region",
+    "domain",
     "lang",
     "nbt_group_email",
     "notify_daily_due_soon_template",
@@ -32,8 +32,6 @@ locals {
     "rails_serve_static_files",
     "redis_url",
     "sms_blacklist",
-    "domain",
-    "oauth_debug"
   ]
   container_definition_base = {
     image     = "${aws_ecr_repository.app_repository.repository_url}:latest"


### PR DESCRIPTION
Replace redirects that utilise path helpers (for example, `dashboard_path`) with URL helpers (such as `dashboard_url`). This change is part of the migration process for the application to AWS (see #213). It has been split into a separate pull request to keep the git diff clean.

As mentioned in #213, the application currently assumes it is hosted at the Load Balancer URL instead of the CloudFront URL. As a result, when it redirects users, it directs them to the load balancer rather than the publicly accessible CloudFront URL. Using absolute paths resolves this issue.

There are also minor terraform changes, such as adding OOH shutdown tags & removing unnecessary environment variables.