### PR TITLE
Hotfix: Fix more broken redirects

### DIFF
--- a/app/controllers/staff/comments_controller.rb
+++ b/app/controllers/staff/comments_controller.rb
@@ -15,7 +15,7 @@ class Staff::CommentsController < Staff::BaseController
     if @comment.valid?
       @comment.save
       flash[:success] = I18n.t('generic.notice.create.success', resource: 'comment')
-      redirect_to defect_path_for(defect: @defect)
+      redirect_to defect_url_for(defect: @defect)
     else
       render :new
     end

--- a/app/controllers/staff/defect_flags_controller.rb
+++ b/app/controllers/staff/defect_flags_controller.rb
@@ -1,12 +1,12 @@
 class Staff::DefectFlagsController < Staff::BaseController
   def create
     defect.update!(flagged: true)
-    redirect_to helpers.defect_path_for(defect: defect)
+    redirect_to helpers.defect_url_for(defect: defect)
   end
 
   def destroy
     defect.update!(flagged: false)
-    redirect_to helpers.defect_path_for(defect: defect)
+    redirect_to helpers.defect_url_for(defect: defect)
   end
 
   private

--- a/app/controllers/staff/defects/completion_controller.rb
+++ b/app/controllers/staff/defects/completion_controller.rb
@@ -19,7 +19,7 @@ class Staff::Defects::CompletionController < Staff::BaseController
     UpdateDefect.new(defect: @defect).call
 
     flash[:success] = I18n.t('generic.notice.update.success', resource: 'defect')
-    redirect_to defect_path_for(defect: @defect)
+    redirect_to defect_url_for(defect: @defect)
   end
 
   private

--- a/app/controllers/staff/defects/forwarding_controller.rb
+++ b/app/controllers/staff/defects/forwarding_controller.rb
@@ -16,7 +16,7 @@ class Staff::Defects::ForwardingController < Staff::BaseController
       EmailEmployerAgent.new(defect: defect).call
     end
 
-    redirect_to defect_path_for(defect: defect),
+    redirect_to defect_url_for(defect: defect),
                 flash: {
                   success: I18n.t('page_content.defect.forwarding.success',
                                   recipient_type: formatted_recipient_type),

--- a/app/controllers/staff/evidences_controller.rb
+++ b/app/controllers/staff/evidences_controller.rb
@@ -14,7 +14,7 @@ class Staff::EvidencesController < Staff::BaseController
     if @evidence.valid?
       @evidence.save
       flash[:success] = I18n.t('generic.notice.create.success', resource: 'evidence')
-      redirect_to defect_path_for(defect: @defect)
+      redirect_to defect_url_for(defect: @defect)
     else
       render :new
     end

--- a/app/controllers/staff/searches_controller.rb
+++ b/app/controllers/staff/searches_controller.rb
@@ -19,7 +19,7 @@ class Staff::SearchesController < Staff::BaseController
     defect = Defect.by_reference_number(number)
 
     if defect
-      redirect_to helpers.defect_path_for(defect: defect)
+      redirect_to helpers.defect_url_for(defect: defect)
     else
       flash[:notice] = I18n.t('page_content.defect.not_found', reference_number: query)
       redirect_to dashboard_url

--- a/app/helpers/defect_helper.rb
+++ b/app/helpers/defect_helper.rb
@@ -24,6 +24,14 @@ module DefectHelper
     end
   end
 
+  def defect_url_for(defect:)
+    if defect.communal?
+      communal_area_defect_url(defect.communal_area, defect.id)
+    else
+      property_defect_url(defect.property, defect.id)
+    end
+  end
+
   def defect_type_for(defect:)
     defect.communal? ? 'Communal Area' : 'Property'
   end


### PR DESCRIPTION
Same issue as in #214. Using path helpers for redirects breaks in prod because we have a load balancer & then a CloudFront distro in front. The issue can't be replicated locally, so it's hard to discover bugs.
