### PR TITLE
Make domain name SSM parameter use cname_alias when it has one

### DIFF
--- a/terraform/app_infra_module/cloudfront.tf
+++ b/terraform/app_infra_module/cloudfront.tf
@@ -59,6 +59,6 @@ resource "aws_ssm_parameter" "app_domain_name" {
   name        = "/report-a-defect/${var.environment_name}/domain"
   description = "Domain name for the report a defect app"
   type        = "String"
-  value       = aws_cloudfront_distribution.app_distribution.domain_name
+  value       = var.use_cloudfront_cert ? aws_cloudfront_distribution.app_distribution.domain_name : var.cname_aliases[0]
   overwrite   = true
 }


### PR DESCRIPTION
The app needs the domain name SSM parameter to be set to the alias when there is one. (ie. in prod, it needs to be set to `lbh-report-a-defect.hackney.gov.uk`, but in dev it needs to be `xxxxxxxxx.cloudfront.net` since there is no alias). This should fix that.
