### PR TITLE
Fix redirects on unauthenticated users

### DIFF
--- a/app/controllers/concerns/secured.rb
+++ b/app/controllers/concerns/secured.rb
@@ -6,6 +6,6 @@ module Secured
   end
 
   def logged_in_using_omniauth?
-    redirect_to '/' if session[:userinfo].blank?
+    redirect_to root_url if session[:userinfo].blank?
   end
 end


### PR DESCRIPTION
Bugfix: Missed in #214.

When an unauthenticated user attempts to access a private page, they should be redirected to the root URL (sign-in page). Using '/' redirects them to the load balancer URL instead of CloudFront.